### PR TITLE
Fix editor direction and dialog scrolling

### DIFF
--- a/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
@@ -439,7 +439,7 @@ export const CreateTemplateDialog: React.FC = () => {
               <TabsTrigger value="advanced">Advanced Editor</TabsTrigger>
             </TabsList>
 
-            <TabsContent value="basic" className="jd-flex-1 jd-overflow-hidden jd-mt-4">
+            <TabsContent value="basic" className="jd-flex-1 jd-overflow-y-auto jd-mt-4">
               <BasicEditor
                 blocks={blocks}
                 onUpdateBlock={handleUpdateBlock}
@@ -447,7 +447,7 @@ export const CreateTemplateDialog: React.FC = () => {
               />
             </TabsContent>
 
-            <TabsContent value="advanced" className="jd-flex-1 jd-overflow-hidden jd-mt-4">
+            <TabsContent value="advanced" className="jd-flex-1 jd-overflow-y-auto jd-mt-4">
               <AdvancedEditor
                 blocks={blocks}
                 metadata={metadata}

--- a/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
@@ -106,11 +106,11 @@ export const CustomizeTemplateDialog: React.FC = () => {
               <TabsTrigger value="advanced">{getMessage('advanced')}</TabsTrigger>
             </TabsList>
 
-            <TabsContent value="basic" className="jd-flex-1 jd-overflow-hidden">
+            <TabsContent value="basic" className="jd-flex-1 jd-overflow-y-auto">
               <BasicEditor {...basicProps} mode="customize" />
             </TabsContent>
 
-            <TabsContent value="advanced" className="jd-flex-1 jd-overflow-hidden">
+            <TabsContent value="advanced" className="jd-flex-1 jd-overflow-y-auto">
               <AdvancedEditor {...advancedProps} />
             </TabsContent>
           </Tabs>

--- a/src/components/dialogs/prompts/editors/BasicEditor.tsx
+++ b/src/components/dialogs/prompts/editors/BasicEditor.tsx
@@ -367,6 +367,7 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
             <div
               ref={editorRef}
               contentEditable
+              dir="ltr"
               suppressContentEditableWarning
               onFocus={handleEditorFocus}
               onBlur={handleEditorBlur}


### PR DESCRIPTION
## Summary
- force LTR text direction for BasicEditor content
- allow overflow scrolling for template dialog tab contents

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run type-check`