### PR TITLE
Allow changing block type in editor

### DIFF
--- a/src/components/dialogs/templates/TemplateDialog.tsx
+++ b/src/components/dialogs/templates/TemplateDialog.tsx
@@ -16,6 +16,7 @@ import { getMessage } from '@/core/utils/i18n';
 import { BaseDialog } from '../BaseDialog';
 import { BasicTemplateEditor, AdvancedTemplateEditor } from './editor/template';
 import { getBlockContent } from './utils/blockUtils';
+import { formatBlockForPrompt, formatMetadataForPrompt } from './utils/promptUtils';
 import { ALL_METADATA_TYPES } from '@/components/templates/metadata/types';
 
 // Define types for folder data
@@ -262,21 +263,21 @@ export const TemplateDialog: React.FC = () => {
     
     // Advanced mode: combine metadata and blocks
     const parts: string[] = [];
-    
-    // Add metadata content
+
+    // Add metadata content with French prefixes
     ALL_METADATA_TYPES.forEach((type) => {
       const value = metadata.values?.[type];
       if (value) {
-        parts.push(value);
+        parts.push(formatMetadataForPrompt(type, value));
       }
     });
-    
-    // Add block content
+
+    // Add block content with prefixes
     blocks.forEach((block) => {
-      const blockContent = getBlockContent(block);
-      if (blockContent) parts.push(blockContent);
+      const formatted = formatBlockForPrompt(block);
+      if (formatted) parts.push(formatted);
     });
-    
+
     return parts.filter(Boolean).join('\n\n');
   };
   
@@ -371,14 +372,20 @@ export const TemplateDialog: React.FC = () => {
   };
   
   // Block management functions
-  const handleAddBlock = (position: 'start' | 'end', blockType: BlockType, existingBlock?: Block) => {
+  const handleAddBlock = (
+    position: 'start' | 'end',
+    blockType?: BlockType | null,
+    existingBlock?: Block
+  ) => {
     const newBlock: Block = existingBlock
       ? { ...existingBlock, isNew: false }
       : {
           id: Date.now() + Math.random(),
-          type: blockType,
+          type: blockType || null,
           content: '',
-          name: `New ${blockType.charAt(0).toUpperCase() + blockType.slice(1)} Block`,
+          name: blockType
+            ? `New ${blockType.charAt(0).toUpperCase() + blockType.slice(1)} Block`
+            : 'New Block',
           description: '',
           isNew: true
         };

--- a/src/components/dialogs/templates/editor/AdvancedEditor.tsx
+++ b/src/components/dialogs/templates/editor/AdvancedEditor.tsx
@@ -4,11 +4,12 @@ import { Block, BlockType } from '@/components/templates/blocks/types';
 import { PromptMetadata, DEFAULT_METADATA, METADATA_CONFIGS, MetadataType } from '@/components/templates/metadata/types';
 import { blocksApi } from '@/services/api/BlocksApi';
 import { getCurrentLanguage } from '@/core/utils/i18n';
+import { formatMetadataForPreview, formatBlockForPreview } from '../utils/promptUtils';
+import { highlightPlaceholders } from '@/utils/templates/placeholderUtils';
 import { Button } from '@/components/ui/button';
 import { MetadataCard } from './components/MetadataCard';
 import { BlockCard } from './components/BlockCard';
 import { PreviewSection } from './components/PreviewSection';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Plus, FileText, User, MessageSquare, Target, Users, Type, Layout } from 'lucide-react';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
 import { cn } from '@/core/utils/classNames';
@@ -16,7 +17,7 @@ import { cn } from '@/core/utils/classNames';
 interface AdvancedEditorProps {
   blocks: Block[];
   metadata?: PromptMetadata;
-  onAddBlock: (position: 'start' | 'end', blockType: BlockType, existingBlock?: Block) => void;
+  onAddBlock: (position: 'start' | 'end', blockType?: BlockType | null, existingBlock?: Block) => void;
   onRemoveBlock: (blockId: number) => void;
   onUpdateBlock: (blockId: number, updatedBlock: Partial<Block>) => void;
   onReorderBlocks: (blocks: Block[]) => void;
@@ -39,28 +40,6 @@ const METADATA_ICONS: Record<MetadataType, React.ComponentType<any>> = {
   example: Layout
 };
 
-// Available block types for adding new blocks
-const BLOCK_TYPES: BlockType[] = ['content', 'context', 'role', 'example', 'format', 'audience'];
-
-const BLOCK_TYPE_LABELS: Record<BlockType, string> = {
-  content: 'Content',
-  goal: 'Goal',
-  context: 'Context',
-  role: 'Role',
-  example: 'Example',
-  format: 'Format',
-  audience: 'Audience'
-};
-
-const BLOCK_TYPE_ICONS: Record<BlockType, React.ComponentType<any>> = {
-  content: FileText,
-  goal: Target,
-  context: MessageSquare,
-  role: User,
-  example: Layout,
-  format: Type,
-  audience: Users
-};
 
 export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   blocks,
@@ -79,9 +58,6 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   const [expandedMetadata, setExpandedMetadata] = useState<MetadataType | null>(null);
   const [previewExpanded, setPreviewExpanded] = useState(false);
   const [activeSecondaryMetadata, setActiveSecondaryMetadata] = useState<Set<MetadataType>>(new Set());
-  const [showAddBlockDropdown, setShowAddBlockDropdown] = useState(false);
-  const [selectedBlockType, setSelectedBlockType] = useState<BlockType | null>(null);
-  const [availableBlocksByType, setAvailableBlocksByType] = useState<Record<BlockType, Block[]>>({} as Record<BlockType, Block[]>);
   const [draggedBlockId, setDraggedBlockId] = useState<number | null>(null);
 
   const isDarkMode = useThemeDetector();
@@ -101,16 +77,6 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
         })
       );
       setAvailableBlocks(metadataBlocks);
-
-      // Fetch blocks for each block type
-      const blocksByType: Record<BlockType, Block[]> = {} as any;
-      await Promise.all(
-        BLOCK_TYPES.map(async (blockType) => {
-          const res = await blocksApi.getBlocksByType(blockType);
-          blocksByType[blockType] = res.success ? res.data : [];
-        })
-      );
-      setAvailableBlocksByType(blocksByType);
     };
     fetchBlocks();
   }, []);
@@ -179,11 +145,6 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
     onUpdateMetadata(newMetadata);
   };
 
-  const handleAddBlockFromDropdown = (blockType: BlockType, existingBlock?: Block) => {
-    onAddBlock('end', blockType, existingBlock);
-    setShowAddBlockDropdown(false);
-    setSelectedBlockType(null);
-  };
 
   const handleDragStart = (id: number) => {
     setDraggedBlockId(id);
@@ -208,12 +169,6 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
     // Update block id and mark as saved
     onUpdateBlock(tempId, { id: saved.id, isNew: false });
 
-    // Add to available blocks lists
-    setAvailableBlocksByType(prev => ({
-      ...prev,
-      [saved.type]: [saved, ...(prev[saved.type] || [])]
-    }));
-
     Object.entries(METADATA_CONFIGS).forEach(([metaType, cfg]) => {
       if (cfg.blockType === saved.type) {
         setAvailableBlocks(prev => ({
@@ -225,10 +180,6 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   };
 
   const handleMetadataBlockSaved = (saved: Block) => {
-    setAvailableBlocksByType(prev => ({
-      ...prev,
-      [saved.type]: [saved, ...(prev[saved.type] || [])]
-    }));
     Object.entries(METADATA_CONFIGS).forEach(([metaType, cfg]) => {
       if (cfg.blockType === saved.type) {
         setAvailableBlocks(prev => ({
@@ -242,24 +193,23 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   // Generate final content for preview
   const generatePreviewContent = () => {
     const parts: string[] = [];
-    
+
     // Add metadata content
     ALL_METADATA_TYPES.forEach((type) => {
       const value = metadata.values?.[type];
       if (value) {
-        parts.push(value);
+        parts.push(formatMetadataForPreview(type, value));
       }
     });
-    
+
     // Add block content
     blocks.forEach((block) => {
-      const content = typeof block.content === 'string' 
-        ? block.content 
-        : block.content[getCurrentLanguage()] || block.content.en || '';
-      if (content) parts.push(content);
+      const formatted = formatBlockForPreview(block);
+      if (formatted) parts.push(formatted);
     });
-    
-    return parts.filter(Boolean).join('\n\n');
+
+    const html = parts.filter(Boolean).join('<br><br>');
+    return highlightPlaceholders(html);
   };
 
   if (isProcessing) {
@@ -382,104 +332,16 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
                 onSave={(saved) => handleBlockSaved(block.id, saved)}
               />
               {index === blocks.length - 1 && (
-                <div className="jd-flex jd-justify-center jd-mt-3 jd-relative">
-                  {!showAddBlockDropdown ? (
-                    <Button
-                      onClick={() => setShowAddBlockDropdown(true)}
-                      variant="outline"
-                      size="sm"
-                      className="jd-flex jd-items-center jd-gap-2"
-                    >
-                      <Plus className="jd-h-4 jd-w-4" />
-                      Add Block
-                    </Button>
-                  ) : (
-                    <div className="jd-flex jd-flex-col jd-gap-2 jd-p-4 jd-border jd-rounded-lg jd-shadow-lg jd-min-w-64">
-                      <div className="jd-flex jd-items-center jd-justify-between">
-                        <span className="jd-font-medium jd-text-sm">Add Block</span>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => {
-                            setShowAddBlockDropdown(false);
-                            setSelectedBlockType(null);
-                          }}
-                          className="jd-h-6 jd-w-6 jd-p-0"
-                        >
-                          ×
-                        </Button>
-                      </div>
-                      
-                      <Select
-                        value={selectedBlockType || ''}
-                        onValueChange={(value) => setSelectedBlockType(value as BlockType)}
-                      >
-                        <SelectTrigger className="jd-w-full">
-                          <SelectValue placeholder="Select block type" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {BLOCK_TYPES.map((blockType) => {
-                            const Icon = BLOCK_TYPE_ICONS[blockType];
-                            return (
-                              <SelectItem key={blockType} value={blockType}>
-                                <div className="jd-flex jd-items-center jd-gap-2">
-                                  <Icon className="jd-h-4 jd-w-4" />
-                                  {BLOCK_TYPE_LABELS[blockType]}
-                                </div>
-                              </SelectItem>
-                            );
-                          })}
-                        </SelectContent>
-                      </Select>
-
-                      {selectedBlockType && (
-                        <div className="jd-space-y-2">
-                          <div className="jd-text-xs jd-text-muted-foreground">
-                            Choose from existing blocks or create new:
-                          </div>
-                          
-                          <Button
-                            onClick={() => handleAddBlockFromDropdown(selectedBlockType)}
-                            variant="outline"
-                            size="sm"
-                            className="jd-w-full jd-justify-start"
-                          >
-                            <Plus className="jd-h-3 jd-w-3 jd-mr-2" />
-                            Create new {BLOCK_TYPE_LABELS[selectedBlockType].toLowerCase()} block
-                          </Button>
-
-                          {availableBlocksByType[selectedBlockType]?.length > 0 && (
-                            <div className="jd-space-y-1">
-                              <div className="jd-text-xs jd-text-muted-foreground">
-                                Or use existing:
-                              </div>
-                              {availableBlocksByType[selectedBlockType].slice(0, 3).map((block) => (
-                                <Button
-                                  key={block.id}
-                                  onClick={() => handleAddBlockFromDropdown(selectedBlockType, block)}
-                                  variant="ghost"
-                                  size="sm"
-                                  className="jd-w-full jd-justify-start jd-text-left jd-h-auto jd-p-2"
-                                >
-                                  <div className="jd-flex jd-flex-col jd-items-start">
-                                    <span className="jd-font-medium jd-text-xs">
-                                      {block.name || `${selectedBlockType} block`}
-                                    </span>
-                                    <span className="jd-text-xs jd-text-muted-foreground jd-truncate jd-max-w-full">
-                                      {typeof block.content === 'string' 
-                                        ? block.content.substring(0, 40) + '...'
-                                        : Object.values(block.content)[0]?.substring(0, 40) + '...' || ''
-                                      }
-                                    </span>
-                                  </div>
-                                </Button>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  )}
+                <div className="jd-flex jd-justify-center jd-mt-3">
+                  <Button
+                    onClick={() => onAddBlock('end')}
+                    variant="outline"
+                    size="sm"
+                    className="jd-flex jd-items-center jd-gap-2"
+                  >
+                    <Plus className="jd-h-4 jd-w-4" />
+                    Add Block
+                  </Button>
                 </div>
               )}
             </div>
@@ -490,7 +352,7 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
               <FileText className="jd-h-12 jd-w-12 jd-mx-auto jd-mb-2 jd-text-muted-foreground/50" />
               <p>No content blocks yet</p>
               <Button
-                onClick={() => setShowAddBlockDropdown(true)}
+                onClick={() => onAddBlock('end')}
                 variant="outline"
                 size="sm"
                 className="jd-mt-2"
@@ -507,6 +369,7 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
         content={generatePreviewContent()}
         expanded={previewExpanded}
         onToggle={() => setPreviewExpanded(!previewExpanded)}
+        isHtml
       />
     </div>
   );

--- a/src/components/dialogs/templates/editor/BasicEditor.tsx
+++ b/src/components/dialogs/templates/editor/BasicEditor.tsx
@@ -10,7 +10,7 @@ import { useThemeDetector } from '@/hooks/useThemeDetector';
 
 interface BasicEditorProps {
   blocks: Block[];
-  onAddBlock: (position: 'start' | 'end', blockType: BlockType, existingBlock?: Block) => void;
+  onAddBlock: (position: 'start' | 'end', blockType?: BlockType | null, existingBlock?: Block) => void;
   onRemoveBlock: (blockId: number) => void;
   onUpdateBlock: (blockId: number, updatedBlock: Partial<Block>) => void;
   onMoveBlock: (blockId: number, direction: 'up' | 'down') => void;

--- a/src/components/dialogs/templates/editor/components/BlockCard.tsx
+++ b/src/components/dialogs/templates/editor/components/BlockCard.tsx
@@ -3,11 +3,11 @@ import { Block, BlockType } from '@/components/templates/blocks/types';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
-import { Badge } from '@/components/ui/badge';
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
 import { Trash2, FileText, MessageSquare, User, Layout, Type, Users, GripVertical } from 'lucide-react';
 import { SaveBlockButton } from './SaveBlockButton';
 import { getCurrentLanguage } from '@/core/utils/i18n';
-import { cn } from '@/core/utils/classNames';
+import { BLOCK_TYPES, BLOCK_TYPE_LABELS } from '../../utils/blockUtils';
 
 const BLOCK_ICONS: Record<BlockType, React.ComponentType<any>> = {
   content: FileText,
@@ -18,14 +18,6 @@ const BLOCK_ICONS: Record<BlockType, React.ComponentType<any>> = {
   audience: Users
 };
 
-const BLOCK_COLORS: Record<BlockType, string> = {
-  content: 'jd-bg-blue-50 jd-border-blue-200 jd-text-blue-900',
-  context: 'jd-bg-green-50 jd-border-green-200 jd-text-green-900',
-  role: 'jd-bg-purple-50 jd-border-purple-200 jd-text-purple-900',
-  example: 'jd-bg-orange-50 jd-border-orange-200 jd-text-orange-900',
-  format: 'jd-bg-pink-50 jd-border-pink-200 jd-text-pink-900',
-  audience: 'jd-bg-teal-50 jd-border-teal-200 jd-text-teal-900'
-};
 
 interface BlockCardProps {
   block: Block;
@@ -46,7 +38,7 @@ export const BlockCard: React.FC<BlockCardProps> = ({
   onDragEnd,
   onSave
 }) => {
-  const Icon = BLOCK_ICONS[block.type];
+  const Icon = block.type ? BLOCK_ICONS[block.type] : FileText;
   const content = typeof block.content === 'string' 
     ? block.content 
     : block.content[getCurrentLanguage()] || block.content.en || '';
@@ -82,17 +74,23 @@ export const BlockCard: React.FC<BlockCardProps> = ({
             </div>
             <div className="jd-flex jd-items-center jd-gap-2">
               <span className="jd-font-medium jd-text-sm">
-                {block.name || `${block.type.charAt(0).toUpperCase() + block.type.slice(1)} Block`}
+                {block.name || 'Block'}
               </span>
-              <Badge 
-                variant="default" 
-                className={cn(
-                  'jd-text-xs jd-border',
-                  BLOCK_COLORS[block.type]
-                )}
+              <Select
+                value={block.type || ''}
+                onValueChange={(value) => onUpdate(block.id, { type: value as BlockType })}
               >
-                {block.type}
-              </Badge>
+                <SelectTrigger className="jd-w-32 jd-text-xs jd-h-7">
+                  <SelectValue placeholder="Select type" />
+                </SelectTrigger>
+                <SelectContent>
+                  {BLOCK_TYPES.map((t) => (
+                    <SelectItem key={t} value={t}>
+                      {BLOCK_TYPE_LABELS[t]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           </div>
           
@@ -106,7 +104,7 @@ export const BlockCard: React.FC<BlockCardProps> = ({
               className="jd-h-8 jd-w-8 jd-p-1 jd-text-muted-foreground jd-hover:jd-text-destructive"
               title="Delete block"
             >
-              <Trash2 className="jd-h-4 jd-w-4" />
+              <Trash2 className="jd-h-5 jd-w-5" />
             </Button>
           </div>
         </div>
@@ -115,7 +113,7 @@ export const BlockCard: React.FC<BlockCardProps> = ({
           value={content}
           onChange={(e) => handleContentChange(e.target.value)}
           className="jd-resize-none jd-min-h-[100px] jd-text-sm"
-          placeholder={`Enter ${block.type} content...`}
+          placeholder={block.type ? `Enter ${block.type} content...` : 'Enter block content...'}
         />
         
         {content && (
@@ -125,7 +123,7 @@ export const BlockCard: React.FC<BlockCardProps> = ({
           </div>
         )}
 
-        {block.isNew && content.trim() && (
+        {block.isNew && content.trim() && block.type && (
           <div className="jd-flex jd-justify-end jd-mt-3">
             <SaveBlockButton
               type={block.type}

--- a/src/components/dialogs/templates/editor/components/PreviewSection.tsx
+++ b/src/components/dialogs/templates/editor/components/PreviewSection.tsx
@@ -9,12 +9,14 @@ interface PreviewSectionProps {
   content: string;
   expanded: boolean;
   onToggle: () => void;
+  isHtml?: boolean;
 }
 
 export const PreviewSection: React.FC<PreviewSectionProps> = ({
   content,
   expanded,
-  onToggle
+  onToggle,
+  isHtml = false
 }) => {
   const [copied, setCopied] = React.useState(false);
   const isDarkMode = useThemeDetector();
@@ -97,11 +99,16 @@ export const PreviewSection: React.FC<PreviewSectionProps> = ({
               expanded ? 'jd-max-h-80 jd-overflow-y-auto' : 'jd-max-h-32 jd-overflow-hidden'
             )}
           >
-            <pre className="jd-whitespace-pre-wrap jd-text-sm jd-font-mono jd-leading-relaxed">
-              {displayed || (
-                <span className="jd-text-muted-foreground jd-italic">
-                  Your prompt will appear here...
-                </span>
+            <pre
+              className="jd-whitespace-pre-wrap jd-text-sm jd-font-mono jd-leading-relaxed"
+              {...(isHtml
+                ? { dangerouslySetInnerHTML: { __html: displayed || '<span class="jd-text-muted-foreground jd-italic">Your prompt will appear here...</span>' } }
+                : {})}
+            >
+              {!isHtml && (
+                displayed || (
+                  <span className="jd-text-muted-foreground jd-italic">Your prompt will appear here...</span>
+                )
               )}
             </pre>
             {!expanded && showToggle && content && (

--- a/src/components/dialogs/templates/editor/template/AdvancedTemplateEditor.tsx
+++ b/src/components/dialogs/templates/editor/template/AdvancedTemplateEditor.tsx
@@ -11,7 +11,11 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { getMessage } from '@/core/utils/i18n';
 import { ALL_METADATA_TYPES, METADATA_CONFIGS } from '@/components/templates/metadata/types';
 import { User, MessageSquare, Target, Users, Type, Layout } from 'lucide-react';
-import { getBlockContent } from '../../utils/blockUtils';
+import {
+  formatMetadataForPreview,
+  formatBlockForPreview,
+} from '../../utils/promptUtils';
+import { highlightPlaceholders } from '@/utils/templates/placeholderUtils';
 
 const METADATA_ICONS: Record<string, React.ComponentType<any>> = {
   role: User,
@@ -28,7 +32,7 @@ const PRIMARY_METADATA = ['role', 'context', 'goal'] as const;
 interface AdvancedTemplateEditorProps {
   blocks: Block[];
   metadata: PromptMetadata;
-  onAddBlock: (position: 'start' | 'end', blockType: BlockType, existingBlock?: Block) => void;
+  onAddBlock: (position: 'start' | 'end', blockType?: BlockType | null, existingBlock?: Block) => void;
   onRemoveBlock: (blockId: number) => void;
   onUpdateBlock: (blockId: number, updatedBlock: Partial<Block>) => void;
   onReorderBlocks: (blocks: Block[]) => void;
@@ -127,22 +131,23 @@ export const AdvancedTemplateEditor: React.FC<AdvancedTemplateEditorProps> = ({
   // Generate preview content
   const generatePreviewContent = () => {
     const parts: string[] = [];
-    
+
     // Add metadata content
     ALL_METADATA_TYPES.forEach((type) => {
       const value = metadata.values?.[type];
       if (value) {
-        parts.push(value);
+        parts.push(formatMetadataForPreview(type, value));
       }
     });
-    
+
     // Add block content
     blocks.forEach((block) => {
-      const content = getBlockContent(block);
-      if (content) parts.push(content);
+      const formatted = formatBlockForPreview(block);
+      if (formatted) parts.push(formatted);
     });
-    
-    return parts.filter(Boolean).join('\n\n');
+
+    const html = parts.filter(Boolean).join('<br><br>');
+    return highlightPlaceholders(html);
   };
 
   return (
@@ -247,7 +252,7 @@ export const AdvancedTemplateEditor: React.FC<AdvancedTemplateEditorProps> = ({
                 <div className="jd-text-center jd-py-8 jd-border-2 jd-border-dashed jd-rounded-lg jd-text-muted-foreground">
                   <p className="jd-mb-2">{getMessage('noContentBlocks', undefined, 'No content blocks yet')}</p>
                   <Button
-                    onClick={() => onAddBlock('end', 'content')}
+                    onClick={() => onAddBlock('end')}
                     variant="outline"
                     size="sm"
                   >
@@ -260,7 +265,7 @@ export const AdvancedTemplateEditor: React.FC<AdvancedTemplateEditorProps> = ({
               {blocks.length > 0 && (
                 <div className="jd-flex jd-justify-center">
                   <Button
-                    onClick={() => onAddBlock('end', 'content')}
+                    onClick={() => onAddBlock('end')}
                     variant="outline"
                     size="sm"
                   >
@@ -279,6 +284,7 @@ export const AdvancedTemplateEditor: React.FC<AdvancedTemplateEditorProps> = ({
         content={generatePreviewContent()}
         expanded={previewExpanded}
         onToggle={() => setPreviewExpanded(!previewExpanded)}
+        isHtml
       />
     </div>
   );

--- a/src/components/dialogs/templates/hooks/usePlaceholderEditor.ts
+++ b/src/components/dialogs/templates/hooks/usePlaceholderEditor.ts
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 import { Block, BlockType } from '@/components/templates/blocks/types';
 import { PromptMetadata, DEFAULT_METADATA, ALL_METADATA_TYPES } from '@/components/templates/metadata/types';
 import { getBlockContent, getLocalizedContent } from '../utils/blockUtils';
+import { formatBlockForPrompt, formatMetadataForPrompt } from '../utils/promptUtils';
 
 export function usePlaceholderEditor() {
   const { isOpen, data, dialogProps } = useDialog('placeholderEditor');
@@ -48,14 +49,20 @@ export function usePlaceholderEditor() {
     }
   }, [isOpen, data]);
 
-  const handleAddBlock = (position: 'start' | 'end', blockType: BlockType, existingBlock?: Block) => {
+  const handleAddBlock = (
+    position: 'start' | 'end',
+    blockType?: BlockType | null,
+    existingBlock?: Block
+  ) => {
     const newBlock: Block = existingBlock
       ? { ...existingBlock, isNew: false }
       : {
           id: Date.now() + Math.random(),
-          type: blockType,
+          type: blockType || null,
           content: '',
-          name: `New ${blockType.charAt(0).toUpperCase() + blockType.slice(1)} Block`,
+          name: blockType
+            ? `New ${blockType.charAt(0).toUpperCase() + blockType.slice(1)} Block`
+            : 'New Block',
           description: '',
           isNew: true
         };
@@ -109,11 +116,11 @@ export function usePlaceholderEditor() {
       const parts: string[] = [];
       ALL_METADATA_TYPES.forEach(type => {
         const value = metadata.values?.[type];
-        if (value) parts.push(value);
+        if (value) parts.push(formatMetadataForPrompt(type, value));
       });
       blocks.forEach(block => {
-        const content = getBlockContent(block);
-        if (content) parts.push(content);
+        const formatted = formatBlockForPrompt(block);
+        if (formatted) parts.push(formatted);
       });
       const finalContent = parts.filter(Boolean).join('\n\n');
       if (data && data.onComplete) {

--- a/src/components/dialogs/templates/utils/promptUtils.ts
+++ b/src/components/dialogs/templates/utils/promptUtils.ts
@@ -1,0 +1,65 @@
+import { Block, BlockType } from '@/components/templates/blocks/types';
+import { MetadataType } from '@/components/templates/metadata/types';
+import { getBlockContent } from './blockUtils';
+
+// French prefixes for metadata and blocks
+const PREFIXES: Partial<Record<BlockType | MetadataType, string>> = {
+  role: 'Ton rôle est de',
+  context: 'Le contexte est',
+  goal: "Ton objectif est",
+  audience: "L'audience ciblée est",
+  format: 'Le format attendu est',
+  example: 'Exemple:',
+};
+
+const PRIMARY_METADATA: MetadataType[] = ['role', 'context', 'goal'];
+const SECONDARY_METADATA: MetadataType[] = ['audience', 'format', 'example'];
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function getHighlightClass(type: BlockType | MetadataType | null): string {
+  if (type && PRIMARY_METADATA.includes(type as MetadataType)) {
+    return 'jd-text-purple-600 jd-font-semibold';
+  }
+  if (type && SECONDARY_METADATA.includes(type as MetadataType)) {
+    return 'jd-text-teal-600 jd-font-semibold';
+  }
+  return 'jd-text-orange-600 jd-font-semibold';
+}
+
+export function formatMetadataForPrompt(type: MetadataType, value: string): string {
+  const prefix = PREFIXES[type];
+  const content = value.trim();
+  return prefix ? `${prefix} ${content}` : content;
+}
+
+export function formatMetadataForPreview(type: MetadataType, value: string): string {
+  const prefix = PREFIXES[type];
+  const cls = getHighlightClass(type);
+  const content = escapeHtml(value.trim());
+  if (!prefix) return content;
+  return `<span class="${cls}">${escapeHtml(prefix)}</span> ${content}`;
+}
+
+export function formatBlockForPrompt(block: Block): string {
+  const content = getBlockContent(block).trim();
+  if (!content) return '';
+  const prefix = block.type ? PREFIXES[block.type] : undefined;
+  return prefix ? `${prefix} ${content}` : content;
+}
+
+export function formatBlockForPreview(block: Block): string {
+  const content = escapeHtml(getBlockContent(block).trim());
+  if (!content) return '';
+  const prefix = block.type ? PREFIXES[block.type] : undefined;
+  const cls = getHighlightClass(block.type || 'custom');
+  if (!prefix) return content;
+  return `<span class="${cls}">${escapeHtml(prefix)}</span> ${content}`;
+}

--- a/src/components/templates/blocks/types.ts
+++ b/src/components/templates/blocks/types.ts
@@ -20,7 +20,8 @@ export type BlockType =
 
 export interface Block {
   id: number;
-  type: BlockType;
+  /** Type of the block. When null, the user can choose it in the editor */
+  type: BlockType | null;
   content: string | Record<string, string>;
   name?: string;
   description?: string;


### PR DESCRIPTION
## Summary
- add french prompt prefixes for metadata and blocks
- preview and saved prompt now use these prefixes
- highlight prefixes by category in preview
- allow HTML preview rendering

## Testing
- `npm run type-check`
- `npm run lint` *(fails: many pre-existing lint errors)*