### PR TITLE
Improve advanced prompt editor

### DIFF
--- a/src/components/common/AddBlockButton.tsx
+++ b/src/components/common/AddBlockButton.tsx
@@ -1,64 +1,93 @@
 import React from 'react';
-import { Plus, Trash2 } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+  DropdownMenuSeparator,
+  DropdownMenuLabel
 } from '@/components/ui/dropdown-menu';
-import { getMessage } from '@/core/utils/i18n';
+import {
+  BLOCK_TYPES,
+  getBlockTypeIcon,
+  getBlockTypeLabel,
+  getLocalizedContent,
+  isMetadataBlock
+} from '@/components/prompts/blocks/blockUtils';
+import { Block, BlockType } from '@/types/prompts/blocks';
 import { cn } from '@/core/utils/classNames';
-import { Block } from '@/types/prompts/blocks';
-import { getLocalizedContent } from '@/components/prompts/blocks/blockUtils';
 
 interface AddBlockButtonProps {
-  blocks: Block[];
-  onAdd: (block: Block) => void;
-  onRemove?: () => void;
+  availableBlocks: Record<BlockType, Block[]>;
+  onAdd: (type: BlockType, existing?: Block, duplicate?: boolean) => void;
   className?: string;
 }
 
-/**
- * Button used to insert a block into a template.
- */
 export const AddBlockButton: React.FC<AddBlockButtonProps> = ({
-  blocks,
+  availableBlocks,
   onAdd,
-  onRemove,
   className
 }) => {
+  const types = BLOCK_TYPES.filter(t => !isMetadataBlock(t));
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
           type="button"
           className={cn(
-            'jd-bg-background jd-border jd-border-input jd-rounded-full jd-shadow jd-w-6 jd-h-6 jd-flex jd-items-center jd-justify-center jd-text-muted-foreground hover:jd-bg-accent hover:jd-text-accent-foreground',
+            'jd-flex jd-items-center jd-gap-1 jd-text-sm jd-bg-background jd-border jd-border-input jd-rounded-md jd-px-2 jd-py-1 hover:jd-bg-accent hover:jd-text-accent-foreground',
             className
           )}
         >
-          <Plus className="jd-h-4 jd-w-4" />
+          <Plus className="jd-h-4 jd-w-4" /> Add Block
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="center">
-        {blocks.map((block) => (
-          <DropdownMenuItem key={block.id} onSelect={() => onAdd(block)}>
-            {getLocalizedContent(block.title) || 'Block'}
-          </DropdownMenuItem>
-        ))}
-        {onRemove && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onSelect={onRemove}
-              className="jd-text-red-600 jd-flex jd-items-center"
-            >
-              <Trash2 className="jd-h-4 jd-w-4 jd-mr-2" />
-              {getMessage('removeBlock', undefined, 'Remove block')}
-            </DropdownMenuItem>
-          </>
-        )}
+      <DropdownMenuContent className="jd-max-h-80 jd-overflow-y-auto">
+        {types.map(type => {
+          const Icon = getBlockTypeIcon(type);
+          const blocks = availableBlocks[type] || [];
+          return (
+            <DropdownMenuSub key={type}>
+              <DropdownMenuSubTrigger className="jd-flex jd-items-center jd-gap-2">
+                <Icon className="jd-h-4 jd-w-4" />
+                {getBlockTypeLabel(type)}
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="jd-max-h-72 jd-overflow-y-auto">
+                {blocks.length > 0 && (
+                  <>
+                    <DropdownMenuLabel>Use Existing</DropdownMenuLabel>
+                    {blocks.map(b => (
+                      <DropdownMenuItem
+                        key={b.id}
+                        onSelect={() => onAdd(type, b, false)}
+                      >
+                        {getLocalizedContent(b.title) || 'Block'}
+                      </DropdownMenuItem>
+                    ))}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuLabel>New from Existing</DropdownMenuLabel>
+                    {blocks.map(b => (
+                      <DropdownMenuItem
+                        key={`copy-${b.id}`}
+                        onSelect={() => onAdd(type, b, true)}
+                      >
+                        {getLocalizedContent(b.title) || 'Block'}
+                      </DropdownMenuItem>
+                    ))}
+                    <DropdownMenuSeparator />
+                  </>
+                )}
+                <DropdownMenuItem onSelect={() => onAdd(type, undefined, true)}>
+                  New {getBlockTypeLabel(type)}
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          );
+        })}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/dialogs/prompts/editors/AdvancedEditor.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor.tsx
@@ -10,7 +10,9 @@ import { Button } from '@/components/ui/button';
 import { MetadataCard } from '@/components/prompts/blocks/MetadataCard';
 import { BlockCard } from '@/components/prompts/blocks/BlockCard';
 import { PreviewSection } from '@/components/prompts/PreviewSection';
