### PR TITLE
Improve dialog event handling

### DIFF
--- a/src/components/dialogs/BaseDialog.tsx
+++ b/src/components/dialogs/BaseDialog.tsx
@@ -1,5 +1,6 @@
 // src/components/dialogs/BaseDialog.tsx
 import React, { useRef, useEffect, useState } from 'react';
+import { useDialogFocusGuard } from '@/core/utils/shadowDomFocusManager';
 import { getMessage } from '@/core/utils/i18n';
 import { cn } from "@/core/utils/classNames";
 import { X } from "lucide-react";
@@ -30,6 +31,8 @@ export const BaseDialog: React.FC<BaseDialogProps> = ({
   // All hooks must be called unconditionally at the top
   const dialogRef = useRef<HTMLDivElement>(null);
   const [mounted, setMounted] = useState(false);
+  // Keep focus trapped inside the dialog when open
+  useDialogFocusGuard(dialogRef.current, open);
   
   // Setup effect for mounting state
   useEffect(() => {
@@ -86,7 +89,8 @@ export const BaseDialog: React.FC<BaseDialogProps> = ({
     const eventsToCapture = [
       'mousedown', 'mouseup', 'click', // Mouse events from outside
       'scroll', 'wheel', // Scrolling events
-      'focus', 'blur' // Focus events from outside
+      'focus', 'blur', // Focus events from outside
+      'keydown', 'keypress', 'keyup' // Keyboard events that could leak to page
     ];
     
     eventsToCapture.forEach(eventName => {

--- a/src/components/dialogs/prompts/CreateFolderDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateFolderDialog/index.tsx
@@ -127,15 +127,15 @@ export const CreateFolderDialog: React.FC = () => {
               placeholder={getMessage('enterFolderName', undefined, 'Enter folder name')}
               className="jd-mt-1"
               autoFocus
-              // Minimal event handling - just prevent escape key from closing dialog
               onKeyDown={(e) => {
+                e.stopPropagation();
                 if (e.key === 'Escape') {
-                  e.stopPropagation();
                   e.preventDefault();
                   return;
                 }
-                // Let all other keys work normally
               }}
+              onKeyPress={(e) => e.stopPropagation()}
+              onKeyUp={(e) => e.stopPropagation()}
             />
           </div>
           
@@ -149,15 +149,16 @@ export const CreateFolderDialog: React.FC = () => {
               placeholder={getMessage('enterFolderDescription', undefined, 'Enter folder description (optional)')}
               className="jd-mt-1"
               rows={3}
-              // Minimal event handling
               onKeyDown={(e) => {
+                e.stopPropagation();
                 if (e.key === 'Escape') {
-                  e.stopPropagation();
                   e.preventDefault();
                   return;
                 }
                 // Let Enter work for new lines in textarea
               }}
+              onKeyPress={(e) => e.stopPropagation()}
+              onKeyUp={(e) => e.stopPropagation()}
             />
           </div>
           

--- a/src/components/dialogs/prompts/CreateTemplateDialog/BasicInfoForm.tsx
+++ b/src/components/dialogs/prompts/CreateTemplateDialog/BasicInfoForm.tsx
@@ -36,6 +36,9 @@ export const BasicInfoForm: React.FC<Props> = ({
           onChange={e => setName(e.target.value)}
           placeholder={getMessage('enterTemplateName')}
           className={`jd-mt-1 ${validationErrors.name ? 'jd-border-red-500' : ''}`}
+          onKeyDown={e => e.stopPropagation()}
+          onKeyPress={e => e.stopPropagation()}
+          onKeyUp={e => e.stopPropagation()}
         />
         {validationErrors.name && (
           <p className="jd-text-xs jd-text-red-500 jd-mt-1">{validationErrors.name}</p>
@@ -48,6 +51,9 @@ export const BasicInfoForm: React.FC<Props> = ({
           onChange={e => setDescription(e.target.value)}
           placeholder={getMessage('templateDescriptionPlaceholder')}
           className="jd-mt-1"
+          onKeyDown={e => e.stopPropagation()}
+          onKeyPress={e => e.stopPropagation()}
+          onKeyUp={e => e.stopPropagation()}
         />
       </div>
       <div>

--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -155,6 +155,9 @@ const InlineBlockCreator: React.FC<{
             onChange={(e) => setTitle(e.target.value)}
             placeholder={`${BLOCK_TYPE_LABELS[type]} Block`}
             className="jd-h-8 jd-text-xs"
+            onKeyDown={(e) => e.stopPropagation()}
+            onKeyPress={(e) => e.stopPropagation()}
+            onKeyUp={(e) => e.stopPropagation()}
           />
         </div>
 
@@ -166,6 +169,9 @@ const InlineBlockCreator: React.FC<{
             placeholder={`Enter ${type} content...`}
             className="jd-min-h-[80px] jd-text-xs jd-resize-none"
             rows={4}
+            onKeyDown={(e) => e.stopPropagation()}
+            onKeyPress={(e) => e.stopPropagation()}
+            onKeyUp={(e) => e.stopPropagation()}
           />
         </div>
 
@@ -534,6 +540,9 @@ export const InsertBlockDialog: React.FC = () => {
                 onChange={e => setSearch(e.target.value)}
                 placeholder="Search blocks..."
                 className="jd-pl-9"
+                onKeyDown={(e) => e.stopPropagation()}
+                onKeyPress={(e) => e.stopPropagation()}
+                onKeyUp={(e) => e.stopPropagation()}
               />
             </div>
 


### PR DESCRIPTION
## Summary
- keep focus inside dialogs with `useDialogFocusGuard`
- intercept key events globally in `BaseDialog`
- stop propagation on form inputs in BasicInfoForm, CreateFolderDialog, and InsertBlockDialog

## Testing
- `pnpm lint` *(fails: many existing lint errors)*
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_b_6841640f725083258dca90e64929f4e2