### PR TITLE
Fix text insertion error in contenteditable blocks

### DIFF
--- a/src/utils/templates/insertionStrategies.ts
+++ b/src/utils/templates/insertionStrategies.ts
@@ -54,9 +54,16 @@ export function insertIntoContentEditable(element: HTMLElement, text: string, cu
         if (line) fragment.appendChild(document.createTextNode(line));
         if (i < lines.length - 1) fragment.appendChild(document.createElement('br'));
       });
+
+      const lastNode = fragment.lastChild as ChildNode | null;
       range.insertNode(fragment);
-      range.setStartAfter(fragment.lastChild || fragment);
-      range.setEndAfter(fragment.lastChild || fragment);
+
+      if (lastNode && lastNode.parentNode) {
+        range.setStartAfter(lastNode);
+        range.setEndAfter(lastNode);
+      } else {
+        range.collapse(false);
+      }
     } else {
       const node = document.createTextNode(text);
       range.insertNode(node);


### PR DESCRIPTION
## Summary
- patch `insertIntoContentEditable` to avoid calling `setStartAfter` on a `DocumentFragment`

## Testing
- `npm run lint` *(fails: 417 errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68419e268f6c832596e7d56ef91cd575