### PR TITLE
Fix event handling in BaseDialog

### DIFF
--- a/src/components/dialogs/BaseDialog.tsx
+++ b/src/components/dialogs/BaseDialog.tsx
@@ -78,14 +78,19 @@ export const BaseDialog: React.FC<BaseDialogProps> = ({
     
     events.forEach(eventName => {
       dialogElement.addEventListener(eventName, stopEventPropagation, {
-        capture: true,
+        // Use bubbling phase so events reach their targets before being stopped
+        capture: false,
         passive: false
       });
     });
     
     return () => {
       events.forEach(eventName => {
-        dialogElement.removeEventListener(eventName, stopEventPropagation, true);
+        dialogElement.removeEventListener(
+          eventName,
+          stopEventPropagation,
+          false
+        );
       });
     };
   }, [open]);

--- a/src/core/utils/componentInjector.tsx
+++ b/src/core/utils/componentInjector.tsx
@@ -75,7 +75,7 @@ class ComponentInjector {
     
     // Create shadow root if it doesn't exist
     if (!shadowRoot) {
-      shadowRoot = container.attachShadow({ mode: 'open' });
+      shadowRoot = container.attachShadow({ mode: 'open', delegatesFocus: true });
       this.shadowContainers.set(containerId, shadowRoot);
       
       // Create initial style element


### PR DESCRIPTION
## Summary
- prevent BaseDialog from stopping events before inputs or buttons
- delegate focus into shadow DOM for proper input handling

## Testing
- `npm run lint` *(fails: 396 errors)*


------
https://chatgpt.com/codex/tasks/task_b_683d8d607cb48325a09c713853cb8e3c