### PR TITLE
Refactor AdvancedEditor UI

### DIFF
--- a/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
@@ -48,14 +48,10 @@ export const CreateTemplateDialog: React.FC = () => {
 
           <TabsContent value="advanced" className="jd-flex-1 jd-overflow-y-auto jd-mt-4">
             <AdvancedEditor
-              blocks={dialog.blocks}
+              content={dialog.content}
               metadata={dialog.metadata}
-              onAddBlock={dialog.handleAddBlock}
-              onRemoveBlock={dialog.handleRemoveBlock}
-              onUpdateBlock={dialog.handleUpdateBlock}
-              onReorderBlocks={dialog.handleReorderBlocks}
+              onContentChange={dialog.setContent}
               onUpdateMetadata={dialog.handleUpdateMetadata}
-              isProcessing={false}
             />
           </TabsContent>
         </Tabs>

--- a/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
@@ -21,6 +21,8 @@ export const CustomizeTemplateDialog: React.FC = () => {
     isProcessing,
     activeTab,
     setActiveTab,
+    content,
+    setContent,
     handleAddBlock,
     handleRemoveBlock,
     handleUpdateBlock,
@@ -62,12 +64,9 @@ export const CustomizeTemplateDialog: React.FC = () => {
   };
 
   const advancedProps = {
-    blocks,
+    content,
     metadata,
-    onAddBlock: handleAddBlock,
-    onRemoveBlock: handleRemoveBlock,
-    onUpdateBlock: handleUpdateBlock,
-    onReorderBlocks: handleReorderBlocks,
+    onContentChange: setContent,
     onUpdateMetadata: handleUpdateMetadata,
     isProcessing
   };

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
@@ -1,64 +1,40 @@
-// src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
-import React, { useState, useEffect } from 'react';
-import { Block, BlockType } from '@/types/prompts/blocks';
-import { PromptMetadata, DEFAULT_METADATA } from '@/types/prompts/metadata';
-import { blocksApi } from '@/services/api/BlocksApi';
-import { useThemeDetector } from '@/hooks/useThemeDetector';
+import React, { useState } from 'react';
+import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/core/utils/classNames';
-import { BLOCK_TYPES } from '../../../prompts/blocks/blockUtils';
-
+import { useThemeDetector } from '@/hooks/useThemeDetector';
+import { PromptMetadata, DEFAULT_METADATA } from '@/types/prompts/metadata';
 import { MetadataSection } from './MetadataSection';
 import { SeparatedPreviewSection } from './SeparatedPreviewSection';
-import { ContentSection } from './ContentSection';
-import { useAdvancedEditorLogic } from '@/hooks/prompts/editors/useAdvancedEditorLogic';
+import { buildCompletePromptPreview } from '@/components/prompts/promptUtils';
+import { highlightPlaceholders } from '@/utils/templates/placeholderHelpers';
+import { useSimpleMetadata } from '@/hooks/prompts/editors/useSimpleMetadata';
 
 interface AdvancedEditorProps {
-  blocks: Block[];
+  content: string;
   metadata?: PromptMetadata;
-  onAddBlock: (
-    position: 'start' | 'end',
-    blockType?: BlockType | null,
-    existingBlock?: Block,
-    duplicate?: boolean
-  ) => void;
-  onRemoveBlock: (blockId: number) => void;
-  onUpdateBlock: (blockId: number, updatedBlock: Partial<Block>) => void;
-  onReorderBlocks: (blocks: Block[]) => void;
+  onContentChange: (value: string) => void;
   onUpdateMetadata?: (metadata: PromptMetadata) => void;
-  isProcessing: boolean;
+  isProcessing?: boolean;
 }
 
 export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
-  blocks,
+  content,
   metadata = DEFAULT_METADATA,
-  onAddBlock,
-  onRemoveBlock,
-  onUpdateBlock,
-  onReorderBlocks,
+  onContentChange,
   onUpdateMetadata,
-  isProcessing
+  isProcessing = false
 }) => {
   const isDarkMode = useThemeDetector();
-  
+  const [showPreview, setShowPreview] = useState(false);
+
   const {
-    // Available blocks state
-    availableMetadataBlocks,
-    availableBlocksByType,
-    
-    // UI state
     expandedMetadata,
     setExpandedMetadata,
-    previewExpanded,
-    setPreviewExpanded,
     activeSecondaryMetadata,
-    
-    // Collapsible sections
     metadataCollapsed,
     setMetadataCollapsed,
     secondaryMetadataCollapsed,
     setSecondaryMetadataCollapsed,
-    
-    // Metadata handlers
     handleSingleMetadataChange,
     handleCustomChange,
     handleAddMetadataItem,
@@ -66,37 +42,20 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
     handleUpdateMetadataItem,
     handleReorderMetadataItems,
     addSecondaryMetadata,
-    removeSecondaryMetadata,
-    
-    // Block handlers
-    draggedBlockId,
-    handleDragStart,
-    handleDragOver,
-    handleDragEnd,
-    handleBlockSaved,
-    handleMetadataBlockSaved,
-    
-    // Preview content generation
-    generatePreviewContent,
-    generatePreviewHtml,
-    
-    // Get metadata block mapping for template saving
-    getMetadataBlockMapping
-  } = useAdvancedEditorLogic({
-    metadata,
-    onUpdateMetadata,
-    blocks,
-    onUpdateBlock,
-    onReorderBlocks
-  });
+    removeSecondaryMetadata
+  } = useSimpleMetadata({ metadata, onUpdateMetadata });
 
   if (isProcessing) {
     return (
       <div className="jd-flex jd-items-center jd-justify-center jd-h-full">
-        <div className="jd-animate-spin jd-h-8 jd-w-8 jd-border-4 jd-border-primary jd-border-t-transparent jd-rounded-full"></div>
+        <div className="jd-animate-spin jd-h-8 jd-w-8 jd-border-4 jd-border-primary jd-border-t-transparent jd-rounded-full" />
       </div>
     );
   }
