### PR TITLE
Fix metadata changes updating prompt content

### DIFF
--- a/src/components/dialogs/templates/hooks/usePlaceholderEditor.ts
+++ b/src/components/dialogs/templates/hooks/usePlaceholderEditor.ts
@@ -3,7 +3,7 @@ import { useDialog } from '@/hooks/dialogs/useDialog';
 import { trackEvent, EVENTS } from '@/utils/amplitude';
 import { toast } from 'sonner';
 import { Block, BlockType } from '@/components/templates/blocks/types';
-import { PromptMetadata, DEFAULT_METADATA } from '@/components/templates/metadata/types';
+import { PromptMetadata, DEFAULT_METADATA, ALL_METADATA_TYPES } from '@/components/templates/metadata/types';
 import { getBlockContent, getLocalizedContent } from '../utils/blockUtils';
 
 export function usePlaceholderEditor() {
@@ -105,7 +105,16 @@ export function usePlaceholderEditor() {
 
   const handleComplete = () => {
     try {
-      const finalContent = blocks.map(block => getBlockContent(block)).join('\n\n');
+      const parts: string[] = [];
+      ALL_METADATA_TYPES.forEach(type => {
+        const value = metadata.values?.[type];
+        if (value) parts.push(value);
+      });
+      blocks.forEach(block => {
+        const content = getBlockContent(block);
+        if (content) parts.push(content);
+      });
+      const finalContent = parts.filter(Boolean).join('\n\n');
       if (data && data.onComplete) {
         data.onComplete(finalContent);
       }

--- a/src/components/templates/metadata/types.ts
+++ b/src/components/templates/metadata/types.ts
@@ -10,6 +10,7 @@ export interface PromptMetadata {
   audience?: number;
   format?: number;
   example?: number;
+  values?: Partial<Record<MetadataType, string>>;
 }
 
 export interface MetadataConfig {
@@ -65,11 +66,14 @@ export const METADATA_CONFIGS: Record<MetadataType, MetadataConfig> = {
   }
 };
 
+export const ALL_METADATA_TYPES: MetadataType[] = Object.keys(METADATA_CONFIGS) as MetadataType[];
+
 export const DEFAULT_METADATA: PromptMetadata = {
   role: undefined,
   context: undefined,
   goal: undefined,
   audience: undefined,
   format: undefined,
-  example: undefined
+  example: undefined,
+  values: {}
 };


### PR DESCRIPTION
## Summary
- store selected metadata text in `PromptMetadata`
- sync metadata values when editing in the Advanced editor
- update preview generator to use stored metadata values
- include metadata when building final prompt content

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*
- `npm run type-check`