### PR TITLE
Add content editing to AdvancedEditor

### DIFF
--- a/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
@@ -50,6 +50,8 @@ export const CreateTemplateDialog: React.FC = () => {
             <AdvancedEditor
               blocks={dialog.blocks}
               metadata={dialog.metadata}
+              onAddBlock={dialog.handleAddBlock}
+              onRemoveBlock={dialog.handleRemoveBlock}
               onUpdateBlock={dialog.handleUpdateBlock}
               onReorderBlocks={dialog.handleReorderBlocks}
               onUpdateMetadata={dialog.handleUpdateMetadata}

--- a/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
@@ -64,6 +64,8 @@ export const CustomizeTemplateDialog: React.FC = () => {
   const advancedProps = {
     blocks,
     metadata,
+    onAddBlock: handleAddBlock,
+    onRemoveBlock: handleRemoveBlock,
     onUpdateBlock: handleUpdateBlock,
     onReorderBlocks: handleReorderBlocks,
     onUpdateMetadata: handleUpdateMetadata,

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
@@ -9,11 +9,19 @@ import { BLOCK_TYPES } from '../../../prompts/blocks/blockUtils';
 
 import { MetadataSection } from './MetadataSection';
 import { SeparatedPreviewSection } from './SeparatedPreviewSection';
+import { ContentSection } from './ContentSection';
 import { useAdvancedEditorLogic } from '@/hooks/prompts/editors/useAdvancedEditorLogic';
 
 interface AdvancedEditorProps {
   blocks: Block[];
   metadata?: PromptMetadata;
+  onAddBlock: (
+    position: 'start' | 'end',
+    blockType?: BlockType | null,
+    existingBlock?: Block,
+    duplicate?: boolean
+  ) => void;
+  onRemoveBlock: (blockId: number) => void;
   onUpdateBlock: (blockId: number, updatedBlock: Partial<Block>) => void;
   onReorderBlocks: (blocks: Block[]) => void;
   onUpdateMetadata?: (metadata: PromptMetadata) => void;
@@ -23,6 +31,8 @@ interface AdvancedEditorProps {
 export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   blocks,
   metadata = DEFAULT_METADATA,
+  onAddBlock,
+  onRemoveBlock,
   onUpdateBlock,
   onReorderBlocks,
   onUpdateMetadata,
@@ -33,6 +43,7 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   const {
     // Available blocks state
     availableMetadataBlocks,
+    availableBlocksByType,
     
     // UI state
     expandedMetadata,
@@ -58,6 +69,10 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
     removeSecondaryMetadata,
     
     // Block handlers
+    draggedBlockId,
+    handleDragStart,
+    handleDragOver,
+    handleDragEnd,
     handleBlockSaved,
     handleMetadataBlockSaved,
     
@@ -131,6 +146,20 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
           onAddSecondaryMetadata={addSecondaryMetadata}
           onRemoveSecondaryMetadata={removeSecondaryMetadata}
           onSaveBlock={handleMetadataBlockSaved}
+        />
+
+        {/* Content Section */}
+        <ContentSection
+          blocks={blocks}
+          availableBlocksByType={availableBlocksByType}
+          draggedBlockId={draggedBlockId}
+          onAddBlock={onAddBlock}
+          onRemoveBlock={onRemoveBlock}
+          onUpdateBlock={onUpdateBlock}
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
+          onDragEnd={handleDragEnd}
+          onBlockSaved={handleBlockSaved}
         />
 
         {/* Preview Section */}


### PR DESCRIPTION
## Summary
- wire up AdvancedEditor so users can add content blocks
- pass add and remove handlers from dialogs to the editor

## Testing
- `npm run lint` *(fails: no-unused-vars, no-explicit-any, etc.)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6846c8da4ab88325acf67f2f8e721095