+
+  const previewHtml = highlightPlaceholders(
+    buildCompletePromptPreview(metadata, [{ id: 1, type: 'custom', content }])
+  );
 
   return (
     <div
@@ -107,28 +66,9 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
           : 'jd-bg-gradient-to-br jd-from-slate-50 jd-via-white jd-to-slate-100'
       )}
     >
-      {/* Animated background mesh */}
-      <div className="jd-absolute jd-inset-0 jd-opacity-10">
-        <div className={cn(
-          'jd-absolute jd-inset-0',
-          isDarkMode
-            ? 'jd-bg-[radial-gradient(ellipse_at_top_left,_var(--tw-gradient-stops))] jd-from-purple-900 jd-via-transparent jd-to-transparent'
-            : 'jd-bg-[radial-gradient(ellipse_at_top_left,_var(--tw-gradient-stops))] jd-from-purple-200 jd-via-transparent jd-to-transparent'
-        )}></div>
-        <div className={cn(
-          'jd-absolute jd-inset-0',
-          isDarkMode
-            ? 'jd-bg-[radial-gradient(ellipse_at_bottom_right,_var(--tw-gradient-stops))] jd-from-blue-900 jd-via-transparent jd-to-transparent'
-            : 'jd-bg-[radial-gradient(ellipse_at_bottom_right,_var(--tw-gradient-stops))] jd-from-blue-200 jd-via-transparent jd-to-transparent'
-        )}></div>
-      </div>
-
-      {/* Content wrapper */}
-      <div className="jd-relative jd-z-10 jd-flex-1 jd-flex jd-flex-col jd-space-y-4 jd-p-6 jd-overflow-hidden">
-        
-        {/* Metadata Section */}
+      <div className="jd-relative jd-z-10 jd-flex-1 jd-flex jd-flex-col jd-space-y-4 jd-p-6 jd-overflow-y-auto">
         <MetadataSection
-          availableMetadataBlocks={availableMetadataBlocks}
+          availableMetadataBlocks={{}}
           metadata={metadata}
           expandedMetadata={expandedMetadata}
           setExpandedMetadata={setExpandedMetadata}
@@ -145,34 +85,31 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
           onReorderMetadataItems={handleReorderMetadataItems}
           onAddSecondaryMetadata={addSecondaryMetadata}
           onRemoveSecondaryMetadata={removeSecondaryMetadata}
-          onSaveBlock={handleMetadataBlockSaved}
+          onSaveBlock={() => {}}
         />
 
-        {/* Content Section */}
-        <ContentSection
-          blocks={blocks}
-          availableBlocksByType={availableBlocksByType}
-          draggedBlockId={draggedBlockId}
-          onAddBlock={onAddBlock}
-          onRemoveBlock={onRemoveBlock}
-          onUpdateBlock={onUpdateBlock}
-          onDragStart={handleDragStart}
-          onDragOver={handleDragOver}
-          onDragEnd={handleDragEnd}
-          onBlockSaved={handleBlockSaved}
-        />
+        <div className="jd-space-y-2">
+          <h3 className="jd-text-lg jd-font-semibold">Main Content</h3>
+          <Textarea
+            value={content}
+            onChange={e => onContentChange(e.target.value)}
+            className="jd-min-h-[200px] jd-text-sm jd-resize-none"
+            placeholder="Enter prompt content..."
+          />
+        </div>
 
-        {/* Preview Section */}
-        {(() => {
-          const { before, content, after } = generateSeparatedPreviewHtml();
-          return (
-            <SeparatedPreviewSection
-              beforeHtml={before}
-              contentHtml={content}
-              afterHtml={after}
-            />
-          );
-        })()}
+        <div className="jd-pt-2">
+          <button
+            className="jd-px-3 jd-py-2 jd-rounded jd-bg-primary jd-text-primary-foreground hover:jd-bg-primary/90 jd-transition"
+            onClick={() => setShowPreview(prev => !prev)}
+          >
+            {showPreview ? 'Hide Preview' : 'Show Preview'}
+          </button>
+        </div>
+
+        {showPreview && (
+          <SeparatedPreviewSection beforeHtml="" contentHtml={previewHtml} afterHtml="" />
+        )}
       </div>
     </div>
   );

--- a/src/hooks/dialogs/useCreateTemplateDialog.ts
+++ b/src/hooks/dialogs/useCreateTemplateDialog.ts
@@ -317,6 +317,8 @@ export function useCreateTemplateDialog() {
     handleFolderSelect,
     userFoldersList,
     validationErrors,
+    content,
+    setContent,
     blocks,
     metadata,
     activeTab,

--- a/src/hooks/dialogs/useCustomizeTemplateDialog.ts
+++ b/src/hooks/dialogs/useCustomizeTemplateDialog.ts
@@ -31,6 +31,7 @@ import { prefillMetadataFromMapping } from '@/utils/templates/metadataPrefill';
 
 export function useCustomizeTemplateDialog() {
   const { isOpen, data, dialogProps } = useDialog('placeholderEditor');
+  const [content, setContent] = useState('');
   const [blocks, setBlocks] = useState<Block[]>([]);
   const [metadata, setMetadata] = useState<PromptMetadata>(DEFAULT_METADATA);
   const [error, setError] = useState<string | null>(null);
@@ -47,12 +48,15 @@ export function useCustomizeTemplateDialog() {
 
         if (data.content) {
           const contentString = getLocalizedContent(data.content);
+          setContent(contentString);
           templateBlocks = [{
             id: Date.now(),
             type: 'custom',
             content: contentString,
             title: { en: 'Template Content' }
           }];
+        } else {
+          setContent('');
         }
 
         setBlocks(templateBlocks);
@@ -166,7 +170,15 @@ export function useCustomizeTemplateDialog() {
   };
 
   const handleUpdateBlock = (blockId: number, updatedBlock: Partial<Block>) => {
-    setBlocks(prev => updateBlockUtil(prev, blockId, updatedBlock));
+    setBlocks(prev => {
+      const newBlocks = updateBlockUtil(prev, blockId, updatedBlock);
+      if (newBlocks.length > 0 && newBlocks[0].id === blockId) {
+        const first = newBlocks[0];
+        const newContent = typeof first.content === 'string' ? first.content : getLocalizedContent(first.content);
+        setContent(newContent);
+      }
+      return newBlocks;
+    });
   };
 
   const handleMoveBlock = (blockId: number, direction: 'up' | 'down') => {
@@ -241,6 +253,8 @@ export function useCustomizeTemplateDialog() {
   return {
     isOpen,
     error,
+    content,
+    setContent,
     blocks,
     metadata,
     isProcessing,

--- a/src/hooks/prompts/editors/useSimpleMetadata.tsx
+++ b/src/hooks/prompts/editors/useSimpleMetadata.tsx
@@ -1,0 +1,137 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  PromptMetadata,
+  MetadataType,
+  SingleMetadataType,
+  MultipleMetadataType,
+  MetadataItem,
+  PRIMARY_METADATA,
+  SECONDARY_METADATA,
+  isMultipleMetadataType,
+  generateMetadataItemId
+} from '@/types/prompts/metadata';
+
+interface UseSimpleMetadataProps {
+  metadata: PromptMetadata;
+  onUpdateMetadata?: (metadata: PromptMetadata) => void;
+}
+
+export function useSimpleMetadata({ metadata, onUpdateMetadata }: UseSimpleMetadataProps) {
+  const [expandedMetadata, setExpandedMetadata] = useState<MetadataType | null>(null);
+  const [activeSecondaryMetadata, setActiveSecondaryMetadata] = useState<Set<MetadataType>>(new Set());
+  const [metadataCollapsed, setMetadataCollapsed] = useState(false);
+  const [secondaryMetadataCollapsed, setSecondaryMetadataCollapsed] = useState(false);
+
+  useEffect(() => {
+    const active = new Set<MetadataType>();
+    SECONDARY_METADATA.forEach(type => {
+      if (isMultipleMetadataType(type)) {
+        const items = metadata[type as MultipleMetadataType];
+        if (items && items.length > 0) active.add(type);
+      } else {
+        const value = metadata.values?.[type as SingleMetadataType];
+        if (value) active.add(type);
+      }
+    });
+    setActiveSecondaryMetadata(active);
+  }, [metadata]);
+
+  const handleSingleMetadataChange = useCallback(
+    (type: SingleMetadataType, value: string) => {
+      if (!onUpdateMetadata) return;
+      const newValues = { ...(metadata.values || {}), [type]: value };
+      onUpdateMetadata({ ...metadata, values: newValues });
+    },
+    [metadata, onUpdateMetadata]
+  );
+
+  const handleCustomChange = handleSingleMetadataChange;
+
+  const handleAddMetadataItem = useCallback(
+    (type: MultipleMetadataType) => {
+      if (!onUpdateMetadata) return;
+      const items = metadata[type] || [];
+      onUpdateMetadata({ ...metadata, [type]: [...items, { id: generateMetadataItemId(), value: '' }] });
+    },
+    [metadata, onUpdateMetadata]
+  );
+
+  const handleRemoveMetadataItem = useCallback(
+    (type: MultipleMetadataType, itemId: string) => {
+      if (!onUpdateMetadata) return;
+      const items = (metadata[type] || []).filter(i => i.id !== itemId);
+      onUpdateMetadata({ ...metadata, [type]: items });
+    },
+    [metadata, onUpdateMetadata]
+  );
+
+  const handleUpdateMetadataItem = useCallback(
+    (type: MultipleMetadataType, itemId: string, updates: Partial<MetadataItem>) => {
+      if (!onUpdateMetadata) return;
+      const items = (metadata[type] || []).map(i => (i.id === itemId ? { ...i, ...updates } : i));
+      onUpdateMetadata({ ...metadata, [type]: items });
+    },
+    [metadata, onUpdateMetadata]
+  );
+
+  const handleReorderMetadataItems = useCallback(
+    (type: MultipleMetadataType, newItems: MetadataItem[]) => {
+      if (!onUpdateMetadata) return;
+      onUpdateMetadata({ ...metadata, [type]: newItems });
+    },
+    [metadata, onUpdateMetadata]
+  );
+
+  const addSecondaryMetadata = useCallback(
+    (type: MetadataType) => {
+      setActiveSecondaryMetadata(prev => new Set([...prev, type]));
+      if (!onUpdateMetadata) return;
+      if (isMultipleMetadataType(type)) {
+        onUpdateMetadata({ ...metadata, [type]: [] });
+      } else {
+        const newValues = { ...(metadata.values || {}), [type as SingleMetadataType]: '' };
+        onUpdateMetadata({ ...metadata, values: newValues });
+      }
+    },
+    [metadata, onUpdateMetadata]
+  );
+
+  const removeSecondaryMetadata = useCallback(
+    (type: MetadataType) => {
+      setActiveSecondaryMetadata(prev => {
+        const n = new Set(prev);
+        n.delete(type);
+        return n;
+      });
+      if (!onUpdateMetadata) return;
+      const newMetadata = { ...metadata } as PromptMetadata;
+      if (isMultipleMetadataType(type)) {
+        delete (newMetadata as any)[type];
+      } else {
+        const values = { ...(metadata.values || {}) };
+        delete values[type as SingleMetadataType];
+        newMetadata.values = values;
+      }
+      onUpdateMetadata(newMetadata);
+    },
+    [metadata, onUpdateMetadata]
+  );
+
+  return {
+    expandedMetadata,
+    setExpandedMetadata,
+    activeSecondaryMetadata,
+    metadataCollapsed,
+    setMetadataCollapsed,
+    secondaryMetadataCollapsed,
+    setSecondaryMetadataCollapsed,
+    handleSingleMetadataChange,
+    handleCustomChange,
+    handleAddMetadataItem,
+    handleRemoveMetadataItem,
+    handleUpdateMetadataItem,
+    handleReorderMetadataItems,
+    addSecondaryMetadata,
+    removeSecondaryMetadata
+  };
+}


### PR DESCRIPTION
## Summary
- remove old block-based logic from AdvancedEditor
- add simplified metadata hook
- update template dialogs to use the new editor API

## Testing
- `npm run lint` *(fails: 435 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6846e51d4534832580ae2bd9f706113e