### PR TITLE
Fix slash command listener for dynamic inputs

### DIFF
--- a/src/core/errors/ErrorReporter.ts
+++ b/src/core/errors/ErrorReporter.ts
@@ -35,6 +35,9 @@ export class ErrorReporter {
     // Listen for unhandled errors and promises
     if (typeof window !== 'undefined') {
       window.addEventListener('error', (event) => {
+        if (event.message?.includes('ResizeObserver loop completed')) {
+          return;
+        }
         this.captureError(
           new AppError(
             event.message || 'Unhandled error',
@@ -45,9 +48,13 @@ export class ErrorReporter {
       });
       
       window.addEventListener('unhandledrejection', (event) => {
+        const message = event.reason?.message || '';
+        if (message.includes('ResizeObserver loop completed')) {
+          return;
+        }
         this.captureError(
           new AppError(
-            event.reason?.message || 'Unhandled promise rejection',
+            message || 'Unhandled promise rejection',
             ErrorCode.UNHANDLED_REJECTION,
             event.reason
           )


### PR DESCRIPTION
## Summary
- attach `SlashCommandService` input listener on `document` level
- update handler to detect prompt area via closest match
- refresh listener periodically without element checks
- ignore ResizeObserver errors in `ErrorReporter`

## Testing
- `npm run lint` *(fails: many errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6841a62f7d00832591bf71f343c5e0db