### PR TITLE
Add block insertion buttons

### DIFF
--- a/src/components/dialogs/templates/PlaceHolderEditor.tsx
+++ b/src/components/dialogs/templates/PlaceHolderEditor.tsx
@@ -14,6 +14,7 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useBlockActions } from '@/hooks/prompts/useBlockActions';
 import { Textarea } from "@/components/ui/textarea";
+import { AddBlockButton, AddBlockControls } from '@/components/templates';
 
 // Custom hook to detect dark mode
 const useDarkMode = () => {
@@ -72,6 +73,7 @@ export const PlaceholderEditor: React.FC = () => {
   const [customBlockContent, setCustomBlockContent] = useState<string>('');
   const [selectedBlockType, setSelectedBlockType] = useState<string>('');
   const [selectedBlockId, setSelectedBlockId] = useState<string>('');
+  const [addPosition, setAddPosition] = useState<'top' | 'bottom' | null>(null);
 
   // Import block hooks
   const { 
@@ -428,6 +430,38 @@ export const PlaceholderEditor: React.FC = () => {
     }
   };
 
+  const handleAddBlockAtPosition = (type: string, id: string, position: 'top' | 'bottom') => {
+    if (!type || (!id && id !== '0')) return;
+
+    let newBlock: any;
+
+    if (id === 'custom') {
+      newBlock = {
+        id: `custom-${Date.now()}`,
+        type,
+        content: '',
+        name: `Custom ${type}`,
+        isCustom: true
+      };
+    } else if (id === '0') {
+      newBlock = {
+        id: 0,
+        type: 'content',
+        content: modifiedContent,
+        name: 'Template Content'
+      };
+    } else {
+      const selectedBlock = availableBlocks.find(block => block.id.toString() === id);
+      if (!selectedBlock) return;
+      newBlock = { ...selectedBlock, originalId: selectedBlock.id };
+    }
+
+    setTemplateBlocks(prev =>
+      position === 'top' ? [newBlock, ...prev] : [...prev, newBlock]
+    );
+    setAddPosition(null);
+  };
+
   /**
    * Handle removing a block from the template
    */
@@ -633,12 +667,20 @@ export const PlaceholderEditor: React.FC = () => {
             </div>
 
             {/* Right side: Rich Text Editable Section */}
-            <div 
+            <div
               className={`jd-border jd-rounded-md jd-p-4 jd-overflow-hidden jd-flex jd-flex-col ${
                 isDarkMode ? "jd-border-gray-700" : "jd-border-gray-200"
               }`}
             >
               <h3 className="jd-text-sm jd-font-medium jd-mb-2">{getMessage('editTemplate', undefined, 'Edit Template')}</h3>
+              <AddBlockButton onClick={() => setAddPosition('top')} />
+              {addPosition === 'top' && (
+                <AddBlockControls
+                  blocks={groupedBlocks}
+                  onAdd={(t, id) => handleAddBlockAtPosition(t, id, 'top')}
+                  onCancel={() => setAddPosition(null)}
+                />
+              )}
               <div
                 ref={editorRef}
                 contentEditable
@@ -646,11 +688,19 @@ export const PlaceholderEditor: React.FC = () => {
                 onFocus={handleEditorFocus}
                 onBlur={handleEditorBlur}
                 className={`jd-flex-grow jd-h-[50vh] jd-resize-none jd-border jd-rounded-md jd-p-4 jd-focus-visible:jd-outline-none jd-focus-visible:jd-ring-2 jd-focus-visible:jd-ring-primary jd-overflow-auto jd-whitespace-pre-wrap ${
-                  isDarkMode 
-                    ? "jd-bg-gray-800 jd-text-gray-100 jd-border-gray-700" 
+                  isDarkMode
+                    ? "jd-bg-gray-800 jd-text-gray-100 jd-border-gray-700"
                     : "jd-bg-white jd-text-gray-900 jd-border-gray-200"
                 }`}
               ></div>
+              <AddBlockButton onClick={() => setAddPosition('bottom')} />
+              {addPosition === 'bottom' && (
+                <AddBlockControls
+                  blocks={groupedBlocks}
+                  onAdd={(t, id) => handleAddBlockAtPosition(t, id, 'bottom')}
+                  onCancel={() => setAddPosition(null)}
+                />
+              )}
             </div>
           </TabsContent>
 

--- a/src/components/dialogs/templates/TemplateDialog.tsx
+++ b/src/components/dialogs/templates/TemplateDialog.tsx
@@ -6,6 +6,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { useDialog } from '@/hooks/dialogs/useDialog';
 import { FolderPlus, Plus, Trash, ArrowUp, ArrowDown } from 'lucide-react';
+import { AddBlockButton, AddBlockControls } from '@/components/templates';
 import { DEFAULT_FORM_DATA } from '@/types/prompts/templates';
 import { toast } from 'sonner';
 import { promptApi } from '@/services/api';
@@ -41,6 +42,7 @@ export const TemplateDialog: React.FC = () => {
   const [validationErrors, setValidationErrors] = useState<{[key: string]: string}>({});
   const [userFoldersList, setUserFoldersList] = useState<FolderData[]>([]);
   const [selectedBlockType, setSelectedBlockType] = useState<string>('');
+  const [addBlockPosition, setAddBlockPosition] = useState<'top' | 'bottom' | null>(null);
   
   // Extract data from dialog
   const currentTemplate = data?.template || null;
@@ -248,6 +250,15 @@ export const TemplateDialog: React.FC = () => {
     
     // Reset selected block type
     setSelectedBlockType('');
+  };
+
+  const handleAddBlockAtPosition = (type: string, id: string, position: 'top' | 'bottom') => {
+    if (!type || (!id && id !== '0')) return;
+    const blockId = id === 'custom' ? id : parseInt(id, 10);
+    const blocks = formData.blocks || [];
+    const newBlocks = position === 'top' ? [blockId, ...blocks] : [...blocks, blockId];
+    handleFormChange('blocks', newBlocks);
+    setAddBlockPosition(null);
   };
 
   // Remove a block from the template
@@ -641,7 +652,15 @@ export const TemplateDialog: React.FC = () => {
         
         <div>
           <label className="jd-text-sm jd-font-medium">{getMessage('content')}</label>
-          <textarea 
+          <AddBlockButton onClick={() => setAddBlockPosition('top')} />
+          {addBlockPosition === 'top' && (
+            <AddBlockControls
+              blocks={availableBlocks}
+              onAdd={(t, id) => handleAddBlockAtPosition(t, id, 'top')}
+              onCancel={() => setAddBlockPosition(null)}
+            />
+          )}
+          <textarea
             className={`jd-flex jd-w-full jd-rounded-md jd-border jd-border-input jd-bg-background jd-px-3 jd-py-2 jd-text-sm jd-shadow-sm jd-mt-1 ${
               validationErrors.content ? 'jd-border-red-500' : ''
             }`}
@@ -677,6 +696,14 @@ export const TemplateDialog: React.FC = () => {
           />
           {validationErrors.content && (
             <p className="jd-text-xs jd-text-red-500 jd-mt-1">{validationErrors.content}</p>
+          )}
+          <AddBlockButton onClick={() => setAddBlockPosition('bottom')} />
+          {addBlockPosition === 'bottom' && (
+            <AddBlockControls
+              blocks={availableBlocks}
+              onAdd={(t, id) => handleAddBlockAtPosition(t, id, 'bottom')}
+              onCancel={() => setAddBlockPosition(null)}
+            />
           )}
         </div>
       </div>

--- a/src/components/templates/AddBlockButton.tsx
+++ b/src/components/templates/AddBlockButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export interface AddBlockButtonProps {
+  onClick?: () => void;
+  className?: string;
+}
+
+export const AddBlockButton: React.FC<AddBlockButtonProps> = ({ onClick, className }) => {
+  return (
+    <div className={`jd-relative jd-my-2 jd-flex jd-justify-center jd-items-center ${className || ''}`.trim()}>
+      <div className="jd-absolute jd-inset-x-0 jd-border-t jd-border-dashed" />
+      <Button
+        variant="outline"
+        size="icon"
+        onClick={onClick}
+        className="jd-relative jd-bg-background"
+      >
+        <Plus className="jd-h-4 jd-w-4" />
+      </Button>
+    </div>
+  );
+};
+
+export default AddBlockButton;

--- a/src/components/templates/AddBlockControls.tsx
+++ b/src/components/templates/AddBlockControls.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Plus, X } from 'lucide-react';
+import { getMessage } from '@/core/utils/i18n';
+
+export interface AddBlockControlsProps {
+  blocks: Record<string, any[]>;
+  onAdd: (type: string, id: string) => void;
+  onCancel: () => void;
+  className?: string;
+}
+
+export const AddBlockControls: React.FC<AddBlockControlsProps> = ({
+  blocks,
+  onAdd,
+  onCancel,
+  className = ''
+}) => {
+  const [selectedType, setSelectedType] = useState('');
+  const [selectedId, setSelectedId] = useState('');
+
+  const blockTypes = Object.keys(blocks || {});
+
+  return (
+    <div className={`jd-flex jd-items-center jd-gap-2 jd-my-2 ${className}`.trim()}>
+      <Select value={selectedType} onValueChange={setSelectedType}>
+        <SelectTrigger className="jd-w-[180px]">
+          <SelectValue placeholder={getMessage('selectBlockType', undefined, 'Select type')} />
+        </SelectTrigger>
+        <SelectContent>
+          {blockTypes.map((type) => (
+            <SelectItem key={type} value={type}>
+              {type}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {selectedType && (
+        <Select value={selectedId} onValueChange={setSelectedId}>
+          <SelectTrigger className="jd-flex-1">
+            <SelectValue placeholder={getMessage('selectBlock', undefined, 'Select block')} />
+          </SelectTrigger>
+          <SelectContent>
+            {blocks[selectedType]?.map((block: any) => (
+              <SelectItem key={block.id} value={block.id.toString()}>
+                {block.title || block.name || `Block ${block.id}`}
+              </SelectItem>
+            ))}
+            <SelectItem value="custom">{getMessage('customBlock', undefined, 'Custom')}</SelectItem>
+            <SelectItem value="0">{getMessage('addContent', undefined, 'Content')}</SelectItem>
+          </SelectContent>
+        </Select>
+      )}
+
+      <Button
+        size="sm"
+        onClick={() => {
+          onAdd(selectedType, selectedId);
+          setSelectedType('');
+          setSelectedId('');
+        }}
+        disabled={!selectedType || !selectedId}
+      >
+        <Plus className="jd-h-4 jd-w-4 jd-mr-1" />
+        {getMessage('addBlock', undefined, 'Add Block')}
+      </Button>
+
+      <Button variant="ghost" size="icon" onClick={onCancel}>
+        <X className="jd-h-4 jd-w-4" />
+      </Button>
+    </div>
+  );
+};
+
+export default AddBlockControls;

--- a/src/components/templates/index.tsx
+++ b/src/components/templates/index.tsx
@@ -5,3 +5,5 @@ export { PinButton } from './PinButton';
 export { DeleteButton } from './DeleteButton';
 export { TemplateItem } from './TemplateItem';
 export { UnorganizedTemplates } from './UnorganizedTemplates';
+export { AddBlockButton } from './AddBlockButton';
+export { AddBlockControls } from './AddBlockControls';


### PR DESCRIPTION
## Summary
- add `AddBlockButton` and `AddBlockControls` components
- allow inserting blocks at the top or bottom of template content
- update TemplateDialog and PlaceholderEditor with plus buttons for block insertion

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`