### PR TITLE
Support saving metadata block mapping

### DIFF
--- a/src/services/api/prompts/templates/createTemplate.ts
+++ b/src/services/api/prompts/templates/createTemplate.ts
@@ -21,7 +21,11 @@ export async function createTemplate(templateData: any): Promise<any> {
         tags: templateData.tags || [],
         locale: templateData.locale || 'en',
         folder_id: templateData.folder_id || null,
-        type: templateData.type || 'user'
+        type: templateData.type || 'user',
+        // Include advanced editor fields when present
+        blocks: templateData.blocks || [],
+        metadata: templateData.metadata || {},
+        enhanced_metadata: templateData.enhanced_metadata || undefined
       };
 
       const response = await apiClient.request('/prompts/templates', {

--- a/src/types/prompts/templates.ts
+++ b/src/types/prompts/templates.ts
@@ -19,6 +19,18 @@ export interface Template {
     type?: 'official' | 'organization' | 'user';
     language?: string;
     based_on_official_id?: number | null;
+    /**
+     * Mapping of metadata types to block IDs when created with the Advanced Editor
+     */
+    metadata?: Record<string, number | number[]>;
+    /**
+     * IDs of blocks used for the content section
+     */
+    blocks?: number[];
+    /**
+     * Full metadata structure including values and references
+     */
+    enhanced_metadata?: any;
   }
   
   /**


### PR DESCRIPTION
## Summary
- include advanced editor data in createTemplate API calls
- document metadata fields in Template type

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6841c5e0877c8325b0b48e798d576ff3