### PR TITLE
Refactor dialogs with zustand store

### DIFF
--- a/src/components/dialogs/DialogContext.tsx
+++ b/src/components/dialogs/DialogContext.tsx
@@ -1,6 +1,7 @@
 // src/components/dialogs/DialogContext.tsx
 import React, { createContext, useContext, useState, useCallback, ReactNode, useEffect } from 'react';
 import { DialogType, DialogProps } from './DialogRegistry';
+import { useDialogStore } from '@/store/dialogStore';
 
 // Define the Dialog Manager context type
 interface DialogManagerContextType {
@@ -140,11 +141,13 @@ export const DialogManagerProvider: React.FC<DialogManagerProviderProps> = ({ ch
     if (data !== undefined) {
       setDialogData(prev => ({ ...prev, [type]: data }));
     }
+    useDialogStore.getState().openDialog(type, data);
   }, []);
   
   const closeDialog = useCallback((type: DialogType) => {
     console.log(`Closing dialog: ${type}`);
     setOpenDialogs((prev: Record<DialogType, boolean>) => ({ ...prev, [type]: false }));
+    useDialogStore.getState().closeDialog(type);
   }, []);
   
   const isDialogOpen = useCallback((type: DialogType): boolean => {

--- a/src/components/dialogs/DialogManager.tsx
+++ b/src/components/dialogs/DialogManager.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { CreateTemplateDialog } from './prompts/CreateTemplateDialog';
+import { CreateFolderDialog } from './prompts/CreateFolderDialog';
+import { CustomizeTemplateDialog } from './prompts/CustomizeTemplateDialog';
+import { CreateBlockDialog } from './prompts/CreateBlockDialog';
+import { InsertBlockDialog } from './prompts/InsertBlockDialog';
+import { AuthDialog } from './auth/AuthDialog';
+import { SettingsDialog } from './settings/SettingsDialog';
+import { ConfirmationDialog } from './common/ConfirmationDialog';
+import { EnhancedStatsDialog } from './analytics/EnhancedStatsDialog';
+import { DialogManagerProvider } from './DialogContext';
+
+export const DialogManager: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <DialogManagerProvider>
+      {children}
+      <CreateTemplateDialog />
+      <CreateFolderDialog />
+      <CustomizeTemplateDialog />
+      <CreateBlockDialog />
+      <InsertBlockDialog />
+      <AuthDialog />
+      <SettingsDialog />
+      <ConfirmationDialog />
+      <EnhancedStatsDialog />
+    </DialogManagerProvider>
+  );
+};

--- a/src/components/dialogs/auth/AuthDialog.tsx
+++ b/src/components/dialogs/auth/AuthDialog.tsx
@@ -1,7 +1,7 @@
 // src/components/dialogs/auth/AuthDialog.tsx
 import React from 'react';
-import { useDialog } from '../DialogContext';
 import { DIALOG_TYPES } from '../DialogRegistry';
+import { useDialogStore } from '@/store/dialogStore';
 import AuthForm from '@/extension/welcome/auth/AuthForm';
 import { getMessage } from '@/core/utils/i18n';
 import { BaseDialog } from '../BaseDialog';
@@ -10,7 +10,9 @@ import { BaseDialog } from '../BaseDialog';
  * Dialog for authentication (sign in/sign up)
  */
 export const AuthDialog: React.FC = () => {
-  const { isOpen, data, dialogProps } = useDialog(DIALOG_TYPES.AUTH);
+  const isOpen = useDialogStore(state => state[DIALOG_TYPES.AUTH].isOpen);
+  const data = useDialogStore(state => state[DIALOG_TYPES.AUTH].data);
+  const closeDialog = useDialogStore(state => state.closeDialog);
   
   // Safe extraction of dialog data with defaults
   const initialMode = data?.initialMode || 'signin';
@@ -22,7 +24,9 @@ export const AuthDialog: React.FC = () => {
   return (
     <BaseDialog
       open={isOpen}
-      onOpenChange={dialogProps.onOpenChange}
+      onOpenChange={(open) => {
+        if (!open) closeDialog(DIALOG_TYPES.AUTH);
+      }}
       title={initialMode === 'signin' 
         ? getMessage('signIn', undefined, 'Sign In')
         : getMessage('signUp', undefined, 'Sign Up')}
@@ -32,10 +36,10 @@ export const AuthDialog: React.FC = () => {
         <AuthForm
           initialMode={initialMode}
           isSessionExpired={isSessionExpired}
-          onClose={() => dialogProps.onOpenChange(false)}
+          onClose={() => closeDialog(DIALOG_TYPES.AUTH)}
           onSuccess={() => {
             onSuccess();
-            dialogProps.onOpenChange(false);
+            closeDialog(DIALOG_TYPES.AUTH);
           }}
         />
       </div>

--- a/src/components/dialogs/common/ConfirmationDialog.tsx
+++ b/src/components/dialogs/common/ConfirmationDialog.tsx
@@ -1,8 +1,8 @@
 // src/components/dialogs/common/ConfirmationDialog.tsx
 import React from 'react';
 import { Button } from '@/components/ui/button';
-import { useDialog } from '../DialogContext';
 import { DIALOG_TYPES } from '../DialogRegistry';
+import { useDialogStore } from '@/store/dialogStore';
 import { getMessage } from '@/core/utils/i18n';
 import { BaseDialog } from '../BaseDialog';
 
@@ -10,7 +10,9 @@ import { BaseDialog } from '../BaseDialog';
  * Generic confirmation dialog component
  */
 export const ConfirmationDialog: React.FC = () => {
-  const { isOpen, data, dialogProps } = useDialog(DIALOG_TYPES.CONFIRMATION);
+  const isOpen = useDialogStore(state => state[DIALOG_TYPES.CONFIRMATION].isOpen);
+  const data = useDialogStore(state => state[DIALOG_TYPES.CONFIRMATION].data);
+  const closeDialog = useDialogStore(state => state.closeDialog);
   
   // Safe extraction of dialog data with defaults
   const title = data?.title || getMessage('confirmAction', undefined, 'Confirm Action');
@@ -23,21 +25,23 @@ export const ConfirmationDialog: React.FC = () => {
   const handleConfirm = (e: React.MouseEvent) => {
     e.stopPropagation();
     onConfirm();
-    dialogProps.onOpenChange(false);
+    closeDialog(DIALOG_TYPES.CONFIRMATION);
   };
   
   const handleCancel = (e: React.MouseEvent) => {
     e.stopPropagation();
     onCancel();
-    dialogProps.onOpenChange(false);
+    closeDialog(DIALOG_TYPES.CONFIRMATION);
   };
   
   if (!isOpen) return null;
   
   return (
-    <BaseDialog 
-      open={isOpen} 
-      onOpenChange={dialogProps.onOpenChange}
+    <BaseDialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) closeDialog(DIALOG_TYPES.CONFIRMATION);
+      }}
       title={title}
       description={description}
       className="jd-max-w-md"

--- a/src/components/dialogs/index.tsx
+++ b/src/components/dialogs/index.tsx
@@ -1,50 +1,16 @@
 // src/components/dialogs/index.tsx
 import React from 'react';
-import { DialogProvider as DialogContextProvider } from './DialogContext';
-import { CreateTemplateDialog } from './prompts/CreateTemplateDialog';
-import { CreateFolderDialog } from './prompts/CreateFolderDialog';
-import { CustomizeTemplateDialog } from './prompts/CustomizeTemplateDialog';
-import { AuthDialog } from './auth/AuthDialog';
-import { SettingsDialog } from './settings/SettingsDialog';
-import { ConfirmationDialog } from './common/ConfirmationDialog';
-import { EnhancedStatsDialog } from './analytics/EnhancedStatsDialog';
+import { DialogManager } from './DialogManager';
 
 /**
  * Main dialog provider that includes all dialog components
  * This component ensures window.dialogManager is available
  */
 export const DialogProvider: React.FC<{children: React.ReactNode}> = ({ children }) => {
-  // Debug check to verify dialog manager initialization
-  React.useEffect(() => {
-    console.log('DialogProvider mounted, checking dialogManager availability');
-    
-    // Monitor for any errors in dialog functionality
-    const handleError = (error: ErrorEvent) => {
-      if (error.message.includes('dialogManager') || error.message.includes('Dialog')) {
-        console.error('Dialog system error detected:', error);
-      }
-    };
-    
-    window.addEventListener('error', handleError);
-    
-    return () => {
-      window.removeEventListener('error', handleError);
-    };
-  }, []);
-  
   return (
-    <DialogContextProvider>
+    <DialogManager>
       {children}
-      
-      {/* Register all dialogs here */}
-      <CreateTemplateDialog />
-      <CreateFolderDialog  />
-      <CustomizeTemplateDialog />
-      <AuthDialog />
-      <SettingsDialog />
-      <ConfirmationDialog />
-      <EnhancedStatsDialog />
-    </DialogContextProvider>
+    </DialogManager>
   );
 };
 

--- a/src/components/dialogs/prompts/CreateFolderDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateFolderDialog/index.tsx
@@ -5,8 +5,8 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Plus } from 'lucide-react';
 import { cn } from '@/core/utils/classNames';
-import { useDialog } from '@/components/dialogs/DialogContext';
 import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
+import { useDialogStore } from '@/store/dialogStore';
 import { toast } from 'sonner';
 import { promptApi } from '@/services/api';
 import { BaseDialog } from '@/components/dialogs/BaseDialog';
@@ -17,7 +17,9 @@ import { getMessage } from '@/core/utils/i18n';
  * Enhanced for dialog stacking scenarios and Claude.ai compatibility
  */
 export const CreateFolderDialog: React.FC = () => {
-  const { isOpen, data, dialogProps } = useDialog(DIALOG_TYPES.CREATE_FOLDER);
+  const isOpen = useDialogStore(state => state[DIALOG_TYPES.CREATE_FOLDER].isOpen);
+  const data = useDialogStore(state => state[DIALOG_TYPES.CREATE_FOLDER].data);
+  const closeDialog = useDialogStore(state => state.closeDialog);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -63,7 +65,7 @@ export const CreateFolderDialog: React.FC = () => {
           
           toast.success(`Folder "${name}" created successfully`);
           resetForm();
-          dialogProps.onOpenChange(false);
+          closeDialog(DIALOG_TYPES.CREATE_FOLDER);
           return;
         } else if (customResult && !customResult.success) {
           toast.error(customResult.error || 'Failed to create folder');
@@ -82,7 +84,7 @@ export const CreateFolderDialog: React.FC = () => {
         
         toast.success(`Folder "${name}" created successfully`);
         resetForm();
-        dialogProps.onOpenChange(false);
+        closeDialog(DIALOG_TYPES.CREATE_FOLDER);
       } else {
         toast.error(response.message || 'Failed to create folder');
       }
@@ -102,8 +104,8 @@ export const CreateFolderDialog: React.FC = () => {
   const handleClose = (open: boolean) => {
     if (!open) {
       resetForm();
+      closeDialog(DIALOG_TYPES.CREATE_FOLDER);
     }
-    dialogProps.onOpenChange(open);
   };
 
   if (!isOpen) return null;

--- a/src/components/dialogs/settings/SettingsDialog.tsx
+++ b/src/components/dialogs/settings/SettingsDialog.tsx
@@ -4,8 +4,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { toast } from "sonner";
-import { useDialog } from '@/components/dialogs/DialogContext';
 import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
+import { useDialogStore } from '@/store/dialogStore';
 import { getMessage } from '@/core/utils/i18n';
 import { BaseDialog } from '../BaseDialog';
 
@@ -20,7 +20,8 @@ interface Settings {
  * Dialog for application settings
  */
 export const SettingsDialog: React.FC = () => {
-  const { isOpen, dialogProps } = useDialog(DIALOG_TYPES.SETTINGS);
+  const isOpen = useDialogStore(state => state[DIALOG_TYPES.SETTINGS].isOpen);
+  const closeDialog = useDialogStore(state => state.closeDialog);
   const [settings, setSettings] = useState<Settings>({
     autoSave: true,
     autoSaveInterval: 60,
@@ -69,8 +70,7 @@ export const SettingsDialog: React.FC = () => {
           }
         });
         
-        // Close the dialog
-        dialogProps.onOpenChange(false);
+        closeDialog(DIALOG_TYPES.SETTINGS);
       });
     } catch (error) {
       console.error('Failed to save settings:', error);
@@ -86,7 +86,7 @@ export const SettingsDialog: React.FC = () => {
   };
 
   const handleCancel = () => {
-    dialogProps.onOpenChange(false);
+    closeDialog(DIALOG_TYPES.SETTINGS);
   };
   
   return (
@@ -96,7 +96,6 @@ export const SettingsDialog: React.FC = () => {
         if (!open) {
           handleCancel();
         }
-        dialogProps.onOpenChange(open);
       }}
       title={getMessage('settings', undefined, 'Settings')}
       description={getMessage('settingsDescription', undefined, 'Configure your application settings')}

--- a/src/store/dialogStore.ts
+++ b/src/store/dialogStore.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand';
+import { DialogType, DialogProps, DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
+
+interface DialogStateEntry<T> {
+  isOpen: boolean;
+  data?: T;
+}
+
+type DialogStoreState = {
+  [K in DialogType]: DialogStateEntry<DialogProps[K]>;
+};
+
+interface DialogStore extends DialogStoreState {
+  openDialog: <T extends DialogType>(type: T, data?: DialogProps[T]) => void;
+  closeDialog: (type: DialogType) => void;
+  closeAllDialogs: () => void;
+}
+
+const initialState: DialogStoreState = Object.values(DIALOG_TYPES).reduce((acc, type) => {
+  acc[type as DialogType] = { isOpen: false, data: undefined };
+  return acc;
+}, {} as DialogStoreState);
+
+export const useDialogStore = create<DialogStore>((set) => ({
+  ...initialState,
+
+  openDialog: (type, data) =>
+    set(() => ({
+      [type]: { isOpen: true, data }
+    })),
+
+  closeDialog: (type) =>
+    set((state) => ({
+      [type]: { ...state[type], isOpen: false }
+    })),
+
+  closeAllDialogs: () =>
+    set((state) => {
+      const newState: Partial<DialogStoreState> = {};
+      for (const dialogType of Object.values(DIALOG_TYPES)) {
+        newState[dialogType as DialogType] = {
+          ...state[dialogType as DialogType],
+          isOpen: false
+        };
+      }
+      return newState;
+    })
+}));


### PR DESCRIPTION
## Summary
- add zustand-based dialogStore
- add DialogManager component wrapping existing provider
- update AuthDialog, ConfirmationDialog, SettingsDialog and CreateFolderDialog to read from the store
- sync DialogContext provider with dialogStore

## Testing
- `npm run type-check`
- `npm run lint` *(fails: many lint errors)*


------
https://chatgpt.com/codex/tasks/task_b_6842a9af91d0832589e952e40eef8dd6