+import { Textarea } from '@/components/ui/textarea';
 import { Plus, FileText, User, MessageSquare, Target, Users, Type, Layout, Sparkles, Wand2, Palette } from 'lucide-react';
+import { AddBlockButton } from '@/components/common/AddBlockButton';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
 import { cn } from '@/core/utils/classNames';
 import { buildPromptPartHtml, BLOCK_TYPES } from '../../../prompts/blocks/blockUtils';
@@ -18,7 +20,12 @@ import { buildPromptPartHtml, BLOCK_TYPES } from '../../../prompts/blocks/blockU
 interface AdvancedEditorProps {
   blocks: Block[];
   metadata?: PromptMetadata;
-  onAddBlock: (position: 'start' | 'end', blockType?: BlockType | null, existingBlock?: Block) => void;
+  onAddBlock: (
+    position: 'start' | 'end',
+    blockType?: BlockType | null,
+    existingBlock?: Block,
+    duplicate?: boolean
+  ) => void;
   onRemoveBlock: (blockId: number) => void;
   onUpdateBlock: (blockId: number, updatedBlock: Partial<Block>) => void;
   onReorderBlocks: (blocks: Block[]) => void;
@@ -260,13 +267,16 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
     );
   }
 
+  const contentBlock = blocks[0];
+  const otherBlocks = blocks.slice(1);
+
   return (
     <div
       className={cn(
         'jd-h-full jd-flex jd-flex-col jd-px-6 jd-relative jd-overflow-hidden',
         // Enhanced gradient background with animated mesh
-        isDarkMode 
-          ? 'jd-bg-gradient-to-br jd-from-gray-900 jd-via-gray-800 jd-to-gray-900' 
+        isDarkMode
+          ? 'jd-bg-gradient-to-br jd-from-gray-900 jd-via-gray-800 jd-to-gray-900'
           : 'jd-bg-gradient-to-br jd-from-slate-50 jd-via-white jd-to-slate-100'
       )}
     >
@@ -379,9 +389,22 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
               Content Blocks
             </h3>
           </div>
-          
+
           <div className="jd-space-y-3 jd-flex-1 jd-overflow-y-auto jd-max-h-[400px] jd-pr-2">
-            {blocks.map((block, index) => (
+
+            {contentBlock && (
+              <div className="jd-space-y-2">
+                <h4 className="jd-text-sm jd-font-medium">Prompt Content</h4>
+                <Textarea
+                  value={typeof contentBlock.content === 'string' ? contentBlock.content : contentBlock.content[getCurrentLanguage()] || contentBlock.content.en || ''}
+                  onChange={e => onUpdateBlock(contentBlock.id, { content: e.target.value })}
+                  className="jd-min-h-[120px] jd-text-sm"
+                  placeholder="Enter main prompt content..."
+                />
+              </div>
+            )}
+
+            {otherBlocks.map((block, index) => (
               <div key={block.id} className="jd-animate-in jd-slide-in-from-bottom-2 jd-duration-300">
                 <BlockCard
                   block={block}
@@ -393,36 +416,23 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
                   onDragEnd={handleDragEnd}
                   onSave={(saved) => handleBlockSaved(block.id, saved)}
                 />
-                {index === blocks.length - 1 && (
-                  <div className="jd-flex jd-justify-center jd-my-3">
-                    <Button
-                      onClick={() => onAddBlock('end')}
-                      variant="outline"
-                      size="sm"
-                      className={cn(
-                        'jd-flex jd-items-center jd-gap-2',
-                        'jd-transition-all jd-duration-300',
-                        'hover:jd-scale-105 hover:jd-shadow-md',
-                        isDarkMode 
-                          ? 'jd-bg-gray-800/50 hover:jd-bg-gray-700/50' 
-                          : 'jd-bg-white/70 hover:jd-bg-white/90'
-                      )}
-                    >
-                      <Plus className="jd-h-4 jd-w-4" />
-                      Add Block
-                    </Button>
-                  </div>
-                )}
               </div>
             ))}
-            
-            {blocks.length === 0 && (
+
+            <div className="jd-flex jd-justify-center jd-my-3">
+              <AddBlockButton
+                availableBlocks={availableBlocksByType}
+                onAdd={(type, existing, duplicate) =>
+                  onAddBlock('end', type, existing, duplicate)
+                }
+              />
+            </div>
+
+            {otherBlocks.length === 0 && (
               <div className={cn(
                 'jd-text-center jd-py-12 jd-rounded-lg jd-border-2 jd-border-dashed',
                 'jd-transition-all jd-duration-300',
-                isDarkMode 
-                  ? 'jd-bg-gray-800/30 jd-border-gray-700' 
-                  : 'jd-bg-white/50 jd-border-gray-300'
+                isDarkMode ? 'jd-bg-gray-800/30 jd-border-gray-700' : 'jd-bg-white/50 jd-border-gray-300'
               )}>
                 <div className={cn(
                   'jd-p-4 jd-rounded-full jd-inline-flex jd-mb-4',
@@ -430,16 +440,7 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
                 )}>
                   <Wand2 className="jd-h-12 jd-w-12 jd-text-muted-foreground" />
                 </div>
-                <p className="jd-text-muted-foreground jd-mb-4">No content blocks yet</p>
-                <Button
-                  onClick={() => onAddBlock('end')}
-                  variant="outline"
-                  size="sm"
-                  className="jd-transition-all jd-duration-300 hover:jd-scale-105"
-                >
-                  <Plus className="jd-h-4 jd-w-4 jd-mr-2" />
-                  Add Your First Block
-                </Button>
+                <p className="jd-text-muted-foreground jd-mb-4">No additional blocks yet</p>
               </div>
             )}
           </div>

--- a/src/components/prompts/blocks/BlockCard.tsx
+++ b/src/components/prompts/blocks/BlockCard.tsx
@@ -66,6 +66,7 @@ export const BlockCard: React.FC<BlockCardProps> = ({
   const isContentType = block.type === 'content';
   const blocksForType = block.type ? availableBlocks : [];
   const existing = blocksForType.find(b => b.id === block.id);
+  const readOnly = !block.isNew;
 
   React.useEffect(() => {
     if (block.type && !existing && !block.isNew) {
@@ -125,39 +126,46 @@ export const BlockCard: React.FC<BlockCardProps> = ({
               <span className="jd-font-medium jd-text-sm">
                 {block.name || 'Block'}
               </span>
-              <Select
-                value={block.type || ''}
-                onValueChange={(value) => onUpdate(block.id, { type: value as BlockType })}
-              >
-                <SelectTrigger className="jd-w-32 jd-text-xs jd-h-7">
-                  <SelectValue placeholder="Select type" />
-                </SelectTrigger>
-                <SelectContent>
-                  {AVAILABLE_BLOCK_TYPES.map((t) => (
-                    <SelectItem key={t} value={t}>
-                      {BLOCK_TYPE_LABELS[t]}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {!isContentType && (
-                <Select value={selectedExistingId} onValueChange={handleExistingSelect}>
-                  <SelectTrigger className="jd-w-40 jd-text-xs jd-h-7">
-                    <SelectValue placeholder="Select block" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {blocksForType.map(b => (
-                      <SelectItem key={b.id} value={String(b.id)}>
-                        {getLocalizedContent(b.title) || 'Block'}
-                      </SelectItem>
-                    ))}
-                    <SelectItem value="custom">
-                      <div className="jd-flex jd-items-center jd-gap-1">
-                        <Plus className="jd-h-3 jd-w-3" /> Create custom
-                      </div>
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
+              {!readOnly && (
+                <>
+                  <Select
+                    value={block.type || ''}
+                    onValueChange={(value) => onUpdate(block.id, { type: value as BlockType })}
+                  >
+                    <SelectTrigger className="jd-w-32 jd-text-xs jd-h-7">
+                      <SelectValue placeholder="Select type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {AVAILABLE_BLOCK_TYPES.map((t) => (
+                        <SelectItem key={t} value={t}>
+                          {BLOCK_TYPE_LABELS[t]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {!isContentType && (
+                    <Select value={selectedExistingId} onValueChange={handleExistingSelect}>
+                      <SelectTrigger className="jd-w-40 jd-text-xs jd-h-7">
+                        <SelectValue placeholder="Select block" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {blocksForType.map(b => (
+                          <SelectItem key={b.id} value={String(b.id)}>
+                            {getLocalizedContent(b.title) || 'Block'}
+                          </SelectItem>
+                        ))}
+                        <SelectItem value="custom">
+                          <div className="jd-flex jd-items-center jd-gap-1">
+                            <Plus className="jd-h-3 jd-w-3" /> Create custom
+                          </div>
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  )}
+                </>
+              )}
+              {readOnly && (
+                <span className="jd-text-xs jd-text-muted-foreground">(Existing)</span>
               )}
             </div>
           </div>
@@ -183,9 +191,10 @@ export const BlockCard: React.FC<BlockCardProps> = ({
             onChange={(e) => handleContentChange(e.target.value)}
             className="jd-resize-none jd-min-h-[100px] jd-text-sm"
             placeholder={block.type ? `Enter ${block.type} content...` : 'Enter block content...'}
+            readOnly={readOnly}
           />
 
-          {content && (
+          {!readOnly && content && (
             <div className="jd-mt-2 jd-text-xs jd-text-muted-foreground jd-flex jd-justify-between">
               <span>{content.length} characters</span>
               <span>{content.split('\n').length} lines</span>

--- a/src/hooks/dialogs/useCreateTemplateDialog.ts
+++ b/src/hooks/dialogs/useCreateTemplateDialog.ts
@@ -232,18 +232,31 @@ export function useCreateTemplateDialog() {
   const handleAddBlock = (
     position: 'start' | 'end',
     blockType?: BlockType | null,
-    existingBlock?: Block
+    existingBlock?: Block,
+    duplicate?: boolean
   ) => {
-    const newBlock: Block = existingBlock
-      ? { ...existingBlock, isNew: false }
-      : {
-          id: Date.now() + Math.random(),
-          type: blockType || null,
-          content: '',
-          name: blockType ? `New ${blockType.charAt(0).toUpperCase() + blockType.slice(1)} Block` : 'New Block',
-          description: '',
-          isNew: true
-        };
+    let newBlock: Block;
+
+    if (existingBlock) {
+      newBlock = duplicate
+        ? {
+            ...existingBlock,
+            id: Date.now() + Math.random(),
+            isNew: true
+          }
+        : { ...existingBlock, isNew: false };
+    } else {
+      newBlock = {
+        id: Date.now() + Math.random(),
+        type: blockType || null,
+        content: '',
+        name: blockType
+          ? `New ${blockType.charAt(0).toUpperCase() + blockType.slice(1)} Block`
+          : 'New Block',
+        description: '',
+        isNew: true
+      };
+    }
 
     setBlocks(prevBlocks => {
       const newBlocks = [...prevBlocks];

--- a/src/hooks/dialogs/useCustomizeTemplateDialog.ts
+++ b/src/hooks/dialogs/useCustomizeTemplateDialog.ts
@@ -53,20 +53,31 @@ export function useCustomizeTemplateDialog() {
   const handleAddBlock = (
     position: 'start' | 'end',
     blockType?: BlockType | null,
-    existingBlock?: Block
+    existingBlock?: Block,
+    duplicate?: boolean
   ) => {
-    const newBlock: Block = existingBlock
-      ? { ...existingBlock, isNew: false }
-      : {
-          id: Date.now() + Math.random(),
-          type: blockType || null,
-          content: '',
-          name: blockType
-            ? `New ${blockType.charAt(0).toUpperCase() + blockType.slice(1)} Block`
-            : 'New Block',
-          description: '',
-          isNew: true
-        };
+    let newBlock: Block;
+
+    if (existingBlock) {
+      newBlock = duplicate
+        ? {
+            ...existingBlock,
+            id: Date.now() + Math.random(),
+            isNew: true
+          }
+        : { ...existingBlock, isNew: false };
+    } else {
+      newBlock = {
+        id: Date.now() + Math.random(),
+        type: blockType || null,
+        content: '',
+        name: blockType
+          ? `New ${blockType.charAt(0).toUpperCase() + blockType.slice(1)} Block`
+          : 'New Block',
+        description: '',
+        isNew: true
+      };
+    }
 
     setBlocks(prevBlocks => {
       const newBlocks = [...prevBlocks];


### PR DESCRIPTION
## Summary
- add new AddBlockButton dropdown for selecting existing blocks or creating copies
- disable editing for existing blocks in BlockCard
- update advanced editor to use single AddBlockButton
- extend add block handlers to support duplicating existing blocks

## Testing
- `pnpm lint` *(fails: 351 problems)*
- `pnpm type-check`
