### PR TITLE
Enhance block visuals

### DIFF
--- a/src/components/dialogs/prompts/CreateFolderDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateFolderDialog/index.tsx
@@ -3,6 +3,8 @@ import React, { useState, useEffect } from 'react';
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { Plus } from 'lucide-react';
+import { cn } from '@/core/utils/classNames';
 import { useDialog } from '../../DialogContext';
 import { DIALOG_TYPES } from '../../DialogRegistry';
 import { toast } from 'sonner';
@@ -185,10 +187,15 @@ export const CreateFolderDialog: React.FC = () => {
           >
             {getMessage('cancel', undefined, 'Cancel')}
           </Button>
-          <Button 
-            type="submit" 
+          <Button
+            type="submit"
             disabled={isSubmitting || !name.trim()}
             onKeyDown={(e) => e.stopPropagation()}
+            className={cn(
+              'jd-transition-all jd-duration-300',
+              'jd-bg-gradient-to-r jd-from-purple-500 jd-to-blue-500',
+              'hover:jd-from-purple-600 hover:jd-to-blue-600 jd-text-white'
+            )}
           >
             {isSubmitting ? (
               <>
@@ -196,7 +203,10 @@ export const CreateFolderDialog: React.FC = () => {
                 {getMessage('creating', undefined, 'Creating...')}
               </>
             ) : (
-              getMessage('create', undefined, 'Create')
+              <>
+                <Plus className="jd-h-4 jd-w-4 jd-mr-1" />
+                {getMessage('create', undefined, 'Create')}
+              </>
             )}
           </Button>
         </div>

--- a/src/components/prompts/blocks/BlockCard.tsx
+++ b/src/components/prompts/blocks/BlockCard.tsx
@@ -4,20 +4,21 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
-import { Trash2, FileText, MessageSquare, User, Layout, Type, Users, GripVertical } from 'lucide-react';
+import { Trash2, GripVertical } from 'lucide-react';
 import { SaveBlockButton } from '@/components/prompts/blocks/SaveBlockButton';
 import { getCurrentLanguage } from '@/core/utils/i18n';
-import { BLOCK_TYPES, BLOCK_TYPE_LABELS, getLocalizedContent } from './blockUtils';
+import {
+  BLOCK_TYPES,
+  BLOCK_TYPE_LABELS,
+  getLocalizedContent,
+  getBlockTypeIcon,
+  getBlockTypeColors,
+  getBlockIconColors
+} from './blockUtils';
+import { useThemeDetector } from '@/hooks/useThemeDetector';
+import { cn } from '@/core/utils/classNames';
 
 
-const BLOCK_ICONS: Record<BlockType, React.ComponentType<any>> = {
-  content: FileText,
-  context: MessageSquare,
-  role: User,
-  example: Layout,
-  format: Type,
-  audience: Users
-};
 
 
 interface BlockCardProps {
@@ -39,7 +40,10 @@ export const BlockCard: React.FC<BlockCardProps> = ({
   onDragEnd,
   onSave
 }) => {
-  const Icon = block.type ? BLOCK_ICONS[block.type] : FileText;
+  const isDark = useThemeDetector();
+  const Icon = getBlockTypeIcon(block.type || 'content');
+  const cardColors = getBlockTypeColors(block.type || 'content', isDark);
+  const iconBg = getBlockIconColors(block.type || 'content', isDark);
   const content = typeof block.content === 'string' 
     ? block.content 
     : block.content[getCurrentLanguage()] || block.content.en || '';
@@ -57,7 +61,12 @@ export const BlockCard: React.FC<BlockCardProps> = ({
 
   return (
     <Card
-      className="jd-transition-all jd-duration-200 jd-hover:jd-shadow-md jd-group"
+      className={cn(
+        'jd-transition-all jd-duration-300 jd-transform',
+        'hover:jd-shadow-xl hover:jd-scale-[1.02] hover:-jd-translate-y-1',
+        'jd-border-2 jd-backdrop-blur-sm',
+        cardColors
+      )}
       draggable
       onDragStart={() => onDragStart && onDragStart(block.id)}
       onDragOver={(e) => {
@@ -71,7 +80,15 @@ export const BlockCard: React.FC<BlockCardProps> = ({
           <div className="jd-flex jd-items-center jd-gap-3">
             <div className="jd-flex jd-items-center jd-gap-2">
               <GripVertical className="jd-h-4 jd-w-4 jd-text-muted-foreground jd-opacity-50 group-hover:jd-opacity-100 jd-transition-opacity" />
-              <Icon className="jd-h-4 jd-w-4 jd-text-muted-foreground" />
+              <div
+                className={cn(
+                  'jd-p-2 jd-rounded-lg jd-transition-all jd-duration-300',
+                  'group-hover:jd-scale-110 group-hover:jd-rotate-3',
+                  iconBg
+                )}
+              >
+                <Icon className="jd-h-4 jd-w-4" />
+              </div>
             </div>
             <div className="jd-flex jd-items-center jd-gap-2">
               <span className="jd-font-medium jd-text-sm">

--- a/src/components/prompts/blocks/MetadataCard.tsx
+++ b/src/components/prompts/blocks/MetadataCard.tsx
@@ -8,7 +8,11 @@ import { Trash2, ChevronUp, ChevronDown, Plus } from 'lucide-react';
 import { SaveBlockButton } from './SaveBlockButton';
 import { cn } from '@/core/utils/classNames';
 import { getCurrentLanguage } from '@/core/utils/i18n';
-import { getLocalizedContent } from '@/components/prompts/blocks/blockUtils';
+import {
+  getLocalizedContent,
+  getBlockTypeColors,
+  getBlockIconColors
+} from '@/components/prompts/blocks/blockUtils';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
 
 interface MetadataCardProps {
@@ -42,6 +46,8 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
 }) => {
   const config = METADATA_CONFIGS[type];
   const isDarkMode = useThemeDetector();
+  const cardColors = getBlockTypeColors(config.blockType, isDarkMode);
+  const iconColors = getBlockIconColors(config.blockType, isDarkMode);
 
   // Handle card click - only toggle if clicking on the card itself, not on interactive elements
   const handleCardClick = (e: React.MouseEvent) => {
@@ -67,8 +73,10 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
     <Card
       onClick={handleCardClick}
       className={cn(
-        'jd-transition-all jd-duration-200 jd-cursor-pointer hover:jd-shadow-md',
-        isPrimary ? 'jd-border-2 jd-border-primary/20 jd-bg-primary/5' : 'jd-border jd-border-muted jd-bg-muted/20',
+        'jd-transition-all jd-duration-300 jd-cursor-pointer hover:jd-shadow-md',
+        'jd-border-2 jd-backdrop-blur-sm',
+        cardColors,
+        isPrimary && 'jd-border-primary/20',
         expanded &&
           (isDarkMode
             ? 'jd-ring-2 jd-ring-primary/50 jd-shadow-lg jd-bg-gray-800'
@@ -78,7 +86,9 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
       <CardContent className="jd-p-4">
         <div className="jd-flex jd-items-center jd-justify-between jd-mb-2">
           <div className="jd-flex jd-items-center jd-gap-2">
-            <Icon className={cn('jd-h-4 jd-w-4', isPrimary ? 'jd-text-primary' : 'jd-text-muted-foreground')} />
+            <div className={cn('jd-p-1.5 jd-rounded-md', iconColors)}>
+              <Icon className="jd-h-4 jd-w-4" />
+            </div>
             <span className={cn('jd-font-medium', isPrimary ? 'jd-text-primary' : 'jd-text-foreground')}>
               {config.label}
             </span>

--- a/src/components/prompts/blocks/blockUtils.ts
+++ b/src/components/prompts/blocks/blockUtils.ts
@@ -1,142 +1,173 @@
-// src/components/dialogs/templates/editor/utils/blockUtils.ts
-import { BlockType } from '@/types/prompts/blocks';
-import { FileText, MessageSquare, User, Layout, Type, Users } from 'lucide-react';
-import { Block } from '@/types/prompts/blocks';
+// src/components/prompts/blocks/blockUtils.ts
+import React from 'react';
+import {
+  FileText,
+  MessageSquare,
+  Target,
+  Users,
+  Layout,
+  Type,
+  Ban,
+  Palette,
+  User,
+  BrainCog,
+  Sparkles
+} from 'lucide-react';
+import { BlockType, Block } from '@/types/prompts/blocks';
 import { getCurrentLanguage } from '@/core/utils/i18n';
 
-export const BLOCK_TYPES: BlockType[] = ['content', 'context', 'role', 'example', 'format', 'audience'];
+export const BLOCK_TYPES: BlockType[] = [
+  'role',
+  'context',
+  'goal',
+  'content',
+  'custom',
+  'output_format',
+  'example',
+  'constraint',
+  'tone_style',
+  'audience',
+  'thinking_step'
+];
 
 export const BLOCK_TYPE_LABELS: Record<BlockType, string> = {
-  content: 'Content',
-  context: 'Context',
   role: 'Role',
+  context: 'Context',
+  goal: 'Goal',
+  content: 'Content',
+  custom: 'Custom',
+  output_format: 'Output Format',
   example: 'Example',
-  format: 'Format',
-  audience: 'Audience'
+  constraint: 'Constraint',
+  tone_style: 'Tone & Style',
+  audience: 'Audience',
+  thinking_step: 'Thinking Step'
 };
 
 export const BLOCK_TYPE_ICONS: Record<BlockType, React.ComponentType<any>> = {
-  content: FileText,
-  context: MessageSquare,
   role: User,
+  context: MessageSquare,
+  goal: Target,
+  content: FileText,
+  custom: Sparkles,
+  output_format: Type,
   example: Layout,
-  format: Type,
-  audience: Users
+  constraint: Ban,
+  tone_style: Palette,
+  audience: Users,
+  thinking_step: BrainCog
 };
 
 export const BLOCK_TYPE_DESCRIPTIONS: Record<BlockType, string> = {
-  content: 'Main content or instructions for the prompt',
-  context: 'Background information or context setting',
-  role: 'Define the AI\'s role or persona',
-  example: 'Provide examples to guide the AI\'s response',
-  format: 'Specify the desired output format',
-  audience: 'Define the target audience for the response'
+  role: "Define the AI's role",
+  context: 'Provide context information',
+  goal: 'Specify the goal',
+  content: 'Main content for the prompt',
+  custom: 'Custom user content',
+  output_format: 'Desired output format',
+  example: 'Provide an example',
+  constraint: 'Specify constraints',
+  tone_style: 'Define tone and style',
+  audience: 'Describe the target audience',
+  thinking_step: 'Guide the reasoning process'
 };
 
-export const BLOCK_COLORS_LIGHT: Record<BlockType, string> = {
-  content: 'jd-bg-blue-50 jd-border-blue-200 jd-text-blue-900',
-  context: 'jd-bg-green-50 jd-border-green-200 jd-text-green-900',
-  role: 'jd-bg-purple-50 jd-border-purple-200 jd-text-purple-900',
-  example: 'jd-bg-orange-50 jd-border-orange-200 jd-text-orange-900',
-  format: 'jd-bg-pink-50 jd-border-pink-200 jd-text-pink-900',
-  audience: 'jd-bg-teal-50 jd-border-teal-200 jd-text-teal-900'
+// Gradient card colors
+export const BLOCK_CARD_COLORS_LIGHT: Record<BlockType, string> = {
+  role: 'jd-bg-gradient-to-br jd-from-purple-50 jd-to-purple-100 jd-border-purple-200 jd-text-purple-900',
+  context: 'jd-bg-gradient-to-br jd-from-green-50 jd-to-green-100 jd-border-green-200 jd-text-green-900',
+  goal: 'jd-bg-gradient-to-br jd-from-blue-50 jd-to-blue-100 jd-border-blue-200 jd-text-blue-900',
+  content: 'jd-bg-gradient-to-br jd-from-slate-50 jd-to-slate-100 jd-border-slate-200 jd-text-slate-900',
+  custom: 'jd-bg-gradient-to-br jd-from-amber-50 jd-to-amber-100 jd-border-amber-200 jd-text-amber-900',
+  output_format: 'jd-bg-gradient-to-br jd-from-pink-50 jd-to-pink-100 jd-border-pink-200 jd-text-pink-900',
+  example: 'jd-bg-gradient-to-br jd-from-orange-50 jd-to-orange-100 jd-border-orange-200 jd-text-orange-900',
+  constraint: 'jd-bg-gradient-to-br jd-from-red-50 jd-to-red-100 jd-border-red-200 jd-text-red-900',
+  tone_style: 'jd-bg-gradient-to-br jd-from-indigo-50 jd-to-indigo-100 jd-border-indigo-200 jd-text-indigo-900',
+  audience: 'jd-bg-gradient-to-br jd-from-teal-50 jd-to-teal-100 jd-border-teal-200 jd-text-teal-900',
+  thinking_step: 'jd-bg-gradient-to-br jd-from-yellow-50 jd-to-yellow-100 jd-border-yellow-200 jd-text-yellow-900'
 };
 
-export const BLOCK_COLORS_DARK: Record<BlockType, string> = {
-  content: 'jd-bg-blue-900/20 jd-border-blue-800 jd-text-blue-300',
-  context: 'jd-bg-green-900/20 jd-border-green-800 jd-text-green-300',
-  role: 'jd-bg-purple-900/20 jd-border-purple-800 jd-text-purple-300',
-  example: 'jd-bg-orange-900/20 jd-border-orange-800 jd-text-orange-300',
-  format: 'jd-bg-pink-900/20 jd-border-pink-800 jd-text-pink-300',
-  audience: 'jd-bg-teal-900/20 jd-border-teal-800 jd-text-teal-300'
+export const BLOCK_CARD_COLORS_DARK: Record<BlockType, string> = {
+  role: 'jd-bg-gradient-to-br jd-from-purple-800/40 jd-to-purple-900/40 jd-border-purple-700 jd-text-purple-200',
+  context: 'jd-bg-gradient-to-br jd-from-green-800/40 jd-to-green-900/40 jd-border-green-700 jd-text-green-200',
+  goal: 'jd-bg-gradient-to-br jd-from-blue-800/40 jd-to-blue-900/40 jd-border-blue-700 jd-text-blue-200',
+  content: 'jd-bg-gradient-to-br jd-from-slate-700/40 jd-to-slate-800/40 jd-border-slate-600 jd-text-slate-200',
+  custom: 'jd-bg-gradient-to-br jd-from-amber-800/40 jd-to-amber-900/40 jd-border-amber-700 jd-text-amber-200',
+  output_format: 'jd-bg-gradient-to-br jd-from-pink-800/40 jd-to-pink-900/40 jd-border-pink-700 jd-text-pink-200',
+  example: 'jd-bg-gradient-to-br jd-from-orange-800/40 jd-to-orange-900/40 jd-border-orange-700 jd-text-orange-200',
+  constraint: 'jd-bg-gradient-to-br jd-from-red-800/40 jd-to-red-900/40 jd-border-red-700 jd-text-red-200',
+  tone_style: 'jd-bg-gradient-to-br jd-from-indigo-800/40 jd-to-indigo-900/40 jd-border-indigo-700 jd-text-indigo-200',
+  audience: 'jd-bg-gradient-to-br jd-from-teal-800/40 jd-to-teal-900/40 jd-border-teal-700 jd-text-teal-200',
+  thinking_step: 'jd-bg-gradient-to-br jd-from-yellow-800/40 jd-to-yellow-900/40 jd-border-yellow-700 jd-text-yellow-200'
 };
 
-/**
- * Get a user-friendly label for a block type
- */
-export const getBlockTypeLabel = (type: BlockType): string => {
-  return BLOCK_TYPE_LABELS[type] || type;
+// Icon background colors
+export const BLOCK_ICON_COLORS_LIGHT: Record<BlockType, string> = {
+  role: 'jd-bg-purple-100 jd-text-purple-700',
+  context: 'jd-bg-green-100 jd-text-green-700',
+  goal: 'jd-bg-blue-100 jd-text-blue-700',
+  content: 'jd-bg-slate-100 jd-text-slate-700',
+  custom: 'jd-bg-amber-100 jd-text-amber-700',
+  output_format: 'jd-bg-pink-100 jd-text-pink-700',
+  example: 'jd-bg-orange-100 jd-text-orange-700',
+  constraint: 'jd-bg-red-100 jd-text-red-700',
+  tone_style: 'jd-bg-indigo-100 jd-text-indigo-700',
+  audience: 'jd-bg-teal-100 jd-text-teal-700',
+  thinking_step: 'jd-bg-yellow-100 jd-text-yellow-700'
 };
 
-/**
- * Get the icon component for a block type
- */
-export const getBlockTypeIcon = (type: BlockType) => {
-  return BLOCK_TYPE_ICONS[type] || FileText;
+export const BLOCK_ICON_COLORS_DARK: Record<BlockType, string> = {
+  role: 'jd-bg-purple-800 jd-text-purple-300',
+  context: 'jd-bg-green-800 jd-text-green-300',
+  goal: 'jd-bg-blue-800 jd-text-blue-300',
+  content: 'jd-bg-slate-700 jd-text-slate-200',
+  custom: 'jd-bg-amber-800 jd-text-amber-300',
+  output_format: 'jd-bg-pink-800 jd-text-pink-300',
+  example: 'jd-bg-orange-800 jd-text-orange-300',
+  constraint: 'jd-bg-red-800 jd-text-red-300',
+  tone_style: 'jd-bg-indigo-800 jd-text-indigo-300',
+  audience: 'jd-bg-teal-800 jd-text-teal-300',
+  thinking_step: 'jd-bg-yellow-800 jd-text-yellow-300'
 };
 
-/**
- * Get a description for a block type
- */
-export const getBlockTypeDescription = (type: BlockType): string => {
-  return BLOCK_TYPE_DESCRIPTIONS[type] || '';
-};
+export const getBlockTypeLabel = (type: BlockType): string => BLOCK_TYPE_LABELS[type] || type;
+export const getBlockTypeIcon = (type: BlockType) => BLOCK_TYPE_ICONS[type] || FileText;
+export const getBlockTypeDescription = (type: BlockType): string => BLOCK_TYPE_DESCRIPTIONS[type] || '';
+export const getBlockTypeColors = (type: BlockType, dark: boolean): string => (dark ? BLOCK_CARD_COLORS_DARK[type] : BLOCK_CARD_COLORS_LIGHT[type]);
+export const getBlockIconColors = (type: BlockType, dark: boolean): string => (dark ? BLOCK_ICON_COLORS_DARK[type] : BLOCK_ICON_COLORS_LIGHT[type]);
 
-/**
- * Get color classes for a block type
- */
-export const getBlockTypeColors = (type: BlockType, isDarkMode: boolean): string => {
-  const palette = isDarkMode ? BLOCK_COLORS_DARK : BLOCK_COLORS_LIGHT;
-  return palette[type] || palette.content;
-};
-
-
-
-/**
- * Extract string content from a block, handling localized content.
- */
 export const getBlockContent = (block: Block): string => {
-  if (typeof block.content === 'string') {
-    return block.content;
-  }
-
+  if (typeof block.content === 'string') return block.content;
   if (block.content && typeof block.content === 'object') {
     const locale = getCurrentLanguage();
     return block.content[locale] || block.content.en || Object.values(block.content)[0] || '';
   }
-
   return '';
 };
 
-/**
- * Get localized content from a string or object.
- */
 export const getLocalizedContent = (content: any): string => {
-  if (typeof content === 'string') {
-    return content;
-  }
-
+  if (typeof content === 'string') return content;
   if (content && typeof content === 'object') {
     const locale = getCurrentLanguage();
     return content[locale] || content.en || Object.values(content)[0] || '';
   }
-
   return '';
 };
 
-/** Prefixes in French used when building prompts */
 const PROMPT_PREFIXES_FR: Record<BlockType, string> = {
   role: "Ton rôle est d'être ",
   context: 'Contexte : ',
   goal: 'Ton objectif est ',
-  example: 'Exemple : ',
-  format: 'Utilise le format suivant : ',
-  audience: 'Audience cible : ',
   content: '',
-  tone_style: 'Ton et style : ',
+  custom: '',
   output_format: 'Format de sortie : ',
-  output_language: 'Langue de sortie : ',
-  main_context: 'Contexte principal : ',
-  main_goal: 'Objectif principal : ',
-  constraints: 'Contraintes : ',
-  thinking_steps: 'Étapes de réflexion : ',
-  additional_context: 'Contexte supplémentaire : ',
-  custom: ''
+  example: 'Exemple : ',
+  constraint: 'Contrainte : ',
+  tone_style: 'Ton et style : ',
+  audience: 'Audience cible : ',
+  thinking_step: 'Étape de réflexion : '
 };
 
-/**
- * Escape HTML special characters and convert newlines to <br> for safe HTML rendering
- */
 const escapeHtml = (str: string): string =>
   str
     .replace(/&/g, '&amp;')
@@ -146,10 +177,6 @@ const escapeHtml = (str: string): string =>
     .replace(/'/g, '&#039;')
     .replace(/\n/g, '<br>');
 
-/**
- * Build the final text that will be inserted into the prompt for the given block
- * or metadata type.
- */
 export const buildPromptPart = (type: BlockType | null | undefined, content: string): string => {
   if (!type || type === 'custom' || type === 'content') {
     return content;
@@ -158,9 +185,6 @@ export const buildPromptPart = (type: BlockType | null | undefined, content: str
   return prefix ? `${prefix}${content}` : content;
 };
 
-/**
- * Build HTML for preview with highlighted prefix words.
- */
 export const buildPromptPartHtml = (type: BlockType | null | undefined, content: string): string => {
   if (!type || type === 'custom' || type === 'content') {
     return escapeHtml(content);
@@ -171,3 +195,4 @@ export const buildPromptPartHtml = (type: BlockType | null | undefined, content:
   }
   return `<span class="jd-text-primary">${escapeHtml(prefix)}</span>${escapeHtml(content)}`;
 };
+


### PR DESCRIPTION
## Summary
- add gradient palettes and icon colors for block types
- implement new animated block card UI
- theme metadata cards based on block colors
- spruce up Create Folder dialog buttons

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run type-check`