### PR TITLE
Add block insertion buttons

### DIFF
--- a/src/components/common/AddBlockButton.tsx
+++ b/src/components/common/AddBlockButton.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Plus } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/core/utils/classNames';
+import { Block } from '@/types/prompts/blocks';
+
+interface AddBlockButtonProps {
+  blocks: Block[];
+  onAdd: (block: Block) => void;
+  className?: string;
+}
+
+/**
+ * Button used to insert a block into a template.
+ */
+export const AddBlockButton: React.FC<AddBlockButtonProps> = ({
+  blocks,
+  onAdd,
+  className
+}) => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            'jd-bg-background jd-border jd-border-input jd-rounded-full jd-shadow jd-w-6 jd-h-6 jd-flex jd-items-center jd-justify-center jd-text-muted-foreground hover:jd-bg-accent hover:jd-text-accent-foreground',
+            className
+          )}
+        >
+          <Plus className="jd-h-4 jd-w-4" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="center">
+        {blocks.map((block) => (
+          <DropdownMenuItem key={block.id} onSelect={() => onAdd(block)}>
+            {block.name}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/components/common/index.tsx
+++ b/src/components/common/index.tsx
@@ -3,5 +3,7 @@
 
 export { default as DeleteButton } from './DeleteButton';
 
+export { AddBlockButton } from './AddBlockButton';
+
 // Include types for better TypeScript integration
 export type { Props as DeleteButtonProps } from './DeleteButton';

--- a/src/components/dialogs/templates/FolderDialog.tsx
+++ b/src/components/dialogs/templates/FolderDialog.tsx
@@ -75,11 +75,11 @@ export const FolderDialog: React.FC = () => {
       
       // Default handling - use direct API call
       const response = await promptApi.createFolder(folderData);
-      
-      if (response.success && response.folder) {
+
+      if (response.success && response.data) {
         // Call the onFolderCreated callback if provided with the created folder
         if (onFolderCreated) {
-          onFolderCreated(response.folder);
+          onFolderCreated(response.data);
         }
         
         toast.success(`Folder "${name}" created successfully`);
@@ -88,7 +88,7 @@ export const FolderDialog: React.FC = () => {
         resetForm();
         dialogProps.onOpenChange(false);
       } else {
-        toast.error(response.error || 'Failed to create folder');
+        toast.error(response.message || 'Failed to create folder');
       }
     } catch (error) {
       console.error('Error creating folder:', error);

--- a/src/components/dialogs/templates/PlaceHolderEditor.tsx
+++ b/src/components/dialogs/templates/PlaceHolderEditor.tsx
@@ -5,6 +5,8 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertTriangle } from "lucide-react";
+import { AddBlockButton } from '@/components/common/AddBlockButton';
+import { Block } from '@/types/prompts/blocks';
 import { useDialog } from '@/hooks/dialogs/useDialog';
 import { BaseDialog } from '../BaseDialog';
 import { getMessage } from '@/core/utils/i18n';
@@ -49,6 +51,11 @@ interface Placeholder {
   value: string;
 }
 
+const SAMPLE_BLOCKS: Block[] = [
+  { id: 1, name: 'Context Block', type: 'context', content: '[Context]' },
+  { id: 2, name: 'Role Block', type: 'role', content: '[Role]' }
+];
+
 /**
  * Dialog for editing template placeholders
  */
@@ -62,6 +69,17 @@ export const PlaceholderEditor: React.FC = () => {
   const editorRef = useRef<HTMLDivElement>(null);
   const observerRef = useRef<MutationObserver | null>(null);
   const isDarkMode = useDarkMode();
+
+  const handleAddBlock = (block: Block, position: 'start' | 'end') => {
+    const newContent = position === 'start'
+      ? `${block.content}\n${modifiedContent}`
+      : `${modifiedContent}\n${block.content}`;
+    setModifiedContent(newContent);
+
+    if (editorRef.current) {
+      editorRef.current.innerHTML = highlightPlaceholders(newContent);
+    }
+  };
 
   // Safe extraction of dialog data with defaults
   const templateContent = data?.content || '';
@@ -385,24 +403,36 @@ export const PlaceholderEditor: React.FC = () => {
           </div>
 
           {/* Rich Text Editable Section */}
-          <div 
+          <div
             className={`jd-border jd-rounded-md jd-p-4 jd-overflow-hidden jd-flex jd-flex-col ${
               isDarkMode ? "jd-border-gray-700" : "jd-border-gray-200"
             }`}
-            >
+          >
             <h3 className="jd-text-sm jd-font-medium jd-mb-2">{getMessage('editTemplate')}</h3>
-            <div
-              ref={editorRef}
-              contentEditable
-              suppressContentEditableWarning
-              onFocus={handleEditorFocus}
-              onBlur={handleEditorBlur}
-              className={`jd-flex-grow jd-h-[50vh] jd-resize-none jd-border jd-rounded-md jd-p-4 jd-focus-visible:jd-outline-none jd-focus-visible:jd-ring-2 jd-focus-visible:jd-ring-primary jd-overflow-auto jd-whitespace-pre-wrap ${
-                isDarkMode 
-                  ? "jd-bg-gray-800 jd-text-gray-100 jd-border-gray-700" 
-                  : "jd-bg-white jd-text-gray-900 jd-border-gray-200"
-              }`}
-            ></div>
+            <div className="jd-relative jd-flex jd-flex-col jd-flex-grow">
+              <AddBlockButton
+                blocks={SAMPLE_BLOCKS}
+                onAdd={(b) => handleAddBlock(b, 'start')}
+                className="jd-absolute jd-left-1/2 -jd-translate-x-1/2 -jd-top-3"
+              />
+              <div
+                ref={editorRef}
+                contentEditable
+                suppressContentEditableWarning
+                onFocus={handleEditorFocus}
+                onBlur={handleEditorBlur}
+                className={`jd-flex-grow jd-h-[50vh] jd-resize-none jd-border jd-rounded-md jd-p-4 jd-focus-visible:jd-outline-none jd-focus-visible:jd-ring-2 jd-focus-visible:jd-ring-primary jd-overflow-auto jd-whitespace-pre-wrap ${
+                  isDarkMode
+                    ? "jd-bg-gray-800 jd-text-gray-100 jd-border-gray-700"
+                    : "jd-bg-white jd-text-gray-900 jd-border-gray-200"
+                }`}
+              ></div>
+              <AddBlockButton
+                blocks={SAMPLE_BLOCKS}
+                onAdd={(b) => handleAddBlock(b, 'end')}
+                className="jd-absolute jd-left-1/2 -jd-translate-x-1/2 jd-bottom-3"
+              />
+            </div>
           </div>
         </div>
 

--- a/src/components/dialogs/templates/TemplateDialog.tsx
+++ b/src/components/dialogs/templates/TemplateDialog.tsx
@@ -189,12 +189,12 @@ export const TemplateDialog: React.FC = () => {
             try {
               // Direct API call fallback
               const response = await promptApi.createFolder(folderData);
-              
-              if (response.success && response.folder) {
-                return { success: true, folder: response.folder };
+
+              if (response.success && response.data) {
+                return { success: true, folder: response.data };
               } else {
-                toast.error(response.error || getMessage('failedToCreateFolder'));
-                return { success: false, error: response.error || getMessage('unknownError') };
+                toast.error(response.message || getMessage('failedToCreateFolder'));
+                return { success: false, error: response.message || getMessage('unknownError') };
               }
             } catch (error) {
               console.error('Error creating folder:', error);

--- a/src/hooks/prompts/actions/useFolderMutations.ts
+++ b/src/hooks/prompts/actions/useFolderMutations.ts
@@ -52,9 +52,9 @@ export function useFolderMutations() {
         async (data: FolderData) => {
           const response = await promptApi.createFolder(data);
           if (!response.success) {
-            throw new Error(response.error || 'Failed to create folder');
+            throw new Error(response.message || 'Failed to create folder');
           }
-          return response.folder;
+          return response.data;
         },
         {
           onSuccess: () => {
@@ -74,9 +74,9 @@ export function useFolderMutations() {
           try {
             const response = await promptApi.createFolder(data);
             if (!response.success) {
-              throw new Error(response.error || 'Failed to create folder');
+              throw new Error(response.message || 'Failed to create folder');
             }
-            return response.folder;
+            return response.data;
           } catch (error) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error';
             console.error('Error creating folder:', error);
@@ -97,7 +97,7 @@ export function useFolderMutations() {
         async ({ folderId, isPinned, type }: TogglePinParams) => {
           const response = await promptApi.toggleFolderPin(folderId, isPinned, type);
           if (!response.success) {
-            throw new Error(response.error || 'Failed to update pin status');
+            throw new Error(response.message || 'Failed to update pin status');
           }
           return response.data;
         },
@@ -121,7 +121,7 @@ export function useFolderMutations() {
           try {
             const response = await promptApi.toggleFolderPin(folderId, isPinned, type);
             if (!response.success) {
-              throw new Error(response.error || 'Failed to update pin status');
+              throw new Error(response.message || 'Failed to update pin status');
             }
             return response.data;
           } catch (error) {
@@ -144,7 +144,7 @@ export function useFolderMutations() {
         async (id: number) => {
           const response = await promptApi.deleteFolder(id);
           if (!response.success) {
-            throw new Error(response.error || 'Failed to delete folder');
+            throw new Error(response.message || 'Failed to delete folder');
           }
           return id;
         },
@@ -170,7 +170,7 @@ export function useFolderMutations() {
           try {
             const response = await promptApi.deleteFolder(id);
             if (!response.success) {
-              throw new Error(response.error || 'Failed to delete folder');
+              throw new Error(response.message || 'Failed to delete folder');
             }
             return id;
           } catch (error) {

--- a/src/hooks/prompts/actions/useTemplateMutations.ts
+++ b/src/hooks/prompts/actions/useTemplateMutations.ts
@@ -51,9 +51,9 @@ export function useTemplateMutations() {
         async (data: TemplateData) => {
           const response = await promptApi.createTemplate(data);
           if (!response.success) {
-            throw new Error(response.error || 'Failed to create template');
+            throw new Error(response.message || 'Failed to create template');
           }
-          return response.template;
+          return response.data;
         },
         {
           onSuccess: () => {
@@ -73,9 +73,9 @@ export function useTemplateMutations() {
           try {
             const response = await promptApi.createTemplate(data);
             if (!response.success) {
-              throw new Error(response.error || 'Failed to create template');
+              throw new Error(response.message || 'Failed to create template');
             }
-            return response.template;
+            return response.data;
           } catch (error) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error';
             console.error('Error creating template:', error);
@@ -96,9 +96,9 @@ export function useTemplateMutations() {
         async ({ id, data }: { id: number; data: Partial<TemplateData> }) => {
           const response = await promptApi.updateTemplate(id, data);
           if (!response.success) {
-            throw new Error(response.error || 'Failed to update template');
+            throw new Error(response.message || 'Failed to update template');
           }
-          return response.template;
+          return response.data;
         },
         {
           onSuccess: () => {
@@ -117,9 +117,9 @@ export function useTemplateMutations() {
           try {
             const response = await promptApi.updateTemplate(id, data);
             if (!response.success) {
-              throw new Error(response.error || 'Failed to update template');
+              throw new Error(response.message || 'Failed to update template');
             }
-            return response.template;
+            return response.data;
           } catch (error) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error';
             console.error('Error updating template:', error);
@@ -140,7 +140,7 @@ export function useTemplateMutations() {
         async (id: number) => {
           const response = await promptApi.deleteTemplate(id);
           if (!response.success) {
-            throw new Error(response.error || 'Failed to delete template');
+            throw new Error(response.message || 'Failed to delete template');
           }
           return id;
         },
@@ -161,7 +161,7 @@ export function useTemplateMutations() {
           try {
             const response = await promptApi.deleteTemplate(id);
             if (!response.success) {
-              throw new Error(response.error || 'Failed to delete template');
+              throw new Error(response.message || 'Failed to delete template');
             }
             return id;
           } catch (error) {

--- a/src/hooks/prompts/queries/folders/useAllFoldersOfType.ts
+++ b/src/hooks/prompts/queries/folders/useAllFoldersOfType.ts
@@ -15,12 +15,12 @@ export function useAllFoldersOfType(folderType: 'official' | 'organization') {
     [QUERY_KEYS.ALL_FOLDERS, folderType], // Query key array with type
     async () => {
       const response = await promptApi.getAllFolders(folderType, false, userLocale);
-      
+
       if (!response.success) {
-        throw new Error(response.error || `Failed to fetch ${folderType} folders`);
+        throw new Error(response.message || `Failed to fetch ${folderType} folders`);
       }
-      
-      return response.folders as TemplateFolder[];
+
+      return response.data as TemplateFolder[];
     },
     {
       refetchOnWindowFocus: false,

--- a/src/hooks/prompts/queries/folders/useUserFolders.ts
+++ b/src/hooks/prompts/queries/folders/useUserFolders.ts
@@ -9,16 +9,16 @@ export function useUserFolders() {
   return useQuery(QUERY_KEYS.USER_FOLDERS, async () => {
     const response = await promptApi.getUserFolders();
     if (!response.success) {
-      throw new Error(response.error || 'Failed to load user folders');
+      throw new Error(response.message || 'Failed to load user folders');
     }
     
     // Also fetch user templates to properly handle templates with null folder_id
     const templatesResponse = await promptApi.getUserTemplates();
-    
-    if (templatesResponse.success && templatesResponse.templates) {
+
+    if (templatesResponse.success && templatesResponse.data) {
       // Create a map of folder ID to folder for easy lookup
       const folderMap = new Map<number, TemplateFolder>();
-      response.folders.forEach((folder: TemplateFolder) => {
+      response.data.forEach((folder: TemplateFolder) => {
         folderMap.set(folder.id, folder);
         
         // Initialize templates array if not present
@@ -28,7 +28,7 @@ export function useUserFolders() {
       });
       
       // Process all templates
-      templatesResponse.templates.forEach(template => {
+      templatesResponse.data.forEach(template => {
         if (template.folder_id === null) {
           // We'll handle unorganized templates separately
           return;
@@ -42,7 +42,7 @@ export function useUserFolders() {
       });
     }
     
-    return response.folders;
+    return response.data;
   }, {
     refetchOnWindowFocus: false,
     onError: (error: Error) => {

--- a/src/hooks/prompts/queries/templates/useUnorganizedTemplates.ts
+++ b/src/hooks/prompts/queries/templates/useUnorganizedTemplates.ts
@@ -12,9 +12,9 @@ export function useUnorganizedTemplates() {
   return useQuery(QUERY_KEYS.UNORGANIZED_TEMPLATES, async () => {
     const response = await promptApi.getUnorganizedTemplates();
     if (!response.success) {
-      throw new Error(response.error || 'Failed to fetch unorganized templates');
+      throw new Error(response.message || 'Failed to fetch unorganized templates');
     }
-    return response.templates.filter((template: Template) => !template.folder_id) as Template[];
+    return response.data.filter((template: Template) => !template.folder_id) as Template[];
   }, {
     refetchOnWindowFocus: false,
     onError: (error: Error) => {

--- a/src/hooks/prompts/queries/templates/useUserTemplates.ts
+++ b/src/hooks/prompts/queries/templates/useUserTemplates.ts
@@ -8,9 +8,9 @@ export function useUserTemplates() {
   return useQuery(QUERY_KEYS.USER_TEMPLATES, async () => {
     const response = await promptApi.getUserTemplates();
     if (!response.success) {
-      throw new Error(response.error || 'Failed to fetch user templates');
+      throw new Error(response.message || 'Failed to fetch user templates');
     }
-    return response.templates as Template[];
+    return response.data as Template[];
   }, {
     refetchOnWindowFocus: false,
     onError: (error: Error) => {

--- a/src/hooks/prompts/queries/user/useUserMetadata.ts
+++ b/src/hooks/prompts/queries/user/useUserMetadata.ts
@@ -12,7 +12,7 @@ export function useUserMetadata() {
     async () => {
       const response = await userApi.getUserMetadata();
       if (!response.success) {
-        throw new Error(response.error || 'Failed to load user metadata');
+        throw new Error(response.message || 'Failed to load user metadata');
       }
       return response.data || {};
     },

--- a/src/hooks/prompts/useTemplateCreation.ts
+++ b/src/hooks/prompts/useTemplateCreation.ts
@@ -44,17 +44,17 @@ export function useTemplateCreation() {
       const response = await promptApi.createTemplate(templateData);
       if (!response.success) {
         trackEvent(EVENTS.TEMPLATE_CREATE_ERROR, {
-          error: response.error || 'Failed to create template'
+          error: response.message || 'Failed to create template'
         });
-        throw new Error(response.error || 'Failed to create template');
+        throw new Error(response.message || 'Failed to create template');
       }
       incrementUserProperty('template_created_count', 1);
       trackEvent(EVENTS.TEMPLATE_CREATE, {
-        template_id: response.template.id,
-        template_name: response.template.title,
-        template_type: response.template.type
+        template_id: response.data.id,
+        template_name: response.data.title,
+        template_type: response.data.type
       });
-      return response.template;
+      return response.data;
     },
     {
       onSuccess: () => {
@@ -83,9 +83,9 @@ export function useTemplateCreation() {
       
       const response = await promptApi.updateTemplate(id, templateData);
       if (!response.success) {
-        throw new Error(response.error || 'Failed to update template');
+        throw new Error(response.message || 'Failed to update template');
       }
-      return response.template;
+      return response.data;
     },
     {
       onSuccess: () => {

--- a/src/hooks/prompts/utils/useTemplateEditor.ts
+++ b/src/hooks/prompts/utils/useTemplateEditor.ts
@@ -104,18 +104,18 @@ export function useTemplateEditor(onSaveSuccess?: () => Promise<void>) {
         description: `Folder for ${folderName} templates`
       });
       
-      if (response.success && response.folder) {
+      if (response.success && response.data) {
         toast.success(`Folder "${folderName}" created`);
         
         // Update form data with new folder
         updateFormData({
           folder: folderName,
-          folder_id: response.folder.id
+          folder_id: response.data.id
         });
-        
-        return response.folder;
+
+        return response.data;
       } else {
-        toast.error(`Failed to create folder: ${response.error || 'Unknown error'}`);
+        toast.error(`Failed to create folder: ${response.message || 'Unknown error'}`);
         return null;
       }
     } catch (error) {
@@ -183,7 +183,7 @@ export function useTemplateEditor(onSaveSuccess?: () => Promise<void>) {
         
         return true;
       } else {
-        const errorMessage = `Failed to ${selectedTemplate ? 'update' : 'create'} template: ${response?.error || 'Unknown error'}`;
+        const errorMessage = `Failed to ${selectedTemplate ? 'update' : 'create'} template: ${response?.message || 'Unknown error'}`;
         setError(errorMessage);
         toast.error(errorMessage);
         return false;

--- a/src/services/api/ApiClient.ts
+++ b/src/services/api/ApiClient.ts
@@ -12,7 +12,7 @@ import { debug } from '@/core/config';
 export interface ApiResponse<T = any> {
   success: boolean;
   data?: T;
-  error?: string;
+  message?: string;
 }
 
 /**

--- a/src/services/api/PromptApi.ts
+++ b/src/services/api/PromptApi.ts
@@ -61,7 +61,7 @@ class PromptApiClient {
     return createFolder(folderData);
   }
 
-  async deleteFolder(folderId: number): Promise<{ success: boolean; error?: string }> {
+  async deleteFolder(folderId: number): Promise<{ success: boolean; message?: string; data?: any }> {
     return deleteFolder(folderId);
   }
 

--- a/src/services/api/prompts/folders/createFolder.ts
+++ b/src/services/api/prompts/folders/createFolder.ts
@@ -9,7 +9,7 @@ export async function createFolder(folderData: { name: string, path: string, des
       if (!folderData.name) {
         return {
           success: false,
-          error: 'Folder name is required'
+          message: 'Folder name is required'
         };
       }
 
@@ -20,9 +20,9 @@ export async function createFolder(folderData: { name: string, path: string, des
       return response;
     } catch (error) {
       console.error('Error creating folder:', error);
-      return { 
-        success: false, 
-        error: error instanceof Error ? error.message : 'Unknown error'
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }

--- a/src/services/api/prompts/folders/deleteFolder.ts
+++ b/src/services/api/prompts/folders/deleteFolder.ts
@@ -3,7 +3,7 @@ import { apiClient } from "@/services/api/ApiClient";
 /**
 * Delete a folder
 */
-export async function deleteFolder(folderId: number): Promise<{ success: boolean; error?: string }> {
+export async function deleteFolder(folderId: number): Promise<{ success: boolean; message?: string; data?: any }> {
     try {
       const response = await apiClient.request(`/prompts/folders/${folderId}`, {
         method: 'DELETE'
@@ -11,9 +11,9 @@ export async function deleteFolder(folderId: number): Promise<{ success: boolean
       return response;
     } catch (error) {
       console.error('Error deleting folder:', error);
-      return { 
-        success: false, 
-        error: error instanceof Error ? error.message : 'Unknown error'
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }

--- a/src/services/api/prompts/folders/getAllFolders.ts
+++ b/src/services/api/prompts/folders/getAllFolders.ts
@@ -4,8 +4,8 @@ import { TemplateFolder } from '@/types/prompts/folders';
 
 interface GetAllFoldersResponse {
   success: boolean;
-  folders: TemplateFolder[];
-  error?: string;
+  data: TemplateFolder[];
+  message?: string;
 }
 
 /**
@@ -28,10 +28,10 @@ export async function getAllFolders(type: string, empty: boolean = false, locale
     } catch (error) {
       console.error(`Error fetching ${type} folders:`, error);
       // Return a safe default value
-      return { 
-        success: false, 
-        folders: [], 
-        error: error instanceof Error ? error.message : 'Unknown error'
+      return {
+        success: false,
+        data: [],
+        message: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }

--- a/src/services/api/prompts/folders/getUserFolders.ts
+++ b/src/services/api/prompts/folders/getUserFolders.ts
@@ -13,10 +13,10 @@ export async function getUserFolders(): Promise<any> {
       return response;
     } catch (error) {
       console.error('Error fetching user folders:', error);
-      return { 
-        success: false, 
-        folders: [],
-        error: error instanceof Error ? error.message : 'Unknown error'
+      return {
+        success: false,
+        data: [],
+        message: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }

--- a/src/services/api/prompts/folders/toggleFolderPin.ts
+++ b/src/services/api/prompts/folders/toggleFolderPin.ts
@@ -27,10 +27,10 @@ export async function toggleFolderPin(folderId: number, isPinned: boolean, type:
       return response;
     } catch (error) {
       console.error(`Error toggling pin for ${type} folder ${folderId}:`, error);
-      return { 
-        success: false, 
-        pinned_folders: [],
-        error: error instanceof Error ? error.message : 'Unknown error'
+      return {
+        success: false,
+        data: [],
+        message: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }

--- a/src/services/api/prompts/folders/updatePinnedFolders.ts
+++ b/src/services/api/prompts/folders/updatePinnedFolders.ts
@@ -28,10 +28,10 @@ export async function updatePinnedFolders(type: 'official' | 'organization', fol
       return response;
     } catch (error) {
       console.error(`Error updating pinned ${type} folders:`, error);
-      return { 
-        success: false, 
-        pinned_folders: [],
-        error: error instanceof Error ? error.message : 'Unknown error'
+      return {
+        success: false,
+        data: [],
+        message: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }

--- a/src/services/api/prompts/templates/createTemplate.ts
+++ b/src/services/api/prompts/templates/createTemplate.ts
@@ -10,7 +10,7 @@ export async function createTemplate(templateData: any): Promise<any> {
       if (!templateData.title || !templateData.content) {
         return {
           success: false,
-          error: 'Title and content are required'
+          message: 'Title and content are required'
         };
       }
     
@@ -31,9 +31,9 @@ export async function createTemplate(templateData: any): Promise<any> {
       return response;
     } catch (error) {
       console.error('Error creating template:', error);
-      return { 
-        success: false, 
-        error: error instanceof Error ? error.message : 'Unknown error'
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }

--- a/src/services/api/prompts/templates/deleteTemplate.ts
+++ b/src/services/api/prompts/templates/deleteTemplate.ts
@@ -12,9 +12,9 @@ export async function deleteTemplate(templateId: number): Promise<any> {
       return response;
     } catch (error) {
       console.error('Error deleting template:', error);
-      return { 
-        success: false, 
-        error: error instanceof Error ? error.message : 'Unknown error'
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }

--- a/src/services/api/prompts/templates/getUnorganizedTemplates.ts
+++ b/src/services/api/prompts/templates/getUnorganizedTemplates.ts
@@ -12,10 +12,10 @@ export async function getUnorganizedTemplates(): Promise<any> {
       return response;
     } catch (error) {
       console.error('Error fetching unorganized templates:', error);
-      return { 
-        success: false, 
-        templates: [],
-        error: error instanceof Error ? error.message : 'Unknown error'
+      return {
+        success: false,
+        data: [],
+        message: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }

--- a/src/services/api/prompts/templates/getUserTemplates.ts
+++ b/src/services/api/prompts/templates/getUserTemplates.ts
@@ -9,17 +9,13 @@ export async function getUserTemplates(): Promise<any> {
       const response = await apiClient.request('/prompts/templates', {
         method: 'GET'
       });
-            
-      return {
-        success: true,
-        templates: response.templates || []
-      };
+      return response;
     } catch (error) {
       console.error('Error fetching user templates:', error);
-      return { 
-        success: false, 
-        templates: [],
-        error: error instanceof Error ? error.message : 'Unknown error'
+      return {
+        success: false,
+        data: [],
+        message: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }

--- a/src/services/api/prompts/templates/trackTemplateUsage.ts
+++ b/src/services/api/prompts/templates/trackTemplateUsage.ts
@@ -12,10 +12,10 @@ export async function trackTemplateUsage(templateId: number): Promise<any> {
       return response;
     } catch (error) {
       console.error('Error tracking template usage:', error);
-      return { 
-        success: false, 
-        usage_count: 0,
-        error: error instanceof Error ? error.message : 'Unknown error'
+      return {
+        success: false,
+        data: { usage_count: 0 },
+        message: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }

--- a/src/services/api/prompts/templates/updateTemplate.ts
+++ b/src/services/api/prompts/templates/updateTemplate.ts
@@ -10,7 +10,7 @@ export async function updateTemplate(templateId: number, templateData: any): Pro
     if (!templateData.title && !templateData.content) {
       return {
         success: false,
-        error: 'At least one field to update is required'
+        message: 'At least one field to update is required'
       };
     }
     
@@ -28,9 +28,9 @@ export async function updateTemplate(templateId: number, templateData: any): Pro
     return response;
   } catch (error) {
     console.error('Error updating template:', error);
-    return { 
-      success: false, 
-      error: error instanceof Error ? error.message : 'Unknown error'
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : 'Unknown error'
     };
   }
 }

--- a/src/services/auth/AuthService/index.ts
+++ b/src/services/auth/AuthService/index.ts
@@ -144,7 +144,7 @@ export class AuthService extends AbstractBaseService {
     } else {
       this.stateManager.updateState({
         isAuthenticated: false,
-        error: response.error || 'Sign-in failed'
+        error: response.message || 'Sign-in failed'
       });
       return false;
     }
@@ -175,7 +175,7 @@ export class AuthService extends AbstractBaseService {
     } else {
       this.stateManager.updateState({
         isAuthenticated: false,
-        error: response.error || 'Sign-up failed'
+        error: response.message || 'Sign-up failed'
       });
       return false;
     }
@@ -208,7 +208,7 @@ export class AuthService extends AbstractBaseService {
         this.stateManager.updateState({
           isAuthenticated: false,
           isLoading: false,
-          error: response.error || 'Google sign-in failed'
+          error: response.message || 'Google sign-in failed'
         });
         return false;
       }

--- a/src/types/prompts/blocks.ts
+++ b/src/types/prompts/blocks.ts
@@ -1,0 +1,6 @@
+export interface Block {
+  id: number;
+  name: string;
+  type: string;
+  content: string;
+}

--- a/src/types/services/api.ts
+++ b/src/types/services/api.ts
@@ -11,7 +11,7 @@
 export interface ApiResponse<T = unknown> {
     success: boolean;
     data?: T;
-    error?: string;
+    message?: string;
     code?: string;
   }
   
@@ -88,7 +88,7 @@ export interface ApiResponse<T = unknown> {
   
   export interface TemplateResponse {
     success: boolean;
-    template?: {
+    data?: {
       id: number;
       title: string;
       content: string;
@@ -98,7 +98,7 @@ export interface ApiResponse<T = unknown> {
       created_at: string;
       [key: string]: any;
     };
-    error?: string;
+    message?: string;
   }
   
   export interface TemplateUsageResponse {
@@ -121,7 +121,7 @@ export interface ApiResponse<T = unknown> {
   
   export interface FolderResponse {
     success: boolean;
-    folder?: {
+    data?: {
       id: number;
       name: string;
       path: string;
@@ -129,12 +129,12 @@ export interface ApiResponse<T = unknown> {
       created_at: string;
       [key: string]: any;
     };
-    error?: string;
+    message?: string;
   }
   
   export interface FoldersResponse {
     success: boolean;
-    folders: Array<{
+    data: Array<{
       id: number;
       name: string;
       path: string;
@@ -145,7 +145,7 @@ export interface ApiResponse<T = unknown> {
       created_at: string;
       [key: string]: any;
     }>;
-    error?: string;
+    message?: string;
   }
   
   export interface FolderPinResponse {
@@ -173,7 +173,7 @@ export interface ApiResponse<T = unknown> {
       pinned_organization_folder_ids: number[] | null;
       [key: string]: any;
     };
-    error?: string;
+    message?: string;
   }
   
   // Stats API types
@@ -245,5 +245,5 @@ export interface ApiResponse<T = unknown> {
       refresh_token: string;
       expires_at: number;
     };
-    error?: string;
+    message?: string;
   }


### PR DESCRIPTION
## Summary
- add AddBlockButton component
- expose AddBlockButton from common index
- allow inserting example blocks in TemplateDialog and PlaceholderEditor
- define simple Block type

## Testing
- `npm run type-check`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*