### PR TITLE
Add block context menu

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,8 @@
   "default_locale": "fr",
   "permissions": [
     "storage",
-    "identity"
+    "identity",
+    "contextMenus"
   ],
   "oauth2": {
     "client_id": "32108269805-53if057t0kgq0qlmjqr3st6v124cajam.apps.googleusercontent.com",

--- a/src/components/dialogs/DialogProvider.tsx
+++ b/src/components/dialogs/DialogProvider.tsx
@@ -5,6 +5,7 @@ import { CreateTemplateDialog } from '@/components/dialogs/prompts/CreateTemplat
 import { CreateFolderDialog } from './prompts/CreateFolderDialog';
 import { CustomizeTemplateDialog } from './prompts/CustomizeTemplateDialog';
 import { CreateBlockDialog } from './prompts/CreateBlockDialog';
+import { InsertBlockDialog } from './prompts/InsertBlockDialog';
 import { AuthDialog } from './auth/AuthDialog';
 import { SettingsDialog } from './settings/SettingsDialog';
 import { ConfirmationDialog } from './common/ConfirmationDialog';
@@ -97,6 +98,7 @@ export const DialogProvider: React.FC<{children: React.ReactNode}> = ({ children
       <CreateFolderDialog />
       <CustomizeTemplateDialog />
       <CreateBlockDialog />
+      <InsertBlockDialog />
       <AuthDialog />
       <SettingsDialog />
       <ConfirmationDialog />

--- a/src/components/dialogs/DialogRegistry.ts
+++ b/src/components/dialogs/DialogRegistry.ts
@@ -10,9 +10,10 @@ export const DIALOG_TYPES = {
   AUTH: 'auth',
   CONFIRMATION: 'confirmation',
   ENHANCED_STATS: 'enhancedStats',
-  
+
   // New dialog type for block creation
-  CREATE_BLOCK: 'createBlock'
+  CREATE_BLOCK: 'createBlock',
+  INSERT_BLOCK: 'insertBlock'
 } as const;
 
 // Export the dialog types
@@ -71,4 +72,6 @@ export interface DialogProps {
     initialContent?: string;
     onBlockCreated?: (block: any) => void;
   };
+
+  [DIALOG_TYPES.INSERT_BLOCK]: Record<string, never>;
 }

--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { BaseDialog } from '@/components/dialogs/BaseDialog';
+import { useDialog } from '@/components/dialogs/DialogContext';
+import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
+import { blocksApi } from '@/services/api/BlocksApi';
+import { Block } from '@/types/prompts/blocks';
+import { Button } from '@/components/ui/button';
+import { insertIntoPromptArea } from '@/utils/templates/placeholderUtils';
+
+export const InsertBlockDialog: React.FC = () => {
+  const { isOpen, dialogProps } = useDialog(DIALOG_TYPES.INSERT_BLOCK);
+  const [blocks, setBlocks] = useState<Block[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setLoading(true);
+      blocksApi.getBlocks().then(res => {
+        if (res.success) {
+          setBlocks(res.data);
+        } else {
+          setBlocks([]);
+        }
+        setLoading(false);
+      });
+    }
+  }, [isOpen]);
+
+  const useBlock = (block: Block) => {
+    const content = typeof block.content === 'string'
+      ? block.content
+      : block.content.en || '';
+    insertIntoPromptArea(content);
+    dialogProps.onOpenChange(false);
+  };
+
+  const handleCreate = () => {
+    window.dialogManager?.openDialog(DIALOG_TYPES.CREATE_BLOCK, {
+      onBlockCreated: (b: Block) => useBlock(b)
+    });
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <BaseDialog
+      open={isOpen}
+      onOpenChange={dialogProps.onOpenChange}
+      title="Insert Block"
+      className="jd-max-w-md"
+    >
+      <div className="jd-flex jd-flex-col jd-gap-2 jd-max-h-72 jd-overflow-y-auto">
+        {loading && <div>Loading...</div>}
+        {blocks.map(block => (
+          <Button
+            key={block.id}
+            variant="ghost"
+            className="jd-justify-start jd-whitespace-normal jd-text-left"
+            onClick={() => useBlock(block)}
+          >
+            {(typeof block.title === 'string' ? block.title : block.title?.en) || 'Untitled'}
+          </Button>
+        ))}
+      </div>
+      <div className="jd-flex jd-justify-between jd-pt-4">
+        <Button variant="outline" onClick={() => dialogProps.onOpenChange(false)}>Close</Button>
+        <Button onClick={handleCreate}>Create Block</Button>
+      </div>
+    </BaseDialog>
+  );
+};

--- a/src/extension/background/background.js
+++ b/src/extension/background/background.js
@@ -1,6 +1,44 @@
 // 🔹 Open welcome page when the extension is installed
+function createContextMenus() {
+  const icon = chrome.runtime.getURL('images/letter-logo-dark.png');
+  chrome.contextMenus.removeAll(() => {
+    console.log('Creating Jaydai context menus');
+    chrome.contextMenus.create({
+      id: 'create_block',
+      title: 'Create a Jaydai Block',
+      contexts: ['selection'],
+      icons: { 16: icon }
+    });
+    chrome.contextMenus.create({
+      id: 'insert_block',
+      title: 'Insert a Jaydai Block',
+      contexts: ['editable'],
+      icons: { 16: icon }
+    });
+  });
+}
+
 chrome.runtime.onInstalled.addListener(() => {
-    chrome.tabs.create({ url: 'welcome.html' });
+  chrome.tabs.create({ url: 'welcome.html' });
+  createContextMenus();
+});
+
+// Recreate menus whenever Chrome starts
+chrome.runtime.onStartup.addListener(createContextMenus);
+
+// Also create menus when the service worker loads
+createContextMenus();
+
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (!tab || !tab.id) return;
+  if (info.menuItemId === 'create_block') {
+    chrome.tabs.sendMessage(tab.id, {
+      action: 'openCreateBlockDialog',
+      content: info.selectionText || ''
+    });
+  } else if (info.menuItemId === 'insert_block') {
+    chrome.tabs.sendMessage(tab.id, { action: 'openInsertBlockDialog' });
+  }
 });
 
 // 🔹 Open welcome page only when the extension is newly installed, not on updates

--- a/src/extension/content/content.js
+++ b/src/extension/content/content.js
@@ -90,3 +90,25 @@ if (process.env.NODE_ENV === 'development') {
     }
   });
 }
+
+// Listen for background messages to open dialogs
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === 'openCreateBlockDialog') {
+    const content = message.content || '';
+    if (window.dialogManager?.openDialog) {
+      window.dialogManager.openDialog('createBlock', { initialContent: content });
+      sendResponse({ success: true });
+    } else {
+      sendResponse({ success: false });
+    }
+  }
+  if (message.action === 'openInsertBlockDialog') {
+    if (window.dialogManager?.openDialog) {
+      window.dialogManager.openDialog('insertBlock');
+      sendResponse({ success: true });
+    } else {
+      sendResponse({ success: false });
+    }
+  }
+  return true;
+});


### PR DESCRIPTION
## Summary
- allow background to define context menus for creating/inserting blocks
- open dialogs from context menu via content-script listener
- support InsertBlock dialog component and registry entry
- include dialog in provider
- enable contextMenus permission in manifest
- ensure context menus recreate on Chrome startup

## Testing
- `npm run lint` *(fails: 352 errors)*