### PR TITLE
Align frontend with updated prompt models

### DIFF
--- a/src/components/common/AddBlockButton.tsx
+++ b/src/components/common/AddBlockButton.tsx
@@ -185,7 +185,7 @@ export const InlineBlockForm: React.FC<{
   onSave: (blockData: { type: BlockType; title: string; content: string }) => void;
   onCancel: () => void;
   initialType?: BlockType;
-}> = ({ onSave, onCancel, initialType = 'content' }) => {
+}> = ({ onSave, onCancel, initialType = 'custom' }) => {
   const [type, setType] = useState<BlockType>(initialType);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');

--- a/src/components/dialogs/prompts/CreateBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateBlockDialog/index.tsx
@@ -16,7 +16,7 @@ import { BLOCK_TYPE_LABELS, getBlockTypeIcon, getBlockTypeColors } from '@/compo
 import { useThemeDetector } from '@/hooks/useThemeDetector';
 
 const AVAILABLE_BLOCK_TYPES: BlockType[] = [
-  'content', 'role', 'context', 'goal', 'custom', 
+  'role', 'context', 'goal', 'custom',
   'output_format', 'example', 'constraint', 'tone_style', 'audience'
 ];
 
@@ -26,7 +26,7 @@ export const CreateBlockDialog: React.FC = () => {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [content, setContent] = useState('');
-  const [blockType, setBlockType] = useState<BlockType>('content');
+  const [blockType, setBlockType] = useState<BlockType>('custom');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   
@@ -43,7 +43,7 @@ export const CreateBlockDialog: React.FC = () => {
   useEffect(() => {
     if (isOpen) {
       setContent(initialContent);
-      setBlockType(initialType || 'content');
+      setBlockType(initialType || 'custom');
       setName('');
       setDescription('');
       setValidationErrors({});
@@ -120,7 +120,7 @@ export const CreateBlockDialog: React.FC = () => {
     setName('');
     setDescription('');
     setContent('');
-    setBlockType('content');
+    setBlockType('custom');
     setValidationErrors({});
     setIsSubmitting(false);
     dialogProps.onOpenChange(false);

--- a/src/components/dialogs/prompts/InsertBlockDialog/AvailableBlockCard.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/AvailableBlockCard.tsx
@@ -24,7 +24,7 @@ export interface AvailableBlockCardProps {
 export function AvailableBlockCard({ block, isDark, onAdd, isSelected = false, onRemove }: AvailableBlockCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const Icon = getBlockTypeIcon(block.type);
-  const cardColors = getBlockTypeColors(block.type || 'content', isDark);
+  const cardColors = getBlockTypeColors(block.type || 'custom', isDark);
   const iconBg = getBlockIconColors(block.type, isDark);
   const title = typeof block.title === 'string' ? block.title : block.title?.en || 'Untitled';
   const content = typeof block.content === 'string' ? block.content : block.content.en || '';
@@ -58,7 +58,7 @@ export function AvailableBlockCard({ block, isDark, onAdd, isSelected = false, o
             <div className="jd-flex jd-items-center jd-gap-2 jd-mb-2">
               <h3 className="jd-font-semibold jd-text-sm jd-truncate jd-flex-1">{title}</h3>
               <Badge variant="secondary" className="jd-text-xs jd-px-2 jd-py-1 jd-h-auto jd-flex-shrink-0">
-                {BLOCK_TYPE_LABELS[block.type || 'content']}
+                {BLOCK_TYPE_LABELS[block.type || 'custom']}
               </Badge>
             </div>
             

--- a/src/components/dialogs/prompts/InsertBlockDialog/PreviewBlock.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/PreviewBlock.tsx
@@ -22,13 +22,13 @@ export function PreviewBlock({ block, isDark }: PreviewBlockProps) {
         </span>
         <span className="jd-text-sm jd-font-medium">{title}</span>
         <Badge variant="outline" className="jd-text-xs">
-          {BLOCK_TYPE_LABELS[block.type || 'content']}
+          {BLOCK_TYPE_LABELS[block.type || 'custom']}
         </Badge>
       </div>
       <div
         className="jd-text-sm jd-text-muted-foreground jd-pl-6"
         dangerouslySetInnerHTML={{
-          __html: buildPromptPartHtml(block.type || 'content', content, isDark),
+          __html: buildPromptPartHtml(block.type || 'custom', content, isDark),
         }}
       />
     </div>

--- a/src/components/dialogs/prompts/InsertBlockDialog/SortableSelectedBlock.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/SortableSelectedBlock.tsx
@@ -66,7 +66,7 @@ export function SortableSelectedBlock({ block, isDark, onRemove, isExpanded, onT
           <div className="jd-flex jd-items-center jd-gap-2 jd-mb-1">
             <h4 className="jd-text-sm jd-font-medium jd-truncate">{title}</h4>
             <Badge variant="secondary" className="jd-text-xs">
-              {BLOCK_TYPE_LABELS[block.type || 'content']}
+              {BLOCK_TYPE_LABELS[block.type || 'custom']}
             </Badge>
           </div>
           <div className="jd-text-xs jd-text-muted-foreground">

--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -76,7 +76,7 @@ const InlineBlockCreator: React.FC<{
   onBlockCreated: (block: Block) => void;
   onCancel: () => void;
 }> = ({ onBlockCreated, onCancel }) => {
-  const [type, setType] = useState<BlockType>('content');
+  const [type, setType] = useState<BlockType>('custom');
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [isCreating, setIsCreating] = useState(false);
@@ -402,7 +402,7 @@ export const InsertBlockDialog: React.FC = () => {
   useEffect(() => {
     const parts = selectedBlocks.map(b => {
       const text = blockContents[b.id] ?? (typeof b.content === 'string' ? b.content : b.content.en || '');
-      return buildPromptPart(b.type || 'content', text);
+      return buildPromptPart(b.type || 'custom', text);
     });
     setEditableContent(parts.join('\n\n'));
   }, [selectedBlocks, blockContents]);
@@ -413,7 +413,7 @@ export const InsertBlockDialog: React.FC = () => {
     return selectedBlocks
       .map(b => {
         const text = blockContents[b.id] ?? (typeof b.content === 'string' ? b.content : b.content.en || '');
-        return buildPromptPartHtml(b.type || 'content', text, isDark);
+        return buildPromptPartHtml(b.type || 'custom', text, isDark);
       })
       .join('<br><br>');
   }, [selectedBlocks, blockContents, isDark]);
@@ -441,7 +441,7 @@ export const InsertBlockDialog: React.FC = () => {
       const updated = { ...prev };
       selectedBlocks.forEach((b, idx) => {
         let seg = segments[idx] ?? '';
-        const prefix = buildPromptPart(b.type || 'content', '');
+        const prefix = buildPromptPart(b.type || 'custom', '');
         if (prefix && seg.startsWith(prefix)) {
           seg = seg.slice(prefix.length);
         }
@@ -480,7 +480,7 @@ export const InsertBlockDialog: React.FC = () => {
   });
 
   // Get unique block types for filter
-  const blockTypes = Array.from(new Set(blocks.map(b => b.type || 'content')));
+  const blockTypes = Array.from(new Set(blocks.map(b => b.type || 'custom')));
 
   const toggleExpanded = (id: number) => {
     setExpandedBlocks(prev => {

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/ContentSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/ContentSection.tsx
@@ -142,7 +142,7 @@ const AdditionalBlocks: React.FC<{
         <div key={block.id} className="jd-animate-in jd-slide-in-from-bottom-2 jd-duration-300">
           <BlockCard
             block={block}
-            availableBlocks={availableBlocksByType[block.type || 'content'] || []}
+            availableBlocks={availableBlocksByType[block.type || 'custom'] || []}
             onRemove={onRemoveBlock}
             onUpdate={onUpdateBlock}
             onDragStart={onDragStart}

--- a/src/components/prompts/blocks/BlockCard.tsx
+++ b/src/components/prompts/blocks/BlockCard.tsx
@@ -45,9 +45,9 @@ export const BlockCard: React.FC<BlockCardProps> = ({
   onSave
 }) => {
   const isDark = useThemeDetector();
-  const Icon = getBlockTypeIcon(block.type || 'content');
-  const cardColors = getBlockTypeColors(block.type || 'content', isDark);
-  const iconBg = getBlockIconColors(block.type || 'content', isDark);
+  const Icon = getBlockTypeIcon(block.type || 'custom');
+  const cardColors = getBlockTypeColors(block.type || 'custom', isDark);
+  const iconBg = getBlockIconColors(block.type || 'custom', isDark);
   const content = typeof block.content === 'string' 
     ? block.content 
     : block.content[getCurrentLanguage()] || block.content.en || '';
@@ -76,7 +76,7 @@ export const BlockCard: React.FC<BlockCardProps> = ({
     setHasUnsavedChanges(content !== originalContent || newType !== originalType);
   };
 
-  const isContentType = block.type === 'content';
+  const isContentType = block.type === 'custom';
   const blocksForType = block.type ? availableBlocks : [];
   const existing = blocksForType.find(b => b.id === block.id);
   const readOnly = !block.isNew;
@@ -117,7 +117,7 @@ export const BlockCard: React.FC<BlockCardProps> = ({
 
   const handleSaveClick = () => {
     openDialog(DIALOG_TYPES.CREATE_BLOCK, {
-      initialType: block.type || 'content',
+      initialType: block.type || 'custom',
       initialContent: content,
       onBlockCreated: handleBlockCreated
     });

--- a/src/components/prompts/blocks/blockUtils.ts
+++ b/src/components/prompts/blocks/blockUtils.ts
@@ -22,7 +22,6 @@ export const BLOCK_TYPES: BlockType[] = [
   'role',
   'context',
   'goal',
-  'content',
   'custom',
   'output_format',
   'example',
@@ -36,7 +35,6 @@ export const BLOCK_TYPE_LABELS: Record<BlockType, string> = {
   role: 'Role',
   context: 'Context',
   goal: 'Goal',
-  content: 'Content',
   custom: 'Custom',
   output_format: 'Output Format',
   example: 'Example',
@@ -50,7 +48,6 @@ export const BLOCK_TYPE_ICONS: Record<BlockType, React.ComponentType<any>> = {
   role: User,
   context: MessageSquare,
   goal: Target,
-  content: FileText,
   custom: Sparkles,
   output_format: Type,
   example: Layout,
@@ -64,7 +61,6 @@ export const BLOCK_TYPE_DESCRIPTIONS: Record<BlockType, string> = {
   role: "Define the AI's role",
   context: 'Provide context information',
   goal: 'Specify the goal',
-  content: 'Main content for the prompt',
   custom: 'Custom user content',
   output_format: 'Desired output format',
   example: 'Provide an example',
@@ -79,7 +75,6 @@ export const BLOCK_CARD_COLORS_LIGHT: Record<BlockType, string> = {
   role: 'jd-bg-gradient-to-br jd-from-purple-50 jd-to-purple-100 jd-border-purple-200 jd-text-purple-900',
   context: 'jd-bg-gradient-to-br jd-from-green-50 jd-to-green-100 jd-border-green-200 jd-text-green-900',
   goal: 'jd-bg-gradient-to-br jd-from-pink-50 jd-to-pink-100 jd-border-pink-200 jd-text-pink-900',
-  content: 'jd-bg-gradient-to-br jd-from-slate-50 jd-to-slate-100 jd-border-slate-200 jd-text-slate-900',
   custom: 'jd-bg-gradient-to-br jd-from-amber-50 jd-to-amber-100 jd-border-amber-200 jd-text-amber-900',
   output_format: 'jd-bg-gradient-to-br jd-from-cyan-50 jd-to-cyan-100 jd-border-cyan-200 jd-text-cyan-900',
   example: 'jd-bg-gradient-to-br jd-from-orange-50 jd-to-orange-100 jd-border-orange-200 jd-text-orange-900',
@@ -93,7 +88,6 @@ export const BLOCK_CARD_COLORS_DARK: Record<BlockType, string> = {
   role: 'jd-bg-gradient-to-br jd-from-purple-800/40 jd-to-purple-900/40 jd-border-purple-700 jd-text-purple-200',
   context: 'jd-bg-gradient-to-br jd-from-green-800/40 jd-to-green-900/40 jd-border-green-700 jd-text-green-200',
   goal: 'jd-bg-gradient-to-br jd-from-pink-800/40 jd-to-pink-900/40 jd-border-pink-700 jd-text-pink-200',
-  content: 'jd-bg-gradient-to-br jd-from-slate-700/40 jd-to-slate-800/40 jd-border-slate-600 jd-text-slate-200',
   custom: 'jd-bg-gradient-to-br jd-from-amber-800/40 jd-to-amber-900/40 jd-border-amber-700 jd-text-amber-200',
   output_format: 'jd-bg-gradient-to-br jd-from-cyan-800/40 jd-to-cyan-900/40 jd-border-cyan-700 jd-text-cyan-200',
   example: 'jd-bg-gradient-to-br jd-from-orange-800/40 jd-to-orange-900/40 jd-border-orange-700 jd-text-orange-200',
@@ -108,7 +102,6 @@ export const BLOCK_ICON_COLORS_LIGHT: Record<BlockType, string> = {
   role: 'jd-bg-purple-100 jd-text-purple-700',
   context: 'jd-bg-green-100 jd-text-green-700',
   goal: 'jd-bg-pink-100 jd-text-pink-700',
-  content: 'jd-bg-slate-100 jd-text-slate-700',
   custom: 'jd-bg-amber-100 jd-text-amber-700',
   output_format: 'jd-bg-cyan-100 jd-text-cyan-700',
   example: 'jd-bg-orange-100 jd-text-orange-700',
@@ -122,7 +115,6 @@ export const BLOCK_ICON_COLORS_DARK: Record<BlockType, string> = {
   role: 'jd-bg-purple-800 jd-text-purple-300',
   context: 'jd-bg-green-800 jd-text-green-300',
   goal: 'jd-bg-pink-800 jd-text-pink-300',
-  content: 'jd-bg-slate-700 jd-text-slate-200',
   custom: 'jd-bg-amber-800 jd-text-amber-300',
   output_format: 'jd-bg-cyan-800 jd-text-cyan-300',
   example: 'jd-bg-orange-800 jd-text-orange-300',
@@ -136,7 +128,6 @@ export const BLOCK_TEXT_COLORS_LIGHT: Record<BlockType, string> = {
   role: 'jd-text-purple-700',
   context: 'jd-text-green-700',
   goal: 'jd-text-pink-700',
-  content: 'jd-text-slate-700',
   custom: 'jd-text-amber-700',
   output_format: 'jd-text-cyan-700',
   example: 'jd-text-orange-700',
@@ -150,7 +141,6 @@ export const BLOCK_TEXT_COLORS_DARK: Record<BlockType, string> = {
   role: 'jd-text-purple-300',
   context: 'jd-text-green-300',
   goal: 'jd-text-pink-300',
-  content: 'jd-text-slate-300',
   custom: 'jd-text-amber-300',
   output_format: 'jd-text-cyan-300',
   example: 'jd-text-orange-300',
@@ -191,7 +181,6 @@ const PROMPT_PREFIXES_FR: Record<BlockType, string> = {
   role: "Role:\n ",
   context: 'Contexte:\n ',
   goal: 'Objectif:\n ',
-  content: '',
   custom: '',
   output_format: 'Format de sortie:\n ',
   example: 'Exemples:\n ',
@@ -211,7 +200,7 @@ const escapeHtml = (str: string): string =>
     .replace(/\n/g, '<br>');
 
 export const buildPromptPart = (type: BlockType | null | undefined, content: string): string => {
-  if (!type || type === 'custom' || type === 'content') {
+  if (!type || type === 'custom') {
     return content;
   }
   const prefix = PROMPT_PREFIXES_FR[type];
@@ -219,7 +208,7 @@ export const buildPromptPart = (type: BlockType | null | undefined, content: str
 };
 
 export const buildPromptPartHtml = (type: BlockType | null | undefined, content: string, isDarkMode: boolean): string => {
-  if (!type || type === 'custom' || type === 'content') {
+  if (!type || type === 'custom') {
     return escapeHtml(content);
   }
   const prefix = PROMPT_PREFIXES_FR[type];
@@ -235,7 +224,7 @@ export const isMetadataBlock = (type: BlockType): boolean => {
 };
 
 export const isContentBlock = (type: BlockType): boolean => {
-  return type === 'content';
+  return type === 'custom';
 };
 
 export const isCustomBlock = (type: BlockType): boolean => {
@@ -247,11 +236,10 @@ export const isMultipleValueBlock = (type: BlockType): boolean => {
 };
 
 // Helper to categorize blocks for UI organization
-export const getBlockCategory = (type: BlockType): 'primary' | 'secondary' | 'multiple' | 'content' | 'custom' => {
+export const getBlockCategory = (type: BlockType): 'primary' | 'secondary' | 'multiple' | 'custom' => {
   if (['role', 'context', 'goal'].includes(type)) return 'primary';
   if (['audience', 'tone_style', 'output_format'].includes(type)) return 'secondary';
   if (['constraint', 'example'].includes(type)) return 'multiple';
-  if (type === 'content') return 'content';
   return 'custom';
 };
 
@@ -294,7 +282,7 @@ export const getSuggestedBlockTypes = (existingBlocks: Block[]): BlockType[] => 
   const available = getAvailableBlockTypesForAdding();
   
   // Prioritize missing essential types
-  const essential: BlockType[] = ['content'];
+  const essential: BlockType[] = ['custom'];
   const recommended: BlockType[] = ['example', 'constraint'];
   
   const suggestions: BlockType[] = [];

--- a/src/components/prompts/blocks/quick-selector/BlockItem.tsx
+++ b/src/components/prompts/blocks/quick-selector/BlockItem.tsx
@@ -49,7 +49,7 @@ export const BlockItem: React.FC<BlockItemProps> = ({
           <div className="jd-flex jd-items-center jd-gap-2">
             <h4 className="jd-text-sm jd-font-medium jd-truncate">{title}</h4>
             <span className="jd-text-[10px] jd-px-1.5 jd-py-0.5 jd-bg-muted jd-rounded jd-text-muted-foreground">
-              {BLOCK_TYPE_LABELS[block.type || 'content']}
+              {BLOCK_TYPE_LABELS[block.type || 'custom']}
             </span>
           </div>
           <p className="jd-text-xs jd-text-muted-foreground jd-line-clamp-1 jd-mt-0.5">

--- a/src/components/prompts/blocks/quick-selector/useBlockInsertion.ts
+++ b/src/components/prompts/blocks/quick-selector/useBlockInsertion.ts
@@ -18,7 +18,7 @@ export function useBlockInsertion(
     if (insertingRef.current) return;
     insertingRef.current = true;
     const content = getLocalizedContent(block.content);
-    let text = buildPromptPart(block.type || 'content', content);
+    let text = buildPromptPart(block.type || 'custom', content);
 
     let currentContent = '';
     if (targetElement instanceof HTMLTextAreaElement) {

--- a/src/hooks/dialogs/useCreateTemplateDialog.ts
+++ b/src/hooks/dialogs/useCreateTemplateDialog.ts
@@ -71,30 +71,17 @@ export function useCreateTemplateDialog() {
         setDescription(currentTemplate.description || '');
         setSelectedFolderId(currentTemplate.folder_id ? currentTemplate.folder_id.toString() : '');
 
-        if (currentTemplate.expanded_blocks && Array.isArray(currentTemplate.expanded_blocks)) {
-          const templateBlocks: Block[] = currentTemplate.expanded_blocks.map((block: any, index: number) => ({
-            id: block.id || Date.now() + index,
-            type: block.type || 'content',
-            content: block.content || '',
-            title: block.title,
-            description: block.description
-          }));
-          setBlocks(templateBlocks);
-        } else {
-          setContent(currentTemplate.content || '');
-          setBlocks([
-            {
-              id: Date.now(),
-              type: 'content',
-              content: currentTemplate.content || '',
-              title: { en: 'Template Content' }
-            }
-          ]);
-        }
+        setContent(currentTemplate.content || '');
+        setBlocks([
+          {
+            id: Date.now(),
+            type: 'custom',
+            content: currentTemplate.content || '',
+            title: { en: 'Template Content' }
+          }
+        ]);
 
-        if (currentTemplate.enhanced_metadata) {
-          setMetadata(currentTemplate.enhanced_metadata);
-        } else if (currentTemplate.metadata) {
+        if (currentTemplate.metadata) {
           prefillMetadataFromMapping(currentTemplate.metadata).then(setMetadata);
         }
       } else {
@@ -104,7 +91,7 @@ export function useCreateTemplateDialog() {
         setBlocks([
           {
             id: Date.now(),
-            type: 'content',
+            type: 'custom',
             content: '',
             title: { en: 'Template Content' }
           }
@@ -131,7 +118,7 @@ export function useCreateTemplateDialog() {
     setBlocks([
       {
         id: Date.now(),
-        type: 'content',
+        type: 'custom',
         content: '',
         title: { en: 'Template Content' }
       }

--- a/src/hooks/dialogs/useCustomizeTemplateDialog.ts
+++ b/src/hooks/dialogs/useCustomizeTemplateDialog.ts
@@ -45,36 +45,20 @@ export function useCustomizeTemplateDialog() {
         let templateBlocks: Block[] = [];
         let templateMetadata: PromptMetadata = { ...DEFAULT_METADATA };
 
-        if (data.expanded_blocks && Array.isArray(data.expanded_blocks)) {
-          templateBlocks = data.expanded_blocks.map((block: any, index: number) => ({
-            id: block.id || Date.now() + index,
-            type: block.type || 'content',
-            content: getLocalizedContent(block.content) || '',
-            title: block.title || { en: `${(block.type || 'content').charAt(0).toUpperCase() + (block.type || 'content').slice(1)} Block` },
-            description: block.description || ''
-          }));
-
-          // Parse enhanced metadata from blocks if available
-          if (data.enhanced_metadata) {
-            templateMetadata = parseEnhancedMetadata(data.enhanced_metadata);
-          }
-        } else if (data.content) {
+        if (data.content) {
           const contentString = getLocalizedContent(data.content);
           templateBlocks = [{
             id: Date.now(),
-            type: 'content',
+            type: 'custom',
             content: contentString,
             title: { en: 'Template Content' }
           }];
-
-          // Try to extract metadata from content structure if it follows the enhanced format
-          templateMetadata = extractMetadataFromContent(contentString);
         }
 
         setBlocks(templateBlocks);
         setMetadata(templateMetadata);
 
-        if (!data.enhanced_metadata && data.metadata) {
+        if (data.metadata) {
           prefillMetadataFromMapping(data.metadata).then(setMetadata);
         }
       } catch (err) {

--- a/src/hooks/prompts/actions/useTemplateActions.ts
+++ b/src/hooks/prompts/actions/useTemplateActions.ts
@@ -131,13 +131,10 @@ const useTemplate = useCallback(async (template: Template) => {
       title: template.title || 'Untitled Template',
       type: template.type,
       id: template.id,
-      expanded_blocks: (template as any).expanded_blocks,
       onComplete: handleTemplateComplete
     };
 
-    if ((template as any).enhanced_metadata) {
-      dialogData.enhanced_metadata = (template as any).enhanced_metadata;
-    } else if ((template as any).metadata) {
+    if ((template as any).metadata) {
       const meta = await prefillMetadataFromMapping((template as any).metadata);
       dialogData.enhanced_metadata = meta;
     }

--- a/src/hooks/prompts/useTemplateCreation.ts
+++ b/src/hooks/prompts/useTemplateCreation.ts
@@ -13,10 +13,7 @@ interface TemplateFormData {
   folder_id?: number | null;
   tags?: string[];
   locale?: string;
-  // Optional advanced editor fields
-  blocks?: number[];
   metadata?: Record<string, number | number[]>;
-  enhanced_metadata?: any;
 }
 
 interface TemplateValidationErrors {
@@ -44,9 +41,7 @@ export function useTemplateCreation() {
         metadata: data.metadata || {},
         tags: data.tags || [],
         locale: data.locale || navigator.language || 'en',
-        ...(data.blocks ? { blocks: data.blocks } : {}),
-        ...(data.metadata ? { metadata: data.metadata } : {}),
-        ...(data.enhanced_metadata ? { enhanced_metadata: data.enhanced_metadata } : {})
+        ...(data.metadata ? { metadata: data.metadata } : {})
       };
 
       console.log("TEMPLATE DATA", templateData);
@@ -89,9 +84,7 @@ export function useTemplateCreation() {
         description: data.description?.trim(),
         folder_id: data.folder_id || null,
         tags: data.tags || [],
-        ...(data.blocks ? { blocks: data.blocks } : {}),
-        ...(data.metadata ? { metadata: data.metadata } : {}),
-        ...(data.enhanced_metadata ? { enhanced_metadata: data.enhanced_metadata } : {})
+        ...(data.metadata ? { metadata: data.metadata } : {})
       };
       
       const response = await promptApi.updateTemplate(id, templateData);

--- a/src/services/api/BlocksApi.ts
+++ b/src/services/api/BlocksApi.ts
@@ -11,7 +11,6 @@ export interface BlockResponse {
   user_id?: string;
   organization_id?: string;
   company_id?: string;
-  is_owned?: boolean;
   created_at: string;
 }
 

--- a/src/services/api/prompts/templates/createTemplate.ts
+++ b/src/services/api/prompts/templates/createTemplate.ts
@@ -22,10 +22,7 @@ export async function createTemplate(templateData: any): Promise<any> {
         locale: templateData.locale || 'en',
         folder_id: templateData.folder_id || null,
         type: templateData.type || 'user',
-        // Include advanced editor fields when present
-        blocks: templateData.blocks || [],
-        metadata: templateData.metadata || {},
-        enhanced_metadata: templateData.enhanced_metadata || undefined
+        metadata: templateData.metadata || {}
       };
 
       const response = await apiClient.request('/prompts/templates', {

--- a/src/types/prompts/blocks.ts
+++ b/src/types/prompts/blocks.ts
@@ -1,15 +1,14 @@
 // src/types/prompts/blocks.ts
-export type BlockType = 
-  | 'role' 
-  | 'context' 
-  | 'goal' 
-  | 'content' 
-  | 'custom' 
-  | 'output_format' 
-  | 'example' 
-  | 'constraint' 
-  | 'tone_style' 
-  | 'audience' 
+export type BlockType =
+  | 'role'
+  | 'context'
+  | 'goal'
+  | 'custom'
+  | 'output_format'
+  | 'example'
+  | 'constraint'
+  | 'tone_style'
+  | 'audience'
   | 'thinking_step';
 
 export interface Block {

--- a/src/types/prompts/templates.ts
+++ b/src/types/prompts/templates.ts
@@ -1,12 +1,21 @@
 // src/types/prompts/templates.ts
 
-/**
- * Template interface
- */
+export interface TemplateMetadata {
+  role?: number;
+  context?: number;
+  goal?: number;
+  tone_style?: number;
+  output_format?: number;
+  audience?: number;
+  examples?: number[];
+  constraints?: number[];
+  thinking_steps?: number[];
+}
+
 export interface Template {
     id: number;
     title: string;
-    content: string;
+    content: string | Record<string, string>;
     description?: string;
     folder_id?: number | null;
     user_id?: number;
@@ -15,22 +24,10 @@ export interface Template {
     updated_at?: string;
     last_used_at?: string;
     usage_count?: number;
-    tags?: string[];
     type?: 'official' | 'organization' | 'user';
     language?: string;
     based_on_official_id?: number | null;
-    /**
-     * Mapping of metadata types to block IDs when created with the Advanced Editor
-     */
-    metadata?: Record<string, number | number[]>;
-    /**
-     * IDs of blocks used for the content section
-     */
-    blocks?: number[];
-    /**
-     * Full metadata structure including values and references
-     */
-    enhanced_metadata?: any;
+    metadata?: TemplateMetadata;
   }
   
   /**

--- a/src/types/services/api.ts
+++ b/src/types/services/api.ts
@@ -73,8 +73,8 @@ export interface ApiResponse<T = unknown> {
     content: string;
     description?: string;
     folder_id?: number | null;
-    tags?: string[];
     locale?: string;
+    metadata?: Record<string, number | number[]>;
     type?: string;
   }
   
@@ -83,7 +83,7 @@ export interface ApiResponse<T = unknown> {
     content?: string;
     description?: string;
     folder_id?: number | null;
-    tags?: string[];
+    metadata?: Record<string, number | number[]>;
   }
   
   export interface TemplateResponse {
@@ -94,7 +94,7 @@ export interface ApiResponse<T = unknown> {
       content: string;
       description?: string;
       folder_id?: number;
-      tags?: string[];
+      metadata?: Record<string, number | number[]>;
       created_at: string;
       [key: string]: any;
     };


### PR DESCRIPTION
## Summary
- remove deprecated `content` block type and add `TemplateMetadata` model
- adjust block utilities and dialogs to use `custom` for content blocks
- drop unused block fields when creating/updating templates
- sync API and type definitions with backend changes

## Testing
- `pnpm lint` *(fails: 432 errors)*
- `pnpm type-check`

------
https://chatgpt.com/codex/tasks/task_b_6846ac25aacc83259f59d68f12e6a551