### PR TITLE
Refactor dialogs to use context

### DIFF
--- a/src/components/common/AddBlockButton.tsx
+++ b/src/components/common/AddBlockButton.tsx
@@ -18,6 +18,7 @@ import {
   BLOCK_TYPES 
 } from '@/components/prompts/blocks/blockUtils';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
+import { useDialogActions } from '@/hooks/dialogs/useDialogActions';
 import { cn } from '@/core/utils/classNames';
 
 interface AddBlockButtonProps {
@@ -37,6 +38,7 @@ export const AddBlockButton: React.FC<AddBlockButtonProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const isDark = useThemeDetector();
+  const { openInsertBlock } = useDialogActions();
 
   const handleAddNewBlock = (blockType: BlockType) => {
     onAdd(blockType);
@@ -162,10 +164,7 @@ export const AddBlockButton: React.FC<AddBlockButtonProps> = ({
             {Object.values(availableBlocks).some(blocks => blocks.length > 3) && (
               <DropdownMenuItem
                 onClick={() => {
-                  // This could open the InsertBlockDialog or a similar interface
-                  if (window.dialogManager) {
-                    window.dialogManager.openDialog('insertBlock', {});
-                  }
+                  openInsertBlock();
                   setIsOpen(false);
                 }}
                 className="jd-flex jd-items-center jd-gap-2 jd-py-2 jd-cursor-pointer jd-text-primary"

--- a/src/components/panels/StatsPanel/index.tsx
+++ b/src/components/panels/StatsPanel/index.tsx
@@ -8,7 +8,7 @@ import StatsDetailRow from './StatsDetailRow';
 import BasePanel from '../BasePanel';
 import ErrorBoundary from '../../common/ErrorBoundary';
 import { getMessage } from '@/core/utils/i18n';
-import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
+import { useDialogActions } from '@/hooks/dialogs/useDialogActions';
 import {
   Tooltip,
   TooltipContent,
@@ -103,12 +103,8 @@ const StatsPanel: React.FC<StatsPanelProps> = ({
   const efficiencyValue = Math.min(100, Math.max(0, stats.efficiency || 0));
   const efficiencyColor = getEfficiencyColor(efficiencyValue);
 
-  // Handle opening enhanced stats dialog
-  const handleOpenEnhancedStats = () => {
-    if (window.dialogManager) {
-      window.dialogManager.openDialog(DIALOG_TYPES.ENHANCED_STATS);
-    }
-  };
+  // Handle opening enhanced stats dialog using the dialog context
+  const { openEnhancedStats } = useDialogActions();
 
   return (
     <ErrorBoundary>
@@ -210,10 +206,10 @@ const StatsPanel: React.FC<StatsPanelProps> = ({
                     </span>
                   </span>
                   
-                  <Button 
+                  <Button
                     className="jd-text-[10px] jd-text-blue-500 jd-px-1 hover:jd-underline jd-p-0 jd-h-auto jd-bg-transparent jd-flex jd-items-center jd-gap-1"
                     variant="ghost"
-                    onClick={handleOpenEnhancedStats}
+                    onClick={openEnhancedStats}
                   >
                     {getMessage('viewEnhancedStats', undefined, 'View Enhanced Analytics')}
                     <ExternalLink className="jd-h-3 jd-w-3" />

--- a/src/components/prompts/templates/TemplateItem.tsx
+++ b/src/components/prompts/templates/TemplateItem.tsx
@@ -27,7 +27,12 @@ export function TemplateItem({
   onUseTemplate
 }: TemplateItemProps) {
   // Use our template actions hook
-  const { isProcessing, useTemplate: defaultUseTemplate } = useTemplateActions();
+  const {
+    isProcessing,
+    useTemplate: defaultUseTemplate,
+    editTemplate: defaultEditTemplate,
+    deleteTemplateWithConfirm,
+  } = useTemplateActions();
   
   // Use the provided use function or fall back to the hook's function
   const handleUseTemplate = onUseTemplate || defaultUseTemplate;
@@ -133,6 +138,8 @@ export function TemplateItem({
     e.stopPropagation();
     if (onEditTemplate) {
       onEditTemplate(template);
+    } else {
+      defaultEditTemplate(template);
     }
   };
   
@@ -140,8 +147,9 @@ export function TemplateItem({
   const handleDeleteClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (onDeleteTemplate && template.id) {
-      // Call the delete handler
       onDeleteTemplate(template.id);
+    } else if (template.id) {
+      deleteTemplateWithConfirm(template.id);
     }
   };
   

--- a/src/hooks/dialogs/useDialogActions.ts
+++ b/src/hooks/dialogs/useDialogActions.ts
@@ -1,0 +1,67 @@
+import { useCallback } from 'react';
+import { useDialogManager } from '@/components/dialogs/DialogContext';
+import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
+
+export function useDialogActions() {
+  const { openDialog } = useDialogManager();
+
+  const openSettings = useCallback(() => openDialog(DIALOG_TYPES.SETTINGS, {}), [openDialog]);
+
+  const openCreateTemplate = useCallback(
+    (props?: any) => openDialog(DIALOG_TYPES.CREATE_TEMPLATE, props),
+    [openDialog]
+  );
+
+  const openEditTemplate = useCallback(
+    (props?: any) => openDialog(DIALOG_TYPES.EDIT_TEMPLATE, props),
+    [openDialog]
+  );
+
+  const openCreateFolder = useCallback(
+    (props?: any) => openDialog(DIALOG_TYPES.CREATE_FOLDER, props),
+    [openDialog]
+  );
+
+  const openAuth = useCallback(
+    (props?: any) => openDialog(DIALOG_TYPES.AUTH, props),
+    [openDialog]
+  );
+
+  const openPlaceholderEditor = useCallback(
+    (props?: any) => openDialog(DIALOG_TYPES.PLACEHOLDER_EDITOR, props),
+    [openDialog]
+  );
+
+  const openConfirmation = useCallback(
+    (props?: any) => openDialog(DIALOG_TYPES.CONFIRMATION, props),
+    [openDialog]
+  );
+
+  const openEnhancedStats = useCallback(
+    () => openDialog(DIALOG_TYPES.ENHANCED_STATS, {}),
+    [openDialog]
+  );
+
+  const openCreateBlock = useCallback(
+    (props?: any) => openDialog(DIALOG_TYPES.CREATE_BLOCK, props),
+    [openDialog]
+  );
+
+  const openInsertBlock = useCallback(
+    () => openDialog(DIALOG_TYPES.INSERT_BLOCK, {}),
+    [openDialog]
+  );
+
+  return {
+    openSettings,
+    openCreateTemplate,
+    openEditTemplate,
+    openCreateFolder,
+    openAuth,
+    openPlaceholderEditor,
+    openConfirmation,
+    openEnhancedStats,
+    openCreateBlock,
+    openInsertBlock,
+  };
+}


### PR DESCRIPTION
## Summary
- centralize dialog helpers with `useDialogActions`
- open enhanced stats panel via context
- update block adding menu to open insert-block dialog via context
- use global confirmation handler for template and folder deletion
- provide default edit/delete actions in `TemplateItem`

## Testing
- `npm run lint` *(fails: 428 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6842a06fa5cc83259e7e96421481f5b8