### PR TITLE
Fix metadata card block selection

### DIFF
--- a/src/components/prompts/blocks/MetadataCard.tsx
+++ b/src/components/prompts/blocks/MetadataCard.tsx
@@ -149,11 +149,13 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
                     onBlockCreated: (b) => {
                       onSaveBlock && onSaveBlock(b);
                       onSelect(String(b.id));
+                      onToggle();
                     }
                   });
                   return;
                 }
                 onSelect(value);
+                onToggle();
               }}
             >
               <SelectTrigger className="jd-w-full">


### PR DESCRIPTION
## Summary
- close metadata card after selecting a block so the UI updates properly

## Testing
- `npm run type-check`
- `npm run lint`
