### PR TITLE
Fix AddBlockButton event handling

### DIFF
--- a/src/components/dialogs/BaseDialog.tsx
+++ b/src/components/dialogs/BaseDialog.tsx
@@ -96,6 +96,21 @@ export const BaseDialog: React.FC<BaseDialogProps> = ({
       });
     };
   }, [open, children]);
+
+  // Stop keyboard events from leaking to the page
+  useEffect(() => {
+    if (!open) return;
+
+    const stopPropagation = (e: KeyboardEvent) => {
+      e.stopPropagation();
+    };
+
+    const events: (keyof DocumentEventMap)[] = ['keydown', 'keypress', 'keyup'];
+    events.forEach(evt => window.addEventListener(evt, stopPropagation, true));
+    return () => {
+      events.forEach(evt => window.removeEventListener(evt, stopPropagation, true));
+    };
+  }, [open]);
   
   // Handle backdrop click
   const handleBackdropClick = (e: React.MouseEvent) => {

--- a/src/components/templates/blocks/BlockSelector.tsx
+++ b/src/components/templates/blocks/BlockSelector.tsx
@@ -20,7 +20,8 @@ export const BlockSelector: React.FC<BlockSelectorProps> = ({
   // Handle clicking outside to close
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (cardRef.current && !cardRef.current.contains(event.target as Node)) {
+      const path = event.composedPath();
+      if (cardRef.current && !path.includes(cardRef.current)) {
         onCancel();
       }
     };


### PR DESCRIPTION
## Summary
- handle outside click and escape listeners from `document` so they don't block other AddBlockButton instances
- intercept keyboard events while dialogs are open so typing doesn't leak to the host page

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`
