### PR TITLE
Fix PlaceholderEditor block insertion UI

### DIFF
--- a/src/components/dialogs/templates/PlaceHolderEditor.tsx
+++ b/src/components/dialogs/templates/PlaceHolderEditor.tsx
@@ -189,7 +189,7 @@ export const PlaceholderEditor: React.FC = () => {
             <div className="jd-animate-spin jd-h-8 jd-w-8 jd-border-4 jd-border-primary jd-border-t-transparent jd-rounded-full"></div>
           </div>
         ) : (
-          <div className="jd-flex jd-flex-col jd-gap-4 jd-flex-1 jd-overflow-hidden">
+          <div className="jd-flex jd-flex-col jd-gap-4 jd-flex-1 jd-overflow-visible">
             {/* Add Block Button - Top */}
             <AddBlockButton
               position="start"

--- a/src/components/templates/blocks/AddBlockButton.tsx
+++ b/src/components/templates/blocks/AddBlockButton.tsx
@@ -41,7 +41,7 @@ export const AddBlockButton: React.FC<AddBlockButtonProps> = ({
       </Button>
 
       {showSelector && (
-        <div className="jd-absolute jd-top-full jd-left-1/2 jd-transform -jd-translate-x-1/2 jd-mt-2 jd-z-50">
+        <div className="jd-absolute jd-top-full jd-left-1/2 jd-transform -jd-translate-x-1/2 jd-mt-1 jd-z-50">
           <BlockSelector
             onSelectBlock={handleSelectBlock}
             onCancel={handleCancel}

--- a/src/components/templates/blocks/BlockItem.tsx
+++ b/src/components/templates/blocks/BlockItem.tsx
@@ -211,9 +211,8 @@ export const BlockItem: React.FC<BlockItemProps> = ({
             placeholder={`Enter ${blockTypeInfo?.name || 'block'} content...`}
           />
         ) : (
-          <div 
-            className="jd-whitespace-pre-wrap jd-p-3 jd-bg-muted/30 jd-rounded-md jd-text-sm jd-font-mono jd-max-h-[150px] jd-overflow-y-auto jd-cursor-pointer"
-            onClick={onEdit}
+          <div
+            className="jd-whitespace-pre-wrap jd-p-3 jd-bg-muted/30 jd-rounded-md jd-text-sm jd-font-mono jd-max-h-[150px] jd-overflow-y-auto"
             dangerouslySetInnerHTML={{ __html: highlightPlaceholders(getBlockContent()) }}
           />
         )}


### PR DESCRIPTION
## Summary
- allow block selector dropdowns to escape overflow in `PlaceholderEditor`
- tighten spacing for block selector dropdown
- prevent accidental editing when clicking on block content

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`
