### PR TITLE
Add save button for custom blocks

### DIFF
--- a/src/components/dialogs/templates/PlaceholderEditor.tsx
+++ b/src/components/dialogs/templates/PlaceholderEditor.tsx
@@ -62,7 +62,6 @@ export const PlaceholderEditor: React.FC = () => {
     onAddBlock: handleAddBlock,
     onRemoveBlock: handleRemoveBlock,
     onUpdateBlock: handleUpdateBlock,
-    onMoveBlock: handleMoveBlock,
     onReorderBlocks: handleReorderBlocks,
     onUpdateMetadata: handleUpdateMetadata,
     isProcessing

--- a/src/components/dialogs/templates/editor/components/BlockCard.tsx
+++ b/src/components/dialogs/templates/editor/components/BlockCard.tsx
@@ -4,7 +4,8 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
-import { ArrowUp, ArrowDown, Trash2, FileText, MessageSquare, User, Layout, Type, Users, GripVertical } from 'lucide-react';
+import { Trash2, FileText, MessageSquare, User, Layout, Type, Users, GripVertical } from 'lucide-react';
+import { SaveBlockButton } from './SaveBlockButton';
 import { getCurrentLanguage } from '@/core/utils/i18n';
 import { cn } from '@/core/utils/classNames';
 
@@ -28,26 +29,22 @@ const BLOCK_COLORS: Record<BlockType, string> = {
 
 interface BlockCardProps {
   block: Block;
-  index: number;
-  total: number;
-  onMove: (id: number, dir: 'up' | 'down') => void;
   onRemove: (id: number) => void;
   onUpdate: (id: number, updated: Partial<Block>) => void;
   onDragStart?: (id: number) => void;
   onDragOver?: (id: number) => void;
   onDragEnd?: () => void;
+  onSave?: (block: Block) => void;
 }
 
 export const BlockCard: React.FC<BlockCardProps> = ({
   block,
-  index,
-  total,
-  onMove,
   onRemove,
   onUpdate,
   onDragStart,
   onDragOver,
-  onDragEnd
+  onDragEnd,
+  onSave
 }) => {
   const Icon = BLOCK_ICONS[block.type];
   const content = typeof block.content === 'string' 
@@ -100,30 +97,20 @@ export const BlockCard: React.FC<BlockCardProps> = ({
           </div>
           
           <div className="jd-flex jd-items-center jd-gap-1 jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity">
-            <Button 
-              size="sm" 
-              variant="ghost" 
-              onClick={() => onMove(block.id, 'up')} 
-              disabled={index === 0} 
-              className="jd-h-8 jd-w-8 jd-p-1"
-              title="Move up"
-            >
-              <ArrowUp className="jd-h-4 jd-w-4" />
-            </Button>
-            <Button 
-              size="sm" 
-              variant="ghost" 
-              onClick={() => onMove(block.id, 'down')} 
-              disabled={index === total - 1} 
-              className="jd-h-8 jd-w-8 jd-p-1"
-              title="Move down"
-            >
-              <ArrowDown className="jd-h-4 jd-w-4" />
-            </Button>
-            <Button 
-              size="sm" 
-              variant="ghost" 
-              onClick={() => onRemove(block.id)} 
+            {block.isNew && content.trim() && (
+              <SaveBlockButton
+                type={block.type}
+                content={content}
+                title={block.name}
+                description={block.description}
+                onSaved={(saved) => onSave && onSave(saved)}
+                className="jd-h-8 jd-w-8 jd-p-1"
+              />
+            )}
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => onRemove(block.id)}
               className="jd-h-8 jd-w-8 jd-p-1 jd-text-muted-foreground jd-hover:jd-text-destructive"
               title="Delete block"
             >

--- a/src/components/dialogs/templates/editor/components/MetadataCard.tsx
+++ b/src/components/dialogs/templates/editor/components/MetadataCard.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { Trash2, ChevronUp, ChevronDown, Plus } from 'lucide-react';
+import { SaveBlockButton } from './SaveBlockButton';
 import { cn } from '@/core/utils/classNames';
 import { getCurrentLanguage } from '@/core/utils/i18n';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
@@ -21,6 +22,7 @@ interface MetadataCardProps {
   onCustomChange: (value: string) => void;
   onToggle: () => void;
   onRemove?: () => void;
+  onSaveBlock?: (block: Block) => void;
 }
 
 export const MetadataCard: React.FC<MetadataCardProps> = ({
@@ -34,7 +36,8 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
   onSelect,
   onCustomChange,
   onToggle,
-  onRemove
+  onRemove,
+  onSaveBlock
 }) => {
   const config = METADATA_CONFIGS[type];
   const isDarkMode = useThemeDetector();
@@ -143,14 +146,24 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
             </Select>
 
             {(!selectedId || selectedId === 0) && (
-              <Textarea
-                value={customValue}
-                onChange={(e) => onCustomChange(e.target.value)}
-                placeholder={`Enter custom ${type} content...`}
-                rows={3}
-                className="jd-resize-none"
-                onClick={stopPropagation}
-              />
+              <>
+                <Textarea
+                  value={customValue}
+                  onChange={(e) => onCustomChange(e.target.value)}
+                  placeholder={`Enter custom ${type} content...`}
+                  rows={3}
+                  className="jd-resize-none"
+                  onClick={stopPropagation}
+                />
+                {customValue && (
+                  <SaveBlockButton
+                    type={config.blockType}
+                    content={customValue}
+                    onSaved={(b) => onSaveBlock && onSaveBlock(b)}
+                    className="jd-h-6 jd-w-6 jd-p-0 jd-text-muted-foreground jd-hover:jd-text-primary"
+                  />
+                )}
+              </>
             )}
           </div>
         ) : (

--- a/src/components/dialogs/templates/editor/components/SaveBlockButton.tsx
+++ b/src/components/dialogs/templates/editor/components/SaveBlockButton.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Check, Save } from 'lucide-react';
+import { CreateBlockData, blocksApi } from '@/services/api/BlocksApi';
+import { Block, BlockType } from '@/components/templates/blocks/types';
+import { toast } from 'sonner';
+
+interface SaveBlockButtonProps {
+  type: BlockType;
+  content: string;
+  title?: string;
+  description?: string;
+  onSaved?: (block: Block) => void;
+  className?: string;
+}
+
+export const SaveBlockButton: React.FC<SaveBlockButtonProps> = ({
+  type,
+  content,
+  title,
+  description,
+  onSaved,
+  className
+}) => {
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const handleSave = async () => {
+    if (!content.trim()) return;
+    setSaving(true);
+    const data: CreateBlockData = {
+      type,
+      content: typeof content === 'string' ? { en: content } : content,
+      title: title ? { en: title } : undefined,
+      description: description ? { en: description } : undefined
+    } as any;
+    try {
+      const res = await blocksApi.createBlock(data);
+      if (res.success) {
+        toast.success('Block saved');
+        setSaved(true);
+        onSaved && onSaved(res.data);
+      } else {
+        toast.error(res.message || 'Failed to save block');
+      }
+    } catch (err) {
+      toast.error('Failed to save block');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Button
+      size="sm"
+      variant="ghost"
+      onClick={handleSave}
+      disabled={saving || saved || !content.trim()}
+      className={className}
+      title="Save block"
+    >
+      {saved ? <Check className="jd-h-4 jd-w-4" /> : <Save className="jd-h-4 jd-w-4" />}
+    </Button>
+  );
+};

--- a/src/components/dialogs/templates/hooks/usePlaceholderEditor.ts
+++ b/src/components/dialogs/templates/hooks/usePlaceholderEditor.ts
@@ -50,13 +50,14 @@ export function usePlaceholderEditor() {
 
   const handleAddBlock = (position: 'start' | 'end', blockType: BlockType, existingBlock?: Block) => {
     const newBlock: Block = existingBlock
-      ? { ...existingBlock }
+      ? { ...existingBlock, isNew: false }
       : {
           id: Date.now() + Math.random(),
           type: blockType,
           content: '',
           name: `New ${blockType.charAt(0).toUpperCase() + blockType.slice(1)} Block`,
-          description: ''
+          description: '',
+          isNew: true
         };
 
     setBlocks(prevBlocks => {

--- a/src/components/templates/blocks/types.ts
+++ b/src/components/templates/blocks/types.ts
@@ -28,6 +28,8 @@ export interface Block {
   user_id?: string;
   organization_id?: string;
   company_id?: string;
+  /** Whether this block has not been saved to the backend */
+  isNew?: boolean;
 }
 
 export interface BlockTypeDefinition {


### PR DESCRIPTION
## Summary
- add `SaveBlockButton` for saving custom blocks
- remove arrow controls from `BlockCard` and add save button logic
- enable saving of custom metadata blocks
- mark new blocks with `isNew`
- update advanced editor to handle block saving

## Testing
- `pnpm lint` *(fails: Unexpected any errors)*
- `pnpm type-check`