### PR TITLE
Add slash command for block insertion

### DIFF
--- a/src/services/index.tsx
+++ b/src/services/index.tsx
@@ -14,6 +14,7 @@ import { TokenService } from './auth/TokenService';
 import { NotificationService } from './notifications/NotificationService';
 import { StatsService } from './analytics/StatsService';
 import { UserProfileService } from './user/UserProfileService';
+import { SlashCommandService } from './ui/SlashCommandService';
 
 /**
  * Register all services with the ServiceManager
@@ -31,6 +32,7 @@ export function registerServices(): void {
   // Other services
   serviceManager.registerService('notifications', NotificationService.getInstance());
   serviceManager.registerService('stats', StatsService.getInstance());
+  serviceManager.registerService('ui.slash', SlashCommandService.getInstance());
   
   // Legacy registrations for backward compatibility
   serviceManager.registerService('auth', AuthService.getInstance());
@@ -60,4 +62,5 @@ export {
 export {
   StatsService,
   NotificationService,
+  SlashCommandService,
 };

--- a/src/services/ui/SlashCommandService.ts
+++ b/src/services/ui/SlashCommandService.ts
@@ -1,0 +1,86 @@
+import { AbstractBaseService } from '../BaseService';
+import { getConfigByHostname } from '@/platforms/config';
+import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
+
+export class SlashCommandService extends AbstractBaseService {
+  private static instance: SlashCommandService;
+  private inputEl: HTMLElement | null = null;
+  private observer: MutationObserver | null = null;
+
+  private constructor() {
+    super();
+  }
+
+  public static getInstance(): SlashCommandService {
+    if (!SlashCommandService.instance) {
+      SlashCommandService.instance = new SlashCommandService();
+    }
+    return SlashCommandService.instance;
+  }
+
+  protected async onInitialize(): Promise<void> {
+    this.attachListener();
+    this.observeDom();
+  }
+
+  protected onCleanup(): void {
+    this.detachListener();
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+  }
+
+  private observeDom() {
+    this.observer = new MutationObserver(() => this.attachListener());
+    this.observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  private attachListener() {
+    const config = getConfigByHostname(window.location.hostname);
+    if (!config) return;
+
+    const el = document.querySelector(config.domSelectors.PROMPT_TEXTAREA) as HTMLElement | null;
+    if (!el || el === this.inputEl) return;
+
+    this.detachListener();
+    this.inputEl = el;
+    this.inputEl.addEventListener('input', this.handleInput);
+  }
+
+  private detachListener() {
+    if (this.inputEl) {
+      this.inputEl.removeEventListener('input', this.handleInput);
+      this.inputEl = null;
+    }
+  }
+
+  private handleInput = (e: Event) => {
+    const target = e.target as HTMLTextAreaElement | HTMLElement;
+    let value = '';
+
+    if (target instanceof HTMLTextAreaElement) {
+      value = target.value;
+    } else if (target instanceof HTMLElement && target.isContentEditable) {
+      value = target.innerText;
+    }
+
+    if (/\/j\s?$/.test(value)) {
+      const newValue = value.replace(/\/j\s?$/, '');
+
+      if (target instanceof HTMLTextAreaElement) {
+        target.value = newValue;
+        target.dispatchEvent(new Event('input', { bubbles: true }));
+      } else if (target instanceof HTMLElement && target.isContentEditable) {
+        target.innerText = newValue;
+        target.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+
+      if (window.dialogManager && typeof window.dialogManager.openDialog === 'function') {
+        window.dialogManager.openDialog(DIALOG_TYPES.INSERT_BLOCK);
+      }
+    }
+  };
+}
+
+export const slashCommandService = SlashCommandService.getInstance();


### PR DESCRIPTION
## Summary
- add `SlashCommandService` to detect `/j` in prompt areas
- register new service with the `ServiceManager`

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68416a267dc0832592dd6dd1c7e105e4