### PR TITLE
Add block management to InsertBlockDialog

### DIFF
--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -10,7 +10,11 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { EmptyMessage } from '@/components/panels/TemplatesPanel/EmptyMessage';
-import { buildPromptPart, BLOCK_TYPE_LABELS } from '@/components/prompts/blocks/blockUtils';
+import {
+  buildPromptPart,
+  buildPromptPartHtml,
+  BLOCK_TYPE_LABELS,
+} from '@/components/prompts/blocks/blockUtils';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
 import { insertIntoPromptArea } from '@/utils/templates/placeholderUtils';
 import { 
@@ -231,7 +235,7 @@ export const InsertBlockDialog: React.FC = () => {
           </div>
 
           {/* Available Blocks */}
-          <ScrollArea className="jd-flex-1">
+          <ScrollArea className="jd-h-[65vh]">
             <div className="jd-space-y-3 jd-pr-4">
               {loading ? (
                 <LoadingSpinner size="sm" message="Loading blocks..." />
@@ -257,8 +261,8 @@ export const InsertBlockDialog: React.FC = () => {
         <div className="jd-w-1/2 jd-flex jd-flex-col">
 
     <div className="jd-flex jd-items-center jd-justify-start jd-mb-4">
-      <h3 className="jd-text-sm jd-font-medium">Prompt Preview</h3>
-      <div className="jd-flex jd-items-center jd-gap-2">
+      <h3 className="jd-text-sm jd-font-medium">Selected Blocks</h3>
+      <div className="jd-flex jd-items-center jd-gap-2 jd-ml-auto">
         <Button
           variant="outline"
           size="sm"
@@ -272,8 +276,8 @@ export const InsertBlockDialog: React.FC = () => {
           <button
             onClick={() => setPreviewMode('text')}
             className={cn(
-              "jd-px-2 jd-py-1 jd-text-xs jd-rounded jd-transition-colors",
-              previewMode === 'text' ? "jd-bg-background jd-shadow-sm" : "jd-hover:bg-background/50"
+              'jd-px-2 jd-py-1 jd-text-xs jd-rounded jd-transition-colors',
+              previewMode === 'text' ? 'jd-bg-background jd-shadow-sm' : 'jd-hover:bg-background/50'
             )}
           >
             <Code className="jd-h-3 jd-w-3" />
@@ -281,8 +285,8 @@ export const InsertBlockDialog: React.FC = () => {
           <button
             onClick={() => setPreviewMode('visual')}
             className={cn(
-              "jd-px-2 jd-py-1 jd-text-xs jd-rounded jd-transition-colors",
-              previewMode === 'visual' ? "jd-bg-background jd-shadow-sm" : "jd-hover:bg-background/50"
+              'jd-px-2 jd-py-1 jd-text-xs jd-rounded jd-transition-colors',
+              previewMode === 'visual' ? 'jd-bg-background jd-shadow-sm' : 'jd-hover:bg-background/50'
             )}
           >
             <Eye className="jd-h-3 jd-w-3" />
@@ -293,36 +297,69 @@ export const InsertBlockDialog: React.FC = () => {
 
     {selectedBlocks.length === 0 ? (
       // Use fixed height instead of jd-flex-1 for empty state
-      <div className="jd-flex jd-items-center jd-justify-center jd-border-2 jd-border-dashed jd-border-muted jd-rounded-lg jd-py-16">
+      <div className="jd-flex jd-items-center jd-justify-center jd-border-2 jd-border-dashed jd-border-muted jd-rounded-lg jd-py-16 jd-flex-1">
         <div className="jd-text-center jd-text-muted-foreground">
           <Eye className="jd-h-8 jd-w-8 jd-mx-auto jd-mb-2 jd-opacity-50" />
           <p className="jd-text-sm">Preview will appear here</p>
         </div>
       </div>
     ) : (
-      // Use proper scrollable container
-      <div className="jd-flex-1 jd-overflow-hidden">
-        <ScrollArea className="jd-h-full">
-          <div className="jd-space-y-4 jd-pr-4">
-            {previewMode === 'visual' ? (
-              selectedBlocks.map((block, index) => (
-                <PreviewBlock 
-                  key={block.id} 
-                  block={block} 
-                  isDark={isDark} 
-                  index={index}
-                />
-              ))
-            ) : (
-              <div className="jd-bg-muted/30 jd-rounded-lg jd-p-4">
-                <div
-                  className="jd-text-sm jd-break-words"
-                  dangerouslySetInnerHTML={{ __html: generateFullPromptHtml() }}
-                />
-              </div>
-            )}
-          </div>
-        </ScrollArea>
+      <div className="jd-flex-1 jd-flex jd-flex-col jd-overflow-hidden jd-space-y-4">
+        <div className="jd-overflow-hidden jd-max-h-[40vh]">
+          <ScrollArea className="jd-h-full">
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext items={selectedBlocks.map(b => b.id)} strategy={verticalListSortingStrategy}>
+                <div className="jd-space-y-2 jd-pr-2">
+                  {selectedBlocks.map(block => (
+                    <SortableSelectedBlock
+                      key={block.id}
+                      block={block}
+                      isDark={isDark}
+                      onRemove={removeBlock}
+                      isExpanded={expandedBlocks.has(block.id)}
+                      onToggleExpand={toggleExpanded}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+              <DragOverlay>
+                {activeBlockId !== null && (
+                  <SortableSelectedBlock
+                    block={selectedBlocks.find(b => b.id === activeBlockId)!}
+                    isDark={isDark}
+                    onRemove={() => {}}
+                    isExpanded={false}
+                    onToggleExpand={() => {}}
+                  />
+                )}
+              </DragOverlay>
+            </DndContext>
+          </ScrollArea>
+        </div>
+
+        <div className="jd-flex-1 jd-overflow-hidden jd-border-t jd-pt-4">
+          <ScrollArea className="jd-h-full">
+            <div className="jd-space-y-4 jd-pr-4">
+              {previewMode === 'visual' ? (
+                selectedBlocks.map((block, index) => (
+                  <PreviewBlock key={block.id} block={block} isDark={isDark} index={index} />
+                ))
+              ) : (
+                <div className="jd-bg-muted/30 jd-rounded-lg jd-p-4">
+                  <div
+                    className="jd-text-sm jd-break-words"
+                    dangerouslySetInnerHTML={{ __html: generateFullPromptHtml() }}
+                  />
+                </div>
+              )}
+            </div>
+          </ScrollArea>
+        </div>
       </div>
     )}
 


### PR DESCRIPTION
## Summary
- enable drag & drop with deletion of blocks in `InsertBlockDialog`
- keep a preview below the reorder list
- limit library area height so block list scrolls
- fix missing `buildPromptPartHtml` import

## Testing
- `pnpm lint` *(fails: Unexpected any)*
- `pnpm type-check`
