### PR TITLE
Fix metadata card update when selecting blocks

### DIFF
--- a/src/components/prompts/blocks/MetadataCard.tsx
+++ b/src/components/prompts/blocks/MetadataCard.tsx
@@ -50,7 +50,6 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
   const isDarkMode = useThemeDetector();
   const cardColors = getBlockTypeColors(config.blockType, isDarkMode);
   const iconColors = getBlockIconColors(config.blockType, isDarkMode);
-  const [name, setName] = React.useState('');
   const { openDialog } = useDialogManager();
 
   // Click outside handler to collapse the card
@@ -192,6 +191,8 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
           <div className="jd-text-sm jd-text-muted-foreground jd-mt-2">
             {selectedId && selectedId !== 0
               ? getLocalizedContent(availableBlocks.find((b) => b.id === selectedId)?.title) || `${type} block`
+              : customValue
+              ? customValue.substring(0, 40) + (customValue.length > 40 ? '...' : '')
               : `Click to set ${type}`}
           </div>
         )}

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -15,14 +15,15 @@ export function useClickOutside<T extends HTMLElement = HTMLElement>(
 
       const path = event.composedPath ? event.composedPath() : [];
 
-      // Ignore events originating from Radix Select portals
-      const clickedRadixSelect = path.some(
-        (el) =>
+      // Ignore events originating from Radix UI portals (like Select)
+      const clickedRadixElement = path.some(
+        el =>
           el instanceof HTMLElement &&
-          (el.hasAttribute('data-radix-select-content') ||
-            el.hasAttribute('data-radix-select-trigger'))
+          Array.from(el.attributes).some(attr =>
+            attr.name.startsWith('data-radix')
+          )
       );
-      if (clickedRadixSelect) return;
+      if (clickedRadixElement) return;
 
       const clickedInside = path.some(
         (el) => el instanceof Node && ref.current!.contains(el as Node)


### PR DESCRIPTION
## Summary
- handle Radix portals in `useClickOutside`
- clean up `MetadataCard` and show custom value when collapsed

## Testing
- `pnpm type-check`
