### PR TITLE
Show textarea only for custom blocks

### DIFF
--- a/src/components/prompts/blocks/BlockCard.tsx
+++ b/src/components/prompts/blocks/BlockCard.tsx
@@ -132,7 +132,7 @@ export const BlockCard: React.FC<BlockCardProps> = ({
                   ))}
                 </SelectContent>
               </Select>
-              {block.type && blocksForType.length > 0 && (
+              {block.type && (
                 <Select value={selectedExistingId} onValueChange={handleExistingSelect}>
                   <SelectTrigger className="jd-w-40 jd-text-xs jd-h-7">
                     <SelectValue placeholder="Select block" />
@@ -169,18 +169,22 @@ export const BlockCard: React.FC<BlockCardProps> = ({
           </div>
         </div>
 
-        <Textarea
-          value={content}
-          onChange={(e) => handleContentChange(e.target.value)}
-          className="jd-resize-none jd-min-h-[100px] jd-text-sm"
-          placeholder={block.type ? `Enter ${block.type} content...` : 'Enter block content...'}
-        />
-        
-        {content && (
-          <div className="jd-mt-2 jd-text-xs jd-text-muted-foreground jd-flex jd-justify-between">
-            <span>{content.length} characters</span>
-            <span>{content.split('\n').length} lines</span>
-          </div>
+        {block.isNew && (
+          <>
+            <Textarea
+              value={content}
+              onChange={(e) => handleContentChange(e.target.value)}
+              className="jd-resize-none jd-min-h-[100px] jd-text-sm"
+              placeholder={block.type ? `Enter ${block.type} content...` : 'Enter block content...'}
+            />
+
+            {content && (
+              <div className="jd-mt-2 jd-text-xs jd-text-muted-foreground jd-flex jd-justify-between">
+                <span>{content.length} characters</span>
+                <span>{content.split('\n').length} lines</span>
+              </div>
+            )}
+          </>
         )}
 
         {block.isNew && (

--- a/src/components/prompts/blocks/MetadataCard.tsx
+++ b/src/components/prompts/blocks/MetadataCard.tsx
@@ -51,6 +51,9 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
   const cardColors = getBlockTypeColors(config.blockType, isDarkMode);
   const iconColors = getBlockIconColors(config.blockType, isDarkMode);
   const [name, setName] = React.useState('');
+  const [isCustom, setIsCustom] = React.useState(
+    selectedId === 0 && !!customValue
+  );
 
   // Handle card click - only toggle if clicking on the card itself, not on interactive elements
   const handleCardClick = (e: React.MouseEvent) => {
@@ -126,9 +129,12 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
 
         {expanded ? (
           <div className="jd-space-y-3" onClick={stopPropagation}>
-            <Select 
-              value={selectedId ? String(selectedId) : '0'} 
-              onValueChange={onSelect}
+            <Select
+              value={isCustom ? 'custom' : selectedId ? String(selectedId) : '0'}
+              onValueChange={(value) => {
+                setIsCustom(value === 'custom');
+                onSelect(value);
+              }}
             >
               <SelectTrigger className="jd-w-full">
                 <SelectValue placeholder="Select or create custom" />
@@ -159,7 +165,7 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
               </SelectContent>
             </Select>
 
-            {(!selectedId || selectedId === 0) && (
+            {isCustom && (
               <>
                 <Textarea
                   value={customValue}


### PR DESCRIPTION
## Summary
- only show block content input when creating a custom block
- only show metadata textarea when the "Create custom" option is chosen
- show dropdown even if there are no saved blocks for a block type

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*
- `npm run type-check`
