### PR TITLE
Fix quick block selector insertion

### DIFF
--- a/src/components/prompts/blocks/quick-selector/QuickBlockSelector.tsx
+++ b/src/components/prompts/blocks/quick-selector/QuickBlockSelector.tsx
@@ -12,6 +12,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
 import { insertIntoPromptArea } from '@/utils/templates/placeholderUtils';
+import { insertTextAtCursor } from '@/utils/dom/insertTextAtCursor';
 import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
 import { 
   Search, 
@@ -142,7 +143,13 @@ export const QuickBlockSelector: React.FC<QuickBlockSelectorProps> = ({
   const handleSelectBlock = (block: Block) => {
     const content = getLocalizedContent(block.content);
     const text = buildPromptPart(block.type || 'content', content);
-    insertIntoPromptArea(text);
+
+    if (targetElement) {
+      insertTextAtCursor(targetElement, text);
+    } else {
+      insertIntoPromptArea(text);
+    }
+
     onClose();
     toast.success(`Inserted ${getLocalizedContent(block.title)} block`);
   };
@@ -187,7 +194,7 @@ export const QuickBlockSelector: React.FC<QuickBlockSelectorProps> = ({
     <div
       ref={containerRef}
       className={cn(
-        'jd-fixed jd-z-[2147483647] jd-w-[400px] jd-max-h-[480px]',
+        'jd-fixed jd-z-[2147483647] jd-w-[400px] jd-max-h-[480px] jd-overflow-hidden',
         'jd-bg-background jd-border jd-rounded-lg jd-shadow-xl',
         'jd-flex jd-flex-col jd-animate-in jd-fade-in jd-slide-in-from-bottom-2',
         isDark ? 'jd-border-gray-700' : 'jd-border-gray-200'
@@ -278,7 +285,7 @@ export const QuickBlockSelector: React.FC<QuickBlockSelectorProps> = ({
       </div>
 
       {/* Blocks List */}
-      <ScrollArea className="jd-flex-1 jd-px-3 jd-pb-3">
+      <ScrollArea className="jd-flex-1 jd-min-h-0 jd-px-3 jd-pb-3">
         {loading ? (
           <div className="jd-py-8">
             <LoadingSpinner size="sm" message="Loading blocks..." />

--- a/src/utils/dom/insertTextAtCursor.ts
+++ b/src/utils/dom/insertTextAtCursor.ts
@@ -1,0 +1,30 @@
+export function insertTextAtCursor(target: HTMLElement, text: string) {
+  if (!target) return;
+  if (target instanceof HTMLTextAreaElement) {
+    const start = target.selectionStart ?? target.value.length;
+    const end = target.selectionEnd ?? target.value.length;
+    const before = target.value.slice(0, start);
+    const after = target.value.slice(end);
+    target.value = before + text + after;
+    const newPos = start + text.length;
+    target.selectionStart = target.selectionEnd = newPos;
+    target.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
+    target.focus();
+    return;
+  }
+
+  if (target.isContentEditable) {
+    const selection = window.getSelection();
+    if (!selection) return;
+    const range = selection.getRangeAt(0);
+    range.deleteContents();
+    const node = document.createTextNode(text);
+    range.insertNode(node);
+    range.setStartAfter(node);
+    range.setEndAfter(node);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    (target as HTMLElement).dispatchEvent(new Event('input', { bubbles: true }));
+    target.focus();
+  }
+}


### PR DESCRIPTION
## Summary
- make quick selector container scrollable
- keep prompt content when inserting a block by using `insertTextAtCursor`
- add dom helper for cursor insertion

## Testing
- `npm run lint` *(fails: 422 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_684179b8feb08325b448c5b823b3e32a