### PR TITLE
Fix theme hook and enable drag and drop

### DIFF
--- a/src/components/dialogs/templates/PlaceholderEditor.tsx
+++ b/src/components/dialogs/templates/PlaceholderEditor.tsx
@@ -25,6 +25,7 @@ export const PlaceholderEditor: React.FC = () => {
     handleRemoveBlock,
     handleUpdateBlock,
     handleMoveBlock,
+    handleReorderBlocks,
     handleUpdateMetadata,
     handleComplete,
     handleClose
@@ -62,6 +63,7 @@ export const PlaceholderEditor: React.FC = () => {
     onRemoveBlock: handleRemoveBlock,
     onUpdateBlock: handleUpdateBlock,
     onMoveBlock: handleMoveBlock,
+    onReorderBlocks: handleReorderBlocks,
     onUpdateMetadata: handleUpdateMetadata,
     isProcessing
   };

--- a/src/components/dialogs/templates/editor/BasicEditor.tsx
+++ b/src/components/dialogs/templates/editor/BasicEditor.tsx
@@ -6,6 +6,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Block, BlockType } from '@/components/templates/blocks/types';
 import { getCurrentLanguage } from '@/core/utils/i18n';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
+import { useThemeDetector } from '@/hooks/useThemeDetector';
 
 interface BasicEditorProps {
   blocks: Block[];
@@ -13,6 +14,7 @@ interface BasicEditorProps {
   onRemoveBlock: (blockId: number) => void;
   onUpdateBlock: (blockId: number, updatedBlock: Partial<Block>) => void;
   onMoveBlock: (blockId: number, direction: 'up' | 'down') => void;
+  onReorderBlocks: (blocks: Block[]) => void;
   isProcessing: boolean;
 }
 
@@ -21,39 +23,6 @@ interface Placeholder {
   value: string;
 }
 
-// Custom hook to detect dark mode
-const useDarkMode = () => {
-  const [isDarkMode, setIsDarkMode] = React.useState<boolean>(() => {
-    if (typeof document !== 'undefined') {
-      return document.documentElement.classList.contains('dark');
-    }
-    return false;
-  });
-
-  React.useEffect(() => {
-    if (typeof document === 'undefined') return;
-    
-    const updateDarkModeState = () => {
-      const isDark = document.documentElement.classList.contains('dark');
-      setIsDarkMode(isDark);
-    };
-
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        if (mutation.attributeName === 'class') {
-          updateDarkModeState();
-        }
-      });
-    });
-
-    observer.observe(document.documentElement, { attributes: true });
-    updateDarkModeState();
-    
-    return () => observer.disconnect();
-  }, []);
-
-  return isDarkMode;
-};
 
 /**
  * Basic editor mode - Simple placeholder and content editing (like the original)
@@ -70,7 +39,7 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
   const [isEditing, setIsEditing] = useState(false);
   const editorRef = useRef<HTMLDivElement>(null);
   const observerRef = useRef<MutationObserver | null>(null);
-  const isDarkMode = useDarkMode();
+  const isDarkMode = useThemeDetector();
 
   // Get combined content from all blocks
   const getBlockContent = (block: Block): string => {

--- a/src/components/dialogs/templates/editor/components/BlockCard.tsx
+++ b/src/components/dialogs/templates/editor/components/BlockCard.tsx
@@ -33,15 +33,21 @@ interface BlockCardProps {
   onMove: (id: number, dir: 'up' | 'down') => void;
   onRemove: (id: number) => void;
   onUpdate: (id: number, updated: Partial<Block>) => void;
+  onDragStart?: (id: number) => void;
+  onDragOver?: (id: number) => void;
+  onDragEnd?: () => void;
 }
 
-export const BlockCard: React.FC<BlockCardProps> = ({ 
-  block, 
-  index, 
-  total, 
-  onMove, 
-  onRemove, 
-  onUpdate 
+export const BlockCard: React.FC<BlockCardProps> = ({
+  block,
+  index,
+  total,
+  onMove,
+  onRemove,
+  onUpdate,
+  onDragStart,
+  onDragOver,
+  onDragEnd
 }) => {
   const Icon = BLOCK_ICONS[block.type];
   const content = typeof block.content === 'string' 
@@ -60,7 +66,16 @@ export const BlockCard: React.FC<BlockCardProps> = ({
   };
 
   return (
-    <Card className="jd-transition-all jd-duration-200 jd-hover:jd-shadow-md jd-group">
+    <Card
+      className="jd-transition-all jd-duration-200 jd-hover:jd-shadow-md jd-group"
+      draggable
+      onDragStart={() => onDragStart && onDragStart(block.id)}
+      onDragOver={(e) => {
+        e.preventDefault();
+        onDragOver && onDragOver(block.id);
+      }}
+      onDragEnd={() => onDragEnd && onDragEnd()}
+    >
       <CardContent className="jd-p-4">
         <div className="jd-flex jd-items-center jd-justify-between jd-mb-3">
           <div className="jd-flex jd-items-center jd-gap-3">

--- a/src/components/dialogs/templates/editor/components/MetadataCard.tsx
+++ b/src/components/dialogs/templates/editor/components/MetadataCard.tsx
@@ -7,6 +7,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Trash2, ChevronUp, ChevronDown, Plus } from 'lucide-react';
 import { cn } from '@/core/utils/classNames';
 import { getCurrentLanguage } from '@/core/utils/i18n';
+import { useThemeDetector } from '@/hooks/useThemeDetector';
 
 interface MetadataCardProps {
   type: MetadataType;
@@ -36,6 +37,7 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
   onRemove
 }) => {
   const config = METADATA_CONFIGS[type];
+  const isDarkMode = useThemeDetector();
 
   // Handle card click - only toggle if clicking on the card itself, not on interactive elements
   const handleCardClick = (e: React.MouseEvent) => {
@@ -63,7 +65,10 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
       className={cn(
         'jd-transition-all jd-duration-200 jd-cursor-pointer hover:jd-shadow-md',
         isPrimary ? 'jd-border-2 jd-border-primary/20 jd-bg-primary/5' : 'jd-border jd-border-muted jd-bg-muted/20',
-        expanded && 'jd-ring-2 jd-ring-primary/50 jd-shadow-lg jd-bg-white dark:jd-bg-gray-800'
+        expanded &&
+          (isDarkMode
+            ? 'jd-ring-2 jd-ring-primary/50 jd-shadow-lg jd-bg-gray-800'
+            : 'jd-ring-2 jd-ring-primary/50 jd-shadow-lg jd-bg-white')
       )}
     >
       <CardContent className="jd-p-4">

--- a/src/components/dialogs/templates/editor/components/PreviewSection.tsx
+++ b/src/components/dialogs/templates/editor/components/PreviewSection.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Eye, ChevronUp, ChevronDown, Copy, Check } from 'lucide-react';
 import { cn } from '@/core/utils/classNames';
+import { useThemeDetector } from '@/hooks/useThemeDetector';
 
 interface PreviewSectionProps {
   content: string;
@@ -10,12 +11,13 @@ interface PreviewSectionProps {
   onToggle: () => void;
 }
 
-export const PreviewSection: React.FC<PreviewSectionProps> = ({ 
-  content, 
-  expanded, 
-  onToggle 
+export const PreviewSection: React.FC<PreviewSectionProps> = ({
+  content,
+  expanded,
+  onToggle
 }) => {
   const [copied, setCopied] = React.useState(false);
+  const isDarkMode = useThemeDetector();
   
   const lines = content.split('\n');
   const showToggle = lines.length > 3;
@@ -33,7 +35,12 @@ export const PreviewSection: React.FC<PreviewSectionProps> = ({
 
   return (
     <div className="jd-border-t jd-pt-4">
-      <Card className="jd-bg-gradient-to-br jd-from-slate-50 jd-to-slate-100 dark:jd-from-gray-800 dark:jd-to-gray-900">
+      <Card
+        className={cn(
+          'jd-bg-gradient-to-br',
+          isDarkMode ? 'jd-from-gray-800 jd-to-gray-900' : 'jd-from-slate-50 jd-to-slate-100'
+        )}
+      >
         <CardContent className="jd-p-4">
           <div className="jd-flex jd-items-center jd-justify-between jd-mb-3">
             <h4 className="jd-font-medium jd-flex jd-items-center jd-gap-2">
@@ -83,10 +90,13 @@ export const PreviewSection: React.FC<PreviewSectionProps> = ({
             </div>
           </div>
           
-          <div className={cn(
-            'jd-bg-white dark:jd-bg-gray-800 jd-rounded-lg jd-p-4 jd-relative jd-border jd-border-gray-200 dark:jd-border-gray-700',
-            expanded ? 'jd-max-h-80 jd-overflow-y-auto' : 'jd-max-h-32 jd-overflow-hidden'
-          )}>
+          <div
+            className={cn(
+              'jd-rounded-lg jd-p-4 jd-relative jd-border',
+              isDarkMode ? 'jd-bg-gray-800 jd-border-gray-700' : 'jd-bg-white jd-border-gray-200',
+              expanded ? 'jd-max-h-80 jd-overflow-y-auto' : 'jd-max-h-32 jd-overflow-hidden'
+            )}
+          >
             <pre className="jd-whitespace-pre-wrap jd-text-sm jd-font-mono jd-leading-relaxed">
               {displayed || (
                 <span className="jd-text-muted-foreground jd-italic">
@@ -95,7 +105,12 @@ export const PreviewSection: React.FC<PreviewSectionProps> = ({
               )}
             </pre>
             {!expanded && showToggle && content && (
-              <div className="jd-absolute jd-inset-x-0 jd-bottom-0 jd-h-8 jd-bg-gradient-to-t jd-from-white dark:jd-from-gray-800 jd-to-white/0 dark:jd-to-gray-800/0 jd-pointer-events-none jd-rounded-b-lg" />
+              <div
+                className={cn(
+                  'jd-absolute jd-inset-x-0 jd-bottom-0 jd-h-8 jd-bg-gradient-to-t jd-pointer-events-none jd-rounded-b-lg',
+                  isDarkMode ? 'jd-from-gray-800 jd-to-gray-800/0' : 'jd-from-white jd-to-white/0'
+                )}
+              />
             )}
           </div>
           

--- a/src/components/dialogs/templates/hooks/usePlaceholderEditor.ts
+++ b/src/components/dialogs/templates/hooks/usePlaceholderEditor.ts
@@ -95,6 +95,10 @@ export function usePlaceholderEditor() {
     });
   };
 
+  const handleReorderBlocks = (newBlocks: Block[]) => {
+    setBlocks(newBlocks);
+  };
+
   const handleUpdateMetadata = (newMetadata: PromptMetadata) => {
     setMetadata(newMetadata);
   };
@@ -142,6 +146,7 @@ export function usePlaceholderEditor() {
     handleRemoveBlock,
     handleUpdateBlock,
     handleMoveBlock,
+    handleReorderBlocks,
     handleUpdateMetadata,
     handleComplete,
     handleClose,

--- a/src/components/dialogs/templates/utils/blockUtils.ts
+++ b/src/components/dialogs/templates/utils/blockUtils.ts
@@ -33,13 +33,22 @@ export const BLOCK_TYPE_DESCRIPTIONS: Record<BlockType, string> = {
   audience: 'Define the target audience for the response'
 };
 
-export const BLOCK_COLORS: Record<BlockType, string> = {
-  content: 'jd-bg-blue-50 jd-border-blue-200 jd-text-blue-900 dark:jd-bg-blue-900/20 dark:jd-border-blue-800 dark:jd-text-blue-300',
-  context: 'jd-bg-green-50 jd-border-green-200 jd-text-green-900 dark:jd-bg-green-900/20 dark:jd-border-green-800 dark:jd-text-green-300',
-  role: 'jd-bg-purple-50 jd-border-purple-200 jd-text-purple-900 dark:jd-bg-purple-900/20 dark:jd-border-purple-800 dark:jd-text-purple-300',
-  example: 'jd-bg-orange-50 jd-border-orange-200 jd-text-orange-900 dark:jd-bg-orange-900/20 dark:jd-border-orange-800 dark:jd-text-orange-300',
-  format: 'jd-bg-pink-50 jd-border-pink-200 jd-text-pink-900 dark:jd-bg-pink-900/20 dark:jd-border-pink-800 dark:jd-text-pink-300',
-  audience: 'jd-bg-teal-50 jd-border-teal-200 jd-text-teal-900 dark:jd-bg-teal-900/20 dark:jd-border-teal-800 dark:jd-text-teal-300'
+export const BLOCK_COLORS_LIGHT: Record<BlockType, string> = {
+  content: 'jd-bg-blue-50 jd-border-blue-200 jd-text-blue-900',
+  context: 'jd-bg-green-50 jd-border-green-200 jd-text-green-900',
+  role: 'jd-bg-purple-50 jd-border-purple-200 jd-text-purple-900',
+  example: 'jd-bg-orange-50 jd-border-orange-200 jd-text-orange-900',
+  format: 'jd-bg-pink-50 jd-border-pink-200 jd-text-pink-900',
+  audience: 'jd-bg-teal-50 jd-border-teal-200 jd-text-teal-900'
+};
+
+export const BLOCK_COLORS_DARK: Record<BlockType, string> = {
+  content: 'jd-bg-blue-900/20 jd-border-blue-800 jd-text-blue-300',
+  context: 'jd-bg-green-900/20 jd-border-green-800 jd-text-green-300',
+  role: 'jd-bg-purple-900/20 jd-border-purple-800 jd-text-purple-300',
+  example: 'jd-bg-orange-900/20 jd-border-orange-800 jd-text-orange-300',
+  format: 'jd-bg-pink-900/20 jd-border-pink-800 jd-text-pink-300',
+  audience: 'jd-bg-teal-900/20 jd-border-teal-800 jd-text-teal-300'
 };
 
 /**
@@ -66,8 +75,9 @@ export const getBlockTypeDescription = (type: BlockType): string => {
 /**
  * Get color classes for a block type
  */
-export const getBlockTypeColors = (type: BlockType): string => {
-  return BLOCK_COLORS[type] || BLOCK_COLORS.content;
+export const getBlockTypeColors = (type: BlockType, isDarkMode: boolean): string => {
+  const palette = isDarkMode ? BLOCK_COLORS_DARK : BLOCK_COLORS_LIGHT;
+  return palette[type] || palette.content;
 };
 
 


### PR DESCRIPTION
## Summary
- apply useThemeDetector hook in `BasicEditor`
- add drag & drop props to `BlockCard`
- handle drag operations in `AdvancedEditor`
- expose reorder handler in placeholder editor hook
- pass new handler through `PlaceholderEditor`
- detect dark mode in `MetadataCard` and `PreviewSection`
- add theme-aware color utilities for block types

## Testing
- `pnpm type-check`
- `pnpm lint` *(fails: Unexpected any. Specify a different type)*
