### PR TITLE
Improve block insertion dialog

### DIFF
--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -5,12 +5,22 @@ import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
 import { blocksApi } from '@/services/api/BlocksApi';
 import { Block } from '@/types/prompts/blocks';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+import { EmptyMessage } from '@/components/panels/TemplatesPanel/EmptyMessage';
+import {
+  getBlockTypeIcon,
+  getBlockTypeColors,
+  getBlockIconColors
+} from '@/components/prompts/blocks/blockUtils';
+import { useThemeDetector } from '@/hooks/useThemeDetector';
 import { insertIntoPromptArea } from '@/utils/templates/placeholderUtils';
 
 export const InsertBlockDialog: React.FC = () => {
   const { isOpen, dialogProps } = useDialog(DIALOG_TYPES.INSERT_BLOCK);
   const [blocks, setBlocks] = useState<Block[]>([]);
   const [loading, setLoading] = useState(false);
+  const isDark = useThemeDetector();
 
   useEffect(() => {
     if (isOpen) {
@@ -50,17 +60,33 @@ export const InsertBlockDialog: React.FC = () => {
       className="jd-max-w-md"
     >
       <div className="jd-flex jd-flex-col jd-gap-2 jd-max-h-72 jd-overflow-y-auto">
-        {loading && <div>Loading...</div>}
-        {blocks.map(block => (
-          <Button
-            key={block.id}
-            variant="ghost"
-            className="jd-justify-start jd-whitespace-normal jd-text-left"
-            onClick={() => useBlock(block)}
-          >
-            {(typeof block.title === 'string' ? block.title : block.title?.en) || 'Untitled'}
-          </Button>
-        ))}
+        {loading ? (
+          <LoadingSpinner size="sm" message="Loading blocks..." />
+        ) : blocks.length === 0 ? (
+          <EmptyMessage>No blocks available</EmptyMessage>
+        ) : (
+          blocks.map(block => {
+            const Icon = getBlockTypeIcon(block.type);
+            const cardColors = getBlockTypeColors(block.type, isDark);
+            const iconBg = getBlockIconColors(block.type, isDark);
+            const title =
+              typeof block.title === 'string'
+                ? block.title
+                : block.title?.en || 'Untitled';
+            return (
+              <Card
+                key={block.id}
+                className={`jd-cursor-pointer ${cardColors} jd-border hover:jd-shadow-md`}
+                onClick={() => useBlock(block)}
+              >
+                <CardContent className="jd-flex jd-items-center jd-gap-2 jd-p-2">
+                  <span className={`jd-p-1 jd-rounded ${iconBg}`}><Icon className="jd-h-4 jd-w-4" /></span>
+                  <span className="jd-text-sm jd-font-medium jd-truncate">{title}</span>
+                </CardContent>
+              </Card>
+            );
+          })
+        )}
       </div>
       <div className="jd-flex jd-justify-between jd-pt-4">
         <Button variant="outline" onClick={() => dialogProps.onOpenChange(false)}>Close</Button>

--- a/src/utils/templates/placeholderUtils.ts
+++ b/src/utils/templates/placeholderUtils.ts
@@ -1,4 +1,5 @@
 // src/utils/template/placeholderUtils.ts
+import { insertContentIntoChat } from './insertPrompt';
 
 /**
  * Placeholder interface
@@ -100,47 +101,17 @@ export interface Placeholder {
       .trim(); // Remove leading/trailing whitespace
   }
   
+
   /**
-   * Insert content into ChatGPT textarea
+   * Insert content into the current chat platform's prompt area.
+   * Delegates to the platform adapters so it works on ChatGPT, Claude, etc.
    * @param content Content to insert
    * @returns True if successful, false otherwise
    */
   export function insertIntoPromptArea(content: string): boolean {
     try {
-      // Find the textarea
-      const textarea = document.querySelector('#prompt-textarea');
-      if (!textarea) {
-        console.error('Could not find the prompt textarea');
-        return false;
-      }
-      
-      // Format content
       const formattedContent = formatForInsertion(content);
-      
-      // Insert content based on element type
-      if (textarea instanceof HTMLTextAreaElement) {
-        textarea.value = formattedContent;
-      } else if (textarea.isContentEditable) {
-        textarea.innerHTML = formattedContent;
-      } else {
-        textarea.textContent = formattedContent;
-      }
-      
-      // Trigger input event to notify any listeners
-      textarea.dispatchEvent(new Event('input', { bubbles: true }));
-      
-      // Focus the textarea
-      textarea.focus();
-      
-      // If the textarea supports setting cursor position, place cursor at end
-      if ('setSelectionRange' in textarea) {
-        (textarea as HTMLTextAreaElement).setSelectionRange(
-          formattedContent.length,
-          formattedContent.length
-        );
-      }
-      
-      return true;
+      return insertContentIntoChat(formattedContent);
     } catch (error) {
       console.error('Error inserting content:', error);
       return false;


### PR DESCRIPTION
## Summary
- style InsertBlockDialog with cards and icons
- support Claude by delegating insertion logic to platform adapters

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run type-check`