### PR TITLE
Improve placeholder detection in editor

### DIFF
--- a/src/components/dialogs/prompts/editors/BasicEditor.tsx
+++ b/src/components/dialogs/prompts/editors/BasicEditor.tsx
@@ -242,6 +242,34 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
     }
   };
 
+  const handleEditorInput = () => {
+    if (mode !== 'create' || !editorRef.current) return;
+
+    const htmlContent = editorRef.current.innerHTML;
+    const textContent = htmlContent
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<div\s*\/?>/gi, '')
+      .replace(/<\/div>/gi, '\n')
+      .replace(/<p\s*\/?>/gi, '')
+      .replace(/<\/p>/gi, '\n')
+      .replace(/<\/?span[^>]*>/g, '')
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#039;/g, "'")
+      .replace(/&amp;/g, '&');
+
+    setModifiedContent(textContent);
+
+    const extracted = extractPlaceholders(textContent);
+    setPlaceholders(extracted);
+
+    if (blocks.length > 0) {
+      onUpdateBlock(blocks[0].id, { content: textContent });
+    }
+  };
+
   const escapeRegExp = (string: string) => {
     return string.replace(/[.*+?^${}()|[\]\\]/g, "");
   };
@@ -342,9 +370,10 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
               suppressContentEditableWarning
               onFocus={handleEditorFocus}
               onBlur={handleEditorBlur}
+              onInput={handleEditorInput}
               className={`jd-flex-1 jd-resize-none jd-border jd-rounded-md jd-p-4 jd-focus-visible:jd-outline-none jd-focus-visible:jd-ring-2 jd-focus-visible:jd-ring-primary jd-overflow-auto jd-whitespace-pre-wrap ${
-                isDarkMode 
-                  ? "jd-bg-gray-800 jd-text-gray-100 jd-border-gray-700" 
+                isDarkMode
+                  ? "jd-bg-gray-800 jd-text-gray-100 jd-border-gray-700"
                   : "jd-bg-white jd-text-gray-900 jd-border-gray-200"
               }`}
               onClick={(e) => e.stopPropagation()}

--- a/src/hooks/prompts/actions/useTemplateActions.ts
+++ b/src/hooks/prompts/actions/useTemplateActions.ts
@@ -8,7 +8,7 @@ import { useFolderMutations } from './useFolderMutations';
 import { useQueryClient } from 'react-query';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 import { useDialogManager } from '@/components/dialogs/DialogContext';
-import { insertContentIntoChat, formatContentForInsertion } from '@/utils/templates/insertPrompt';
+import { insertContentIntoChat, formatContentForInsertion, removePlaceholderBrackets } from '@/utils/templates/insertPrompt';
 import { trackEvent, EVENTS, incrementUserProperty } from '@/utils/amplitude';
 
 
@@ -75,8 +75,9 @@ const handleTemplateComplete = useCallback((finalContent: string) => {
     return;
   }
   
+  const cleanContent = removePlaceholderBrackets(finalContent);
   // Format content for insertion - normalizes newlines while preserving paragraph breaks
-  const formattedContent = formatContentForInsertion(finalContent);
+  const formattedContent = formatContentForInsertion(cleanContent);
   
   // Insert the content with a small delay to ensure dialog is fully closed
   setTimeout(() => {

--- a/src/utils/templates/insertPrompt.ts
+++ b/src/utils/templates/insertPrompt.ts
@@ -21,8 +21,13 @@ export function insertContentIntoChat(content: string): boolean {
 
 export function formatContentForInsertion(content: string): string {
   if (!content) return '';
-  
+
   return content
     .replace(/\r\n/g, '\n')  // Convert Windows newlines to Unix newlines
     .replace(/\n{3,}/g, '\n\n');  // Normalize excessive newlines
+}
+
+export function removePlaceholderBrackets(content: string): string {
+  if (!content) return '';
+  return content.replace(/\[(.*?)\]/g, '$1');
 }


### PR DESCRIPTION
## Summary
- detect placeholders during typing in create mode
- strip placeholder brackets before inserting prompts
- utility to remove brackets from placeholders

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`