### PR TITLE
Fix empty content state in advanced editor

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/ContentSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/ContentSection.tsx
@@ -49,11 +49,15 @@ export const ContentSection: React.FC<ContentSectionProps> = ({
 
       <div className="jd-flex-1 jd-flex jd-flex-col jd-min-h-0 jd-space-y-4">
         {/* Main Content Block */}
-        {contentBlock && (
+        {contentBlock ? (
           <MainContentBlock
             block={contentBlock}
             onUpdateBlock={onUpdateBlock}
           />
+        ) : (
+          <div className="jd-flex jd-items-center jd-justify-center jd-min-h-[200px] jd-border jd-border-dashed jd-rounded-md jd-text-sm jd-text-muted-foreground">
+            No prompt content yet. Use the button below to add your first block.
+          </div>
         )}
 
         {/* Additional Blocks */}

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
@@ -148,7 +148,19 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
           onSaveBlock={handleMetadataBlockSaved}
         />
 
-       
+        {/* Content Section */}
+        <ContentSection
+          blocks={blocks}
+          availableBlocksByType={availableBlocksByType}
+          draggedBlockId={draggedBlockId}
+          onAddBlock={onAddBlock}
+          onRemoveBlock={onRemoveBlock}
+          onUpdateBlock={onUpdateBlock}
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
+          onDragEnd={handleDragEnd}
+          onBlockSaved={handleBlockSaved}
+        />
 
         {/* Preview Section */}
         {(() => {


### PR DESCRIPTION
## Summary
- restore `ContentSection` in `AdvancedEditor`
- show a placeholder message when no content blocks exist

## Testing
- `pnpm lint` *(fails: no-empty, no-unused-vars, etc.)*
- `pnpm type-check`

------
https://chatgpt.com/codex/tasks/task_b_6846cd4411888325be9ca320b067b776