### PR TITLE
Improve BlockCard with block selection and naming

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor.tsx
@@ -60,6 +60,7 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   const [customValues, setCustomValues] = useState<Record<MetadataType, string>>(
     (metadata.values || {}) as Record<MetadataType, string>
   );
+  const [customNames, setCustomNames] = useState<Record<MetadataType, string>>({} as Record<MetadataType, string>);
   const [expandedMetadata, setExpandedMetadata] = useState<MetadataType | null>(null);
   const [previewExpanded, setPreviewExpanded] = useState(false);
   const [activeSecondaryMetadata, setActiveSecondaryMetadata] = useState<Set<MetadataType>>(new Set());
@@ -114,6 +115,10 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
     const newValues = { ...(metadata.values || {}), [type]: value };
     const newMetadata = { ...metadata, [type]: 0, values: newValues };
     onUpdateMetadata(newMetadata);
+  };
+
+  const handleCustomNameChange = (type: MetadataType, value: string) => {
+    setCustomNames(prev => ({ ...prev, [type]: value }));
   };
 
   const getBlockContent = (blockId: number, type: MetadataType): string => {
@@ -294,9 +299,11 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
                   expanded={expandedMetadata === type}
                   selectedId={metadata[type] || 0}
                   customValue={customValues[type] || ''}
+                  customName={customNames[type] || ''}
                   isPrimary
                   onSelect={(v) => handleMetadataChange(type, v)}
                   onCustomChange={(v) => handleCustomChange(type, v)}
+                  onCustomNameChange={(v) => handleCustomNameChange(type, v)}
                   onToggle={() => setExpandedMetadata(expandedMetadata === type ? null : type)}
                   onSaveBlock={handleMetadataBlockSaved}
                 />
@@ -328,8 +335,10 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
                     expanded={expandedMetadata === type}
                     selectedId={metadata[type] || 0}
                     customValue={customValues[type] || ''}
+                    customName={customNames[type] || ''}
                     onSelect={(v) => handleMetadataChange(type, v)}
                     onCustomChange={(v) => handleCustomChange(type, v)}
+                    onCustomNameChange={(v) => handleCustomNameChange(type, v)}
                     onToggle={() => setExpandedMetadata(expandedMetadata === type ? null : type)}
                     onRemove={() => removeSecondaryMetadata(type)}
                     onSaveBlock={handleMetadataBlockSaved}

--- a/src/components/prompts/blocks/BlockCard.tsx
+++ b/src/components/prompts/blocks/BlockCard.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
-import { Block, BlockType } from '@/types/prompts/blocks';
+import React, { useEffect, useState } from 'react';
+import { Block, BlockType, METADATA_BLOCK_TYPES } from '@/types/prompts/blocks';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
 import { Trash2, GripVertical } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import { SaveBlockButton } from '@/components/prompts/blocks/SaveBlockButton';
+import { blocksApi } from '@/services/api/BlocksApi';
 import { getCurrentLanguage } from '@/core/utils/i18n';
 import {
   BLOCK_TYPES,
@@ -44,6 +47,20 @@ export const BlockCard: React.FC<BlockCardProps> = ({
   const Icon = getBlockTypeIcon(block.type || 'content');
   const cardColors = getBlockTypeColors(block.type || 'content', isDark);
   const iconBg = getBlockIconColors(block.type || 'content', isDark);
+  const AVAILABLE_TYPES = BLOCK_TYPES.filter(
+    (t) => !METADATA_BLOCK_TYPES.includes(t)
+  );
+
+  const [availableBlocks, setAvailableBlocks] = useState<Block[]>([]);
+
+  useEffect(() => {
+    const fetchBlocks = async () => {
+      if (!block.type) return;
+      const res = await blocksApi.getBlocksByType(block.type);
+      setAvailableBlocks(res.success ? res.data : []);
+    };
+    fetchBlocks();
+  }, [block.type]);
   const content = typeof block.content === 'string' 
     ? block.content 
     : block.content[getCurrentLanguage()] || block.content.en || '';
@@ -91,9 +108,18 @@ export const BlockCard: React.FC<BlockCardProps> = ({
               </div>
             </div>
             <div className="jd-flex jd-items-center jd-gap-2">
-              <span className="jd-font-medium jd-text-sm">
-                {block.name || 'Block'}
-              </span>
+              {block.isNew ? (
+                <Input
+                  value={block.name || ''}
+                  onChange={(e) => onUpdate(block.id, { name: e.target.value })}
+                  placeholder="Block name"
+                  className="jd-h-7 jd-text-xs jd-w-32"
+                />
+              ) : (
+                <span className="jd-font-medium jd-text-sm">
+                  {block.name || getLocalizedContent(block.title) || 'Block'}
+                </span>
+              )}
               <Select
                 value={block.type || ''}
                 onValueChange={(value) => onUpdate(block.id, { type: value as BlockType })}
@@ -102,7 +128,7 @@ export const BlockCard: React.FC<BlockCardProps> = ({
                   <SelectValue placeholder="Select type" />
                 </SelectTrigger>
                 <SelectContent>
-                  {BLOCK_TYPES.map((t) => (
+                  {AVAILABLE_TYPES.map((t) => (
                     <SelectItem key={t} value={t}>
                       {BLOCK_TYPE_LABELS[t]}
                     </SelectItem>
@@ -111,7 +137,50 @@ export const BlockCard: React.FC<BlockCardProps> = ({
               </Select>
             </div>
           </div>
-          
+
+          {block.type && (
+            <div className="jd-mt-2 jd-w-full">
+              <Select
+                value={block.isNew ? 'custom' : String(block.id)}
+                onValueChange={(value) => {
+                  if (value === 'custom') {
+                    onUpdate(block.id, { isNew: true });
+                  } else {
+                    const existing = availableBlocks.find(b => b.id === Number(value));
+                    if (existing) {
+                      onUpdate(block.id, {
+                        id: existing.id,
+                        type: existing.type,
+                        content: existing.content,
+                        title: existing.title,
+                        description: existing.description,
+                        name: existing.name,
+                        isNew: false
+                      });
+                    }
+                  }
+                }}
+              >
+                <SelectTrigger className="jd-w-full jd-text-xs jd-h-7">
+                  <SelectValue placeholder="Select existing or custom" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="custom">
+                    <div className="jd-flex jd-items-center jd-gap-2">
+                      <Plus className="jd-h-3 jd-w-3" />
+                      Custom Content
+                    </div>
+                  </SelectItem>
+                  {availableBlocks.map(b => (
+                    <SelectItem key={b.id} value={String(b.id)}>
+                      {getLocalizedContent(b.title) || b.name || `Block ${b.id}`}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
 
           <div className="jd-flex jd-items-center jd-gap-1">
 
@@ -146,7 +215,7 @@ export const BlockCard: React.FC<BlockCardProps> = ({
             <SaveBlockButton
               type={block.type}
               content={content}
-              title={getLocalizedContent(block.title)}
+              title={block.name || getLocalizedContent(block.title)}
               description={block.description}
               onSaved={(saved) => onSave && onSave(saved)}
             />

--- a/src/components/prompts/blocks/MetadataCard.tsx
+++ b/src/components/prompts/blocks/MetadataCard.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
 import { Trash2, ChevronUp, ChevronDown, Plus } from 'lucide-react';
 import { SaveBlockButton } from './SaveBlockButton';
 import { cn } from '@/core/utils/classNames';
@@ -22,9 +23,11 @@ interface MetadataCardProps {
   expanded: boolean;
   selectedId: number;
   customValue: string;
+  customName?: string;
   isPrimary?: boolean;
   onSelect: (value: string) => void;
   onCustomChange: (value: string) => void;
+  onCustomNameChange?: (value: string) => void;
   onToggle: () => void;
   onRemove?: () => void;
   onSaveBlock?: (block: Block) => void;
@@ -37,9 +40,11 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
   expanded,
   selectedId,
   customValue,
+  customName,
   isPrimary = false,
   onSelect,
   onCustomChange,
+  onCustomNameChange,
   onToggle,
   onRemove,
   onSaveBlock
@@ -158,6 +163,13 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
 
             {(!selectedId || selectedId === 0) && (
               <>
+                <Input
+                  value={customName || ''}
+                  onChange={(e) => onCustomNameChange && onCustomNameChange(e.target.value)}
+                  placeholder="Block name"
+                  className="jd-h-7 jd-text-xs"
+                  onClick={stopPropagation}
+                />
                 <Textarea
                   value={customValue}
                   onChange={(e) => onCustomChange(e.target.value)}
@@ -170,6 +182,7 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
                   <SaveBlockButton
                     type={config.blockType}
                     content={customValue}
+                    title={customName}
                     onSaved={(b) => onSaveBlock && onSaveBlock(b)}
                     className="jd-h-6 jd-w-6 jd-p-0 jd-text-muted-foreground jd-hover:jd-text-primary"
                   />


### PR DESCRIPTION
## Summary
- tweak BlockCard to filter out metadata types and offer existing block selection
- allow naming a new block and saving with SaveBlockButton
- support custom block naming in MetadataCard
- plumb custom name props through AdvancedEditor

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run type-check`
