### PR TITLE
Fix dropdown menu inside shadow DOM

### DIFF
--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -4,6 +4,8 @@ import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"
 
+import { useShadowRoot } from "@/core/utils/componentInjector"
+
 import { cn } from '@/core/utils/classNames';
 
 const DropdownMenu = DropdownMenuPrimitive.Root
@@ -12,7 +14,14 @@ const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
 
 const DropdownMenuGroup = DropdownMenuPrimitive.Group
 
-const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+const DropdownMenuPortal = ({ children, ...props }: DropdownMenuPrimitive.DropdownMenuPortalProps) => {
+  const shadowRoot = useShadowRoot();
+  return (
+    <DropdownMenuPrimitive.Portal {...props} container={shadowRoot || undefined}>
+      {children}
+    </DropdownMenuPrimitive.Portal>
+  );
+}
 
 const DropdownMenuSub = DropdownMenuPrimitive.Sub
 
@@ -60,7 +69,7 @@ const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
+  <DropdownMenuPortal>
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
@@ -70,7 +79,7 @@ const DropdownMenuContent = React.forwardRef<
       )}
       {...props}
     />
-  </DropdownMenuPrimitive.Portal>
+  </DropdownMenuPortal>
 ))
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 


### PR DESCRIPTION
## Summary
- allow dropdown menus to portal into the extension's shadow root

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run type-check`