### PR TITLE
Add metadata block mapping to template form

### DIFF
--- a/src/hooks/dialogs/templateDialogUtils.ts
+++ b/src/hooks/dialogs/templateDialogUtils.ts
@@ -92,6 +92,39 @@ export function getEnhancedBlockIds(
   return [...metadataIds, ...contentIds];
 }
 
+// Build a mapping of metadata types to block IDs used
+export function getMetadataBlockMapping(
+  metadata: PromptMetadata,
+  activeTab: 'basic' | 'advanced'
+): Record<string, number | number[] | undefined> {
+  if (activeTab === 'basic') return {};
+
+  const mapping: Record<string, number | number[] | undefined> = {};
+
+  ['role', 'context', 'goal', 'audience', 'tone_style', 'output_format'].forEach(
+    type => {
+      const id = metadata[type as SingleMetadataType];
+      if (id && id !== 0) mapping[type] = id;
+    }
+  );
+
+  if (metadata.constraints) {
+    const ids = metadata.constraints
+      .map(c => c.blockId)
+      .filter((id): id is number => typeof id === 'number' && id !== 0);
+    if (ids.length > 0) mapping.constraints = ids;
+  }
+
+  if (metadata.examples) {
+    const ids = metadata.examples
+      .map(e => e.blockId)
+      .filter((id): id is number => typeof id === 'number' && id !== 0);
+    if (ids.length > 0) mapping.examples = ids;
+  }
+
+  return mapping;
+}
+
 
 import { DEFAULT_METADATA } from '@/types/prompts/metadata';
 

--- a/src/hooks/dialogs/useCreateTemplateDialog.ts
+++ b/src/hooks/dialogs/useCreateTemplateDialog.ts
@@ -21,6 +21,7 @@ import {
   validateEnhancedTemplateForm,
   generateEnhancedFinalContent,
   getEnhancedBlockIds,
+  getMetadataBlockMapping,
   parseTemplateMetadata,
   createBlock,
   addBlock as addBlockUtil,
@@ -192,6 +193,7 @@ export function useCreateTemplateDialog() {
 
   const generateFinalContentLocal = () => generateEnhancedFinalContent(content, blocks, metadata, activeTab);
   const getBlockIdsLocal = () => getEnhancedBlockIds(blocks, metadata, activeTab);
+  const getMetadataMappingLocal = () => getMetadataBlockMapping(metadata, activeTab);
 
   const handleSave = async () => {
     if (!validateForm()) {
@@ -207,6 +209,7 @@ export function useCreateTemplateDialog() {
     try {
       const finalContent = generateFinalContentLocal();
       const blockIds = getBlockIdsLocal();
+      const metadataMapping = getMetadataMappingLocal();
 
       const templateData = {
         title: name.trim(),
@@ -215,7 +218,8 @@ export function useCreateTemplateDialog() {
         description: description?.trim(),
         folder_id: selectedFolderId ? parseInt(selectedFolderId, 10) : undefined,
         // Include enhanced metadata for future use
-        enhanced_metadata: metadata
+        enhanced_metadata: metadata,
+        metadata: metadataMapping
       };
 
       if (onSave) {
@@ -224,7 +228,8 @@ export function useCreateTemplateDialog() {
           content: finalContent,
           description: description?.trim(),
           folder_id: selectedFolderId ? parseInt(selectedFolderId, 10) : undefined,
-          enhanced_metadata: metadata
+          enhanced_metadata: metadata,
+          metadata: metadataMapping
         };
         const success = await onSave(formData);
         if (success) {


### PR DESCRIPTION
## Summary
- compute mapping of metadata block IDs
- include this metadata mapping when saving templates

## Testing
- `npm run lint` *(fails: 431 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6841b7ddd748832594f0f63cb196d83c