### PR TITLE
Improve AdvancedEditor preview

### DIFF
--- a/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
@@ -50,8 +50,6 @@ export const CreateTemplateDialog: React.FC = () => {
             <AdvancedEditor
               blocks={dialog.blocks}
               metadata={dialog.metadata}
-              onAddBlock={dialog.handleAddBlock}
-              onRemoveBlock={dialog.handleRemoveBlock}
               onUpdateBlock={dialog.handleUpdateBlock}
               onReorderBlocks={dialog.handleReorderBlocks}
               onUpdateMetadata={dialog.handleUpdateMetadata}

--- a/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
@@ -64,8 +64,6 @@ export const CustomizeTemplateDialog: React.FC = () => {
   const advancedProps = {
     blocks,
     metadata,
-    onAddBlock: handleAddBlock,
-    onRemoveBlock: handleRemoveBlock,
     onUpdateBlock: handleUpdateBlock,
     onReorderBlocks: handleReorderBlocks,
     onUpdateMetadata: handleUpdateMetadata,

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/SeparatedPreviewSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/SeparatedPreviewSection.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Eye } from 'lucide-react';
+
+interface SeparatedPreviewSectionProps {
+  beforeHtml: string;
+  contentHtml: string;
+  afterHtml: string;
+}
+
+export const SeparatedPreviewSection: React.FC<SeparatedPreviewSectionProps> = ({
+  beforeHtml,
+  contentHtml,
+  afterHtml
+}) => {
+  return (
+    <div className="jd-space-y-3 jd-flex-shrink-0">
+      <h3 className="jd-text-lg jd-font-semibold jd-flex jd-items-center jd-gap-2">
+        <Eye className="jd-h-5 jd-w-5" />
+        Preview
+      </h3>
+      <div className="jd-border jd-rounded-lg jd-bg-background jd-text-sm jd-leading-relaxed jd-p-4 jd-space-y-4">
+        {beforeHtml && (
+          <div className="jd-border jd-border-dashed jd-rounded jd-p-3" dangerouslySetInnerHTML={{ __html: beforeHtml }} />
+        )}
+        {contentHtml && (
+          <div className="jd-border jd-border-dashed jd-rounded jd-p-3" dangerouslySetInnerHTML={{ __html: contentHtml }} />
+        )}
+        {afterHtml && (
+          <div className="jd-border jd-border-dashed jd-rounded jd-p-3" dangerouslySetInnerHTML={{ __html: afterHtml }} />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
@@ -8,20 +8,12 @@ import { cn } from '@/core/utils/classNames';
 import { BLOCK_TYPES } from '../../../prompts/blocks/blockUtils';
 
 import { MetadataSection } from './MetadataSection';
-import { ContentSection } from './ContentSection';
-import { EnhancedPreviewSection } from './EnhancedPreviewSection';
+import { SeparatedPreviewSection } from './SeparatedPreviewSection';
 import { useAdvancedEditorLogic } from '@/hooks/prompts/editors/useAdvancedEditorLogic';
 
 interface AdvancedEditorProps {
   blocks: Block[];
   metadata?: PromptMetadata;
-  onAddBlock: (
-    position: 'start' | 'end',
-    blockType?: BlockType | null,
-    existingBlock?: Block,
-    duplicate?: boolean
-  ) => void;
-  onRemoveBlock: (blockId: number) => void;
   onUpdateBlock: (blockId: number, updatedBlock: Partial<Block>) => void;
   onReorderBlocks: (blocks: Block[]) => void;
   onUpdateMetadata?: (metadata: PromptMetadata) => void;
@@ -31,8 +23,6 @@ interface AdvancedEditorProps {
 export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   blocks,
   metadata = DEFAULT_METADATA,
-  onAddBlock,
-  onRemoveBlock,
   onUpdateBlock,
   onReorderBlocks,
   onUpdateMetadata,
@@ -43,7 +33,6 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   const {
     // Available blocks state
     availableMetadataBlocks,
-    availableBlocksByType,
     
     // UI state
     expandedMetadata,
@@ -57,12 +46,6 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
     setMetadataCollapsed,
     secondaryMetadataCollapsed,
     setSecondaryMetadataCollapsed,
-    
-    // Drag and drop
-    draggedBlockId,
-    handleDragStart,
-    handleDragOver,
-    handleDragEnd,
     
     // Metadata handlers
     handleSingleMetadataChange,
@@ -150,28 +133,17 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
           onSaveBlock={handleMetadataBlockSaved}
         />
 
-        {/* Content Section */}
-        <ContentSection
-          blocks={blocks}
-          availableBlocksByType={availableBlocksByType}
-          draggedBlockId={draggedBlockId}
-          onAddBlock={onAddBlock}
-          onRemoveBlock={onRemoveBlock}
-          onUpdateBlock={onUpdateBlock}
-          onDragStart={handleDragStart}
-          onDragOver={handleDragOver}
-          onDragEnd={handleDragEnd}
-          onBlockSaved={handleBlockSaved}
-        />
-
         {/* Preview Section */}
-        <EnhancedPreviewSection
-          content={generatePreviewContent()}
-          htmlContent={generatePreviewHtml()}
-          expanded={previewExpanded}
-          onToggle={() => setPreviewExpanded(!previewExpanded)}
-          metadataBlockMapping={getMetadataBlockMapping()}
-        />
+        {(() => {
+          const { before, content, after } = generateSeparatedPreviewHtml();
+          return (
+            <SeparatedPreviewSection
+              beforeHtml={before}
+              contentHtml={content}
+              afterHtml={after}
+            />
+          );
+        })()}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `SeparatedPreviewSection` for a new preview layout
- update `AdvancedEditor` to use new preview component and drop content editor
- adjust dialogs to pass new props
- generate preview sections from `useAdvancedEditorLogic`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6846b79f39488325889d32c7c9446e12