### PR TITLE
Add support for Mistral platform

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -19,7 +19,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://chatgpt.com/*", "https://claude.ai/*"],
+      "matches": ["https://chatgpt.com/*", "https://claude.ai/*", "https://chat.mistral.ai/*"],
     "js": ["content.js"],
       "run_at": "document_start",
       "type": "module"

--- a/src/extension/content/applicationInitializer.ts
+++ b/src/extension/content/applicationInitializer.ts
@@ -37,8 +37,8 @@ export class AppInitializer {
       return true;
     }
     
-    // Skip if we're not on ChatGPT
-    if (!this.isChatGPTSite() && !this.isClaudeSite()) {
+    // Skip if we're not on a supported site
+    if (!this.isChatGPTSite() && !this.isClaudeSite() && !this.isMistralSite()) {
       return false;
     }
     
@@ -84,6 +84,10 @@ export class AppInitializer {
 
   private isClaudeSite(): boolean {
     return window.location.hostname.includes('claude.ai');
+  }
+
+  private isMistralSite(): boolean {
+    return window.location.hostname.includes('mistral.ai');
   }
 
   

--- a/src/extension/content/content.js
+++ b/src/extension/content/content.js
@@ -2,7 +2,9 @@
 // Immediate self-executing function to inject as early as possible
 (function() {
 
-  if (!window.location.hostname.includes('chatgpt.com') && !window.location.hostname.includes('claude.ai')) {
+  if (!window.location.hostname.includes('chatgpt.com') &&
+      !window.location.hostname.includes('claude.ai') &&
+      !window.location.hostname.includes('mistral.ai')) {
     return;
   }
 

--- a/src/extension/content/networkInterceptor/constants.js
+++ b/src/extension/content/networkInterceptor/constants.js
@@ -17,6 +17,12 @@ export const ENDPOINTS = {
     CONVERSATIONS_LIST: /\/api\/organizations\/[a-f0-9-]+\/chat_conversations/,
     CHAT_COMPLETION: /\/api\/organizations\/[a-f0-9-]+\/chat_conversations\/[a-f0-9-]+\/completion/,
     SPECIFIC_CONVERSATION: /\/api\/organizations\/[a-f0-9-]+\/chat_conversations\/([a-f0-9-]+)/
+  },
+  'mistral': {
+    USER_INFO: '/api/trpc/user.session',
+    CONVERSATIONS_LIST: '/api/trpc/chat.list',
+    CHAT_COMPLETION: '/api/chat',
+    SPECIFIC_CONVERSATION: /\/api\/chat/
   }
 };
   

--- a/src/extension/content/networkInterceptor/detectPlatform.js
+++ b/src/extension/content/networkInterceptor/detectPlatform.js
@@ -6,5 +6,8 @@ export function detectPlatform() {
   if (hostname.includes('claude.ai')) {
     return 'claude';
   }
+  if (hostname.includes('mistral.ai')) {
+    return 'mistral';
+  }
   return 'unknown';
 }

--- a/src/platforms/adapters/index.ts
+++ b/src/platforms/adapters/index.ts
@@ -2,13 +2,15 @@
 import { PlatformAdapter } from './base.adapter';
 import { chatGptAdapter } from './chatgpt.adapter';
 import { claudeAdapter } from './claude.adapter';
+import { mistralAdapter } from './mistral.adapter';
 
 const adapters: PlatformAdapter[] = [
   chatGptAdapter,
-  claudeAdapter
+  claudeAdapter,
+  mistralAdapter,
 ];
 
-export { chatGptAdapter, claudeAdapter };
+export { chatGptAdapter, claudeAdapter, mistralAdapter };
 export * from './base.adapter';
 
 export function getAdapterByName(name: string): PlatformAdapter | null {

--- a/src/platforms/adapters/mistral.adapter.ts
+++ b/src/platforms/adapters/mistral.adapter.ts
@@ -1,0 +1,207 @@
+import { BasePlatformAdapter } from './base.adapter';
+import { mistralConfig } from '../config/mistral.config';
+import { Message, Conversation } from '@/types';
+import { messageApi } from '@/services/api/MessageApi';
+import { errorReporter } from '@/core/errors/ErrorReporter';
+import { AppError, ErrorCode } from '@/core/errors/AppError';
+import { chatService } from '@/services/network/ChatService';
+
+export class MistralAdapter extends BasePlatformAdapter {
+  constructor() {
+    super(mistralConfig);
+  }
+
+  extractUserMessage(requestBody: any): Message | null {
+    try {
+      const content = requestBody.messageInput || '';
+      return {
+        messageId: requestBody.messageId || `user-${Date.now()}`,
+        conversationId: requestBody.chatId || '',
+        content,
+        role: 'user',
+        model: requestBody.model || 'mistral',
+        timestamp: Date.now(),
+        parent_message_provider_id: requestBody.parentMessageId,
+      };
+    } catch (error) {
+      errorReporter.captureError(
+        new AppError('Error extracting user message from Mistral', ErrorCode.PARSING_ERROR, error),
+      );
+      return null;
+    }
+  }
+
+  extractAssistantMessage(data: any): Message | null {
+    try {
+      return {
+        messageId: data.messageId || `mistral-${Date.now()}`,
+        conversationId: data.chatId || '',
+        content: data.content || '',
+        role: 'assistant',
+        model: data.model || 'mistral',
+        timestamp: Date.now(),
+        thinkingTime: data.thinkingTime,
+        parent_message_provider_id: data.parentMessageId,
+      };
+    } catch (error) {
+      errorReporter.captureError(
+        new AppError('Error extracting assistant message from Mistral', ErrorCode.PARSING_ERROR, error),
+      );
+      return null;
+    }
+  }
+
+  extractConversation(data: any): Conversation | null {
+    try {
+      if (!data?.chatId) return null;
+      return {
+        chat_provider_id: data.chatId,
+        title: data.title || 'Conversation',
+        provider_name: 'Mistral',
+      } as any;
+    } catch (error) {
+      errorReporter.captureError(
+        new AppError('Error extracting conversation from Mistral', ErrorCode.PARSING_ERROR, error),
+      );
+      return null;
+    }
+  }
+
+  extractMessagesFromConversation(_data: any): Message[] {
+    return [];
+  }
+
+  async handleConversationList(_data: any): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async handleSpecificConversation(_data: any): Promise<void> {
+    return Promise.resolve();
+  }
+
+  handleChatCompletion(event: CustomEvent): void {
+    try {
+      const { requestBody } = event.detail;
+      const message = this.extractUserMessage(requestBody);
+      if (message) {
+        document.dispatchEvent(
+          new CustomEvent('jaydai:message-extracted', { detail: { message, platform: this.name } }),
+        );
+      }
+    } catch (error) {
+      errorReporter.captureError(
+        new AppError('Error handling chat completion', ErrorCode.PARSING_ERROR, error),
+      );
+    }
+  }
+
+  handleAssistantResponse(event: CustomEvent): void {
+    try {
+      const data = event.detail;
+      if (!data) return;
+      if (data.isComplete) {
+        const message = this.extractAssistantMessage(data);
+        if (message) {
+          document.dispatchEvent(
+            new CustomEvent('jaydai:message-extracted', { detail: { message, platform: this.name } }),
+          );
+        }
+      }
+    } catch (error) {
+      errorReporter.captureError(
+        new AppError('Error handling assistant response', ErrorCode.PARSING_ERROR, error),
+      );
+    }
+  }
+
+  insertPrompt(content: string): boolean {
+    if (!content) return false;
+    try {
+      const textarea = document.querySelector(this.config.domSelectors.PROMPT_TEXTAREA) as HTMLTextAreaElement | null;
+      if (!textarea) return false;
+      textarea.value = content;
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      textarea.focus();
+      textarea.selectionStart = textarea.selectionEnd = content.length;
+      return true;
+    } catch (error) {
+      console.error('Error inserting prompt in Mistral:', error);
+      return false;
+    }
+  }
+
+  supportsStreaming(): boolean {
+    return true;
+  }
+
+  async processStreamingResponse(response: Response, requestBody: any): Promise<void> {
+    if (!response.body) return;
+    const reader = response.clone().body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let messageId = '';
+    let content = '';
+    const conversationId = requestBody.chatId || '';
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let index;
+        while ((index = buffer.indexOf('\n')) !== -1) {
+          const line = buffer.slice(0, index).trim();
+          buffer = buffer.slice(index + 1);
+          if (!line) continue;
+          if (line.startsWith('data:')) {
+            const dataStr = line.slice(5).trim();
+            if (dataStr === '[DONE]') {
+              if (messageId && content) {
+                document.dispatchEvent(
+                  new CustomEvent('jaydai:assistant-response', {
+                    detail: {
+                      messageId,
+                      conversationId,
+                      content,
+                      role: 'assistant',
+                      model: 'mistral',
+                      isComplete: true,
+                      platform: this.name,
+                    },
+                  }),
+                );
+              }
+              continue;
+            }
+            try {
+              const data = JSON.parse(dataStr);
+              if (data.messageId) messageId = data.messageId;
+              if (data.token) content += data.token;
+              if (data.content) content += data.content;
+            } catch (_) {
+              content += dataStr;
+            }
+          }
+        }
+      }
+      if (messageId && content) {
+        document.dispatchEvent(
+          new CustomEvent('jaydai:assistant-response', {
+            detail: {
+              messageId,
+              conversationId,
+              content,
+              role: 'assistant',
+              model: 'mistral',
+              isComplete: true,
+              platform: this.name,
+            },
+          }),
+        );
+      }
+    } catch (error) {
+      console.error('Error processing Mistral stream:', error);
+    }
+  }
+}
+
+export const mistralAdapter = new MistralAdapter();

--- a/src/platforms/config/index.ts
+++ b/src/platforms/config/index.ts
@@ -2,13 +2,15 @@
 import { PlatformConfig } from './base';
 import { chatGptConfig } from './chatgpt.config';
 import { claudeConfig } from './claude.config';
+import { mistralConfig } from './mistral.config';
 
 export const platformConfigs: PlatformConfig[] = [
   chatGptConfig,
-  claudeConfig
+  claudeConfig,
+  mistralConfig
 ];
 
-export { chatGptConfig, claudeConfig };
+export { chatGptConfig, claudeConfig, mistralConfig };
 export * from './base';
 
 export function getConfigByHostname(hostname: string): PlatformConfig | null {

--- a/src/platforms/config/mistral.config.ts
+++ b/src/platforms/config/mistral.config.ts
@@ -1,0 +1,19 @@
+import { PlatformConfig } from './base';
+
+export const mistralConfig: PlatformConfig = {
+  name: 'mistral',
+  hostnames: ['chat.mistral.ai'],
+  endpoints: {
+    USER_INFO: '/api/trpc/user.session',
+    CONVERSATIONS_LIST: '/api/trpc/chat.list',
+    CHAT_COMPLETION: '/api/chat',
+    SPECIFIC_CONVERSATION: /\/api\/chat/,
+  },
+  domSelectors: {
+    PROMPT_TEXTAREA: 'textarea[name="message.text"]',
+    SUBMIT_BUTTON: 'form button[type="submit"]'
+  },
+  conversationIdPatterns: [
+    { urlPath: /\/chat\/([a-f0-9-]+)/ }
+  ]
+};


### PR DESCRIPTION
## Summary
- enable extension on chat.mistral.ai
- add Mistral platform configuration and adapter
- update platform detection and constants
- allow content scripts and initializer to load on Mistral
- include Mistral in extension manifest

## Testing
- `npm run lint` *(fails: 394 problems)*
- `npm run type-check`
- `npm run build`