### PR TITLE
Fix template creation editor

### DIFF
--- a/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
@@ -105,7 +105,14 @@ export const CreateTemplateDialog: React.FC = () => {
         setName('');
         setDescription('');
         setContent('');
-        setBlocks([]);
+        setBlocks([
+          {
+            id: Date.now(),
+            type: 'content',
+            content: '',
+            title: { en: 'Template Content' }
+          }
+        ]);
         setMetadata(DEFAULT_METADATA);
         setSelectedFolderId(selectedFolder?.id?.toString() || '');
       }
@@ -127,7 +134,14 @@ export const CreateTemplateDialog: React.FC = () => {
     setDescription('');
     setSelectedFolderId('');
     setContent('');
-    setBlocks([]);
+    setBlocks([
+      {
+        id: Date.now(),
+        type: 'content',
+        content: '',
+        title: { en: 'Template Content' }
+      }
+    ]);
     setMetadata(DEFAULT_METADATA);
     setValidationErrors({});
     setActiveTab('basic');
@@ -429,7 +443,6 @@ export const CreateTemplateDialog: React.FC = () => {
               <BasicEditor
                 blocks={blocks}
                 onUpdateBlock={handleUpdateBlock}
-                isProcessing={false}
                 mode="create"
               />
             </TabsContent>

--- a/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
@@ -58,8 +58,7 @@ export const CustomizeTemplateDialog: React.FC = () => {
 
   const basicProps = {
     blocks,
-    onUpdateBlock: handleUpdateBlock,
-    isProcessing
+    onUpdateBlock: handleUpdateBlock
   };
 
   const advancedProps = {


### PR DESCRIPTION
## Summary
- ensure a default content block exists when creating a new template
- keep placeholders stable in `BasicEditor`
- support editor create/customize modes without losing focus
- adjust customize dialog props for new `BasicEditor`

## Testing
- `npm run type-check`
- `npm run lint` *(fails: 347 problems)*