### PR TITLE
Improve placeholder handling in basic editor

### DIFF
--- a/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
@@ -430,6 +430,7 @@ export const CreateTemplateDialog: React.FC = () => {
                 blocks={blocks}
                 onUpdateBlock={handleUpdateBlock}
                 isProcessing={false}
+                mode="create"
               />
             </TabsContent>
 

--- a/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
@@ -108,7 +108,7 @@ export const CustomizeTemplateDialog: React.FC = () => {
             </TabsList>
 
             <TabsContent value="basic" className="jd-flex-1 jd-overflow-hidden">
-              <BasicEditor {...basicProps} />
+              <BasicEditor {...basicProps} mode="customize" />
             </TabsContent>
 
             <TabsContent value="advanced" className="jd-flex-1 jd-overflow-hidden">


### PR DESCRIPTION
## Summary
- update `BasicEditor` to support `create` and `customize` modes
- automatically parse placeholders on edit and maintain focus when editing values
- pass mode prop from dialogs

## Testing
- `pnpm lint` *(fails: Unexpected any rules)*
- `pnpm type-check`