### PR TITLE
Modify BlockCard textarea logic

### DIFF
--- a/src/components/prompts/blocks/BlockCard.tsx
+++ b/src/components/prompts/blocks/BlockCard.tsx
@@ -63,6 +63,7 @@ export const BlockCard: React.FC<BlockCardProps> = ({
     }
   };
 
+  const isContentType = block.type === 'content';
   const blocksForType = block.type ? availableBlocks : [];
   const existing = blocksForType.find(b => b.id === block.id);
 
@@ -139,7 +140,7 @@ export const BlockCard: React.FC<BlockCardProps> = ({
                   ))}
                 </SelectContent>
               </Select>
-              {block.type && blocksForType.length > 0 && (
+              {!isContentType && (
                 <Select value={selectedExistingId} onValueChange={handleExistingSelect}>
                   <SelectTrigger className="jd-w-40 jd-text-xs jd-h-7">
                     <SelectValue placeholder="Select block" />
@@ -176,23 +177,21 @@ export const BlockCard: React.FC<BlockCardProps> = ({
           </div>
         </div>
 
-        {block.isNew && (
-          <>
-            <Textarea
-              value={content}
-              onChange={(e) => handleContentChange(e.target.value)}
-              className="jd-resize-none jd-min-h-[100px] jd-text-sm"
-              placeholder={block.type ? `Enter ${block.type} content...` : 'Enter block content...'}
-            />
+        <>
+          <Textarea
+            value={content}
+            onChange={(e) => handleContentChange(e.target.value)}
+            className="jd-resize-none jd-min-h-[100px] jd-text-sm"
+            placeholder={block.type ? `Enter ${block.type} content...` : 'Enter block content...'}
+          />
 
-            {content && (
-              <div className="jd-mt-2 jd-text-xs jd-text-muted-foreground jd-flex jd-justify-between">
-                <span>{content.length} characters</span>
-                <span>{content.split('\n').length} lines</span>
-              </div>
-            )}
-          </>
-        )}
+          {content && (
+            <div className="jd-mt-2 jd-text-xs jd-text-muted-foreground jd-flex jd-justify-between">
+              <span>{content.length} characters</span>
+              <span>{content.split('\n').length} lines</span>
+            </div>
+          )}
+        </>
 
         {block.isNew && (
           <div className="jd-space-y-2 jd-mt-3">


### PR DESCRIPTION
## Summary
- always show textarea in BlockCard
- disable existing block selection when type is `content`

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run type-check`