### PR TITLE
Rearrange metadata in AdvancedEditor

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/MetadataSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/MetadataSection.tsx
@@ -50,6 +50,8 @@ interface MetadataSectionProps {
   onAddSecondaryMetadata: (type: MetadataType) => void;
   onRemoveSecondaryMetadata: (type: MetadataType) => void;
   onSaveBlock: (block: Block) => void;
+  showPrimary?: boolean;
+  showSecondary?: boolean;
 }
 
 export const MetadataSection: React.FC<MetadataSectionProps> = ({
@@ -70,7 +72,9 @@ export const MetadataSection: React.FC<MetadataSectionProps> = ({
   onReorderMetadataItems,
   onAddSecondaryMetadata,
   onRemoveSecondaryMetadata,
-  onSaveBlock
+  onSaveBlock,
+  showPrimary = true,
+  showSecondary = true
 }) => {
   const isDarkMode = useThemeDetector();
 
@@ -91,133 +95,135 @@ export const MetadataSection: React.FC<MetadataSectionProps> = ({
 
   return (
     <>
-      {/* Primary Metadata Row - Collapsible */}
-      <div className="jd-flex-shrink-0">
-        <div className="jd-flex jd-items-center jd-justify-between jd-mb-3">
-          <h3 className="jd-text-lg jd-font-semibold jd-flex jd-items-center jd-gap-2">
-            Prompt Essentials
-          </h3>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setMetadataCollapsed(!metadataCollapsed)}
-            className="jd-h-6 jd-w-6 jd-p-0"
-          >
-            {metadataCollapsed ? <ChevronDown className="jd-h-4 jd-w-4" /> : <ChevronUp className="jd-h-4 jd-w-4" />}
-          </Button>
-        </div>
-        
-        {!metadataCollapsed && (
-          <div className="jd-grid jd-grid-cols-3 jd-gap-4">
-            {PRIMARY_METADATA.map((type) => (
-              <div key={type} className="jd-transform jd-transition-all jd-duration-300 hover:jd-scale-105">
-                <MetadataCard
-                  type={type}
-                  icon={METADATA_ICONS[type]}
-                  availableBlocks={availableMetadataBlocks[type] || []}
-                  expanded={expandedMetadata === type}
-                  selectedId={metadata[type] || 0}
-                  customValue={customValues[type] || ''}
-                  isPrimary
-                  onSelect={(v) => onSingleMetadataChange(type, v)}
-                  onCustomChange={(v) => onCustomChange(type, v)}
-                  onToggle={() => setExpandedMetadata(expandedMetadata === type ? null : type)}
-                  onSaveBlock={onSaveBlock}
-                />
-              </div>
-            ))}
+      {showPrimary && (
+        <div className="jd-flex-shrink-0">
+          <div className="jd-flex jd-items-center jd-justify-between jd-mb-3">
+            <h3 className="jd-text-lg jd-font-semibold jd-flex jd-items-center jd-gap-2">
+              Prompt Essentials
+            </h3>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setMetadataCollapsed(!metadataCollapsed)}
+              className="jd-h-6 jd-w-6 jd-p-0"
+            >
+              {metadataCollapsed ? <ChevronDown className="jd-h-4 jd-w-4" /> : <ChevronUp className="jd-h-4 jd-w-4" />}
+            </Button>
           </div>
-        )}
-      </div>
 
-      {/* Secondary Metadata Row - Collapsible */}
-      <div className="jd-flex-shrink-0">
-        <div className="jd-flex jd-items-center jd-justify-between jd-mb-3">
-          <h4 className="jd-text-sm jd-font-medium jd-text-muted-foreground jd-flex jd-items-center jd-gap-2">
-            Additional Elements
-          </h4>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setSecondaryMetadataCollapsed(!secondaryMetadataCollapsed)}
-            className="jd-h-6 jd-w-6 jd-p-0"
-          >
-            {secondaryMetadataCollapsed ? <ChevronDown className="jd-h-4 jd-w-4" /> : <ChevronUp className="jd-h-4 jd-w-4" />}
-          </Button>
-        </div>
-        
-        {!secondaryMetadataCollapsed && (
-          <>
-            {activeSecondaryMetadata.size > 0 && (
-              <div className="jd-grid jd-grid-cols-2 jd-gap-3 jd-mb-3">
-                {Array.from(activeSecondaryMetadata).map((type) => (
-                  <div key={type} className="jd-transform jd-transition-all jd-duration-300 hover:jd-scale-105">
-                    {isMultipleMetadataType(type) ? (
-                      <MultipleMetadataCard
-                        type={type}
-                        icon={METADATA_ICONS[type]}
-                        availableBlocks={availableMetadataBlocks[type] || []}
-                        items={metadata[type] || []}
-                        expanded={expandedMetadata === type}
-                        onAddItem={() => onAddMetadataItem(type)}
-                        onRemoveItem={(itemId) => onRemoveMetadataItem(type, itemId)}
-                        onUpdateItem={(itemId, updates) => onUpdateMetadataItem(type, itemId, updates)}
-                        onToggle={() => setExpandedMetadata(expandedMetadata === type ? null : type)}
-                        onRemove={() => onRemoveSecondaryMetadata(type)}
-                        onSaveBlock={onSaveBlock}
-                        onReorderItems={(newItems) => onReorderMetadataItems(type, newItems)}
-                      />
-                    ) : (
-                      <MetadataCard
-                        type={type as SingleMetadataType}
-                        icon={METADATA_ICONS[type]}
-                        availableBlocks={availableMetadataBlocks[type] || []}
-                        expanded={expandedMetadata === type}
-                        selectedId={metadata[type as SingleMetadataType] || 0}
-                        customValue={customValues[type as SingleMetadataType] || ''}
-                        onSelect={(v) => onSingleMetadataChange(type as SingleMetadataType, v)}
-                        onCustomChange={(v) => onCustomChange(type as SingleMetadataType, v)}
-                        onToggle={() => setExpandedMetadata(expandedMetadata === type ? null : type)}
-                        onRemove={() => onRemoveSecondaryMetadata(type)}
-                        onSaveBlock={onSaveBlock}
-                      />
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-            
-            <div className="jd-flex jd-flex-wrap jd-gap-2">
-              {SECONDARY_METADATA
-                .filter(type => !activeSecondaryMetadata.has(type))
-                .map((type) => {
-                  const config = METADATA_CONFIGS[type];
-                  const Icon = METADATA_ICONS[type];
-                  return (
-                    <Button
-                      key={type}
-                      variant="outline"
-                      size="sm"
-                      onClick={() => onAddSecondaryMetadata(type)}
-                      className={cn(
-                        'jd-flex jd-items-center jd-gap-1 jd-text-xs',
-                        'jd-transition-all jd-duration-300',
-                        'hover:jd-scale-105 hover:jd-shadow-md',
-                        isDarkMode 
-                          ? 'jd-bg-gray-800/50 hover:jd-bg-gray-700/50' 
-                          : 'jd-bg-white/70 hover:jd-bg-white/90'
-                      )}
-                    >
-                      <Plus className="jd-h-3 jd-w-3" />
-                      <Icon className="jd-h-3 jd-w-3" />
-                      {config.label}
-                    </Button>
-                  );
-                })}
+          {!metadataCollapsed && (
+            <div className="jd-grid jd-grid-cols-3 jd-gap-4">
+              {PRIMARY_METADATA.map((type) => (
+                <div key={type} className="jd-transform jd-transition-all jd-duration-300 hover:jd-scale-105">
+                  <MetadataCard
+                    type={type}
+                    icon={METADATA_ICONS[type]}
+                    availableBlocks={availableMetadataBlocks[type] || []}
+                    expanded={expandedMetadata === type}
+                    selectedId={metadata[type] || 0}
+                    customValue={customValues[type] || ''}
+                    isPrimary
+                    onSelect={(v) => onSingleMetadataChange(type, v)}
+                    onCustomChange={(v) => onCustomChange(type, v)}
+                    onToggle={() => setExpandedMetadata(expandedMetadata === type ? null : type)}
+                    onSaveBlock={onSaveBlock}
+                  />
+                </div>
+              ))}
             </div>
-          </>
-        )}
-      </div>
+          )}
+        </div>
+      )}
+
+      {showSecondary && (
+        <div className="jd-flex-shrink-0">
+          <div className="jd-flex jd-items-center jd-justify-between jd-mb-3">
+            <h4 className="jd-text-sm jd-font-medium jd-text-muted-foreground jd-flex jd-items-center jd-gap-2">
+              Additional Elements
+            </h4>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setSecondaryMetadataCollapsed(!secondaryMetadataCollapsed)}
+              className="jd-h-6 jd-w-6 jd-p-0"
+            >
+              {secondaryMetadataCollapsed ? <ChevronDown className="jd-h-4 jd-w-4" /> : <ChevronUp className="jd-h-4 jd-w-4" />}
+            </Button>
+          </div>
+
+          {!secondaryMetadataCollapsed && (
+            <>
+              {activeSecondaryMetadata.size > 0 && (
+                <div className="jd-grid jd-grid-cols-2 jd-gap-3 jd-mb-3">
+                  {Array.from(activeSecondaryMetadata).map((type) => (
+                    <div key={type} className="jd-transform jd-transition-all jd-duration-300 hover:jd-scale-105">
+                      {isMultipleMetadataType(type) ? (
+                        <MultipleMetadataCard
+                          type={type}
+                          icon={METADATA_ICONS[type]}
+                          availableBlocks={availableMetadataBlocks[type] || []}
+                          items={metadata[type] || []}
+                          expanded={expandedMetadata === type}
+                          onAddItem={() => onAddMetadataItem(type)}
+                          onRemoveItem={(itemId) => onRemoveMetadataItem(type, itemId)}
+                          onUpdateItem={(itemId, updates) => onUpdateMetadataItem(type, itemId, updates)}
+                          onToggle={() => setExpandedMetadata(expandedMetadata === type ? null : type)}
+                          onRemove={() => onRemoveSecondaryMetadata(type)}
+                          onSaveBlock={onSaveBlock}
+                          onReorderItems={(newItems) => onReorderMetadataItems(type, newItems)}
+                        />
+                      ) : (
+                        <MetadataCard
+                          type={type as SingleMetadataType}
+                          icon={METADATA_ICONS[type]}
+                          availableBlocks={availableMetadataBlocks[type] || []}
+                          expanded={expandedMetadata === type}
+                          selectedId={metadata[type as SingleMetadataType] || 0}
+                          customValue={customValues[type as SingleMetadataType] || ''}
+                          onSelect={(v) => onSingleMetadataChange(type as SingleMetadataType, v)}
+                          onCustomChange={(v) => onCustomChange(type as SingleMetadataType, v)}
+                          onToggle={() => setExpandedMetadata(expandedMetadata === type ? null : type)}
+                          onRemove={() => onRemoveSecondaryMetadata(type)}
+                          onSaveBlock={onSaveBlock}
+                        />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              <div className="jd-flex jd-flex-wrap jd-gap-2">
+                {SECONDARY_METADATA
+                  .filter(type => !activeSecondaryMetadata.has(type))
+                  .map((type) => {
+                    const config = METADATA_CONFIGS[type];
+                    const Icon = METADATA_ICONS[type];
+                    return (
+                      <Button
+                        key={type}
+                        variant="outline"
+                        size="sm"
+                        onClick={() => onAddSecondaryMetadata(type)}
+                        className={cn(
+                          'jd-flex jd-items-center jd-gap-1 jd-text-xs',
+                          'jd-transition-all jd-duration-300',
+                          'hover:jd-scale-105 hover:jd-shadow-md',
+                          isDarkMode
+                            ? 'jd-bg-gray-800/50 hover:jd-bg-gray-700/50'
+                            : 'jd-bg-white/70 hover:jd-bg-white/90'
+                        )}
+                      >
+                        <Plus className="jd-h-3 jd-w-3" />
+                        <Icon className="jd-h-3 jd-w-3" />
+                        {config.label}
+                      </Button>
+                    );
+                  })}
+              </div>
+            </>
+          )}
+        </div>
+      )}
     </>
   );
 };

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
@@ -86,17 +86,50 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
           onAddSecondaryMetadata={addSecondaryMetadata}
           onRemoveSecondaryMetadata={removeSecondaryMetadata}
           onSaveBlock={() => {}}
+          showPrimary
+          showSecondary={false}
         />
 
         <div className="jd-space-y-2">
           <h3 className="jd-text-lg jd-font-semibold">Main Content</h3>
-          <Textarea
-            value={content}
-            onChange={e => onContentChange(e.target.value)}
-            className="jd-min-h-[200px] jd-text-sm jd-resize-none"
-            placeholder="Enter prompt content..."
-          />
+          <div className="jd-border jd-rounded-lg jd-bg-background jd-p-4 jd-space-y-2">
+            <Textarea
+              value={content}
+              onChange={e => onContentChange(e.target.value)}
+              className="jd-min-h-[200px] jd-text-sm jd-resize-none"
+              placeholder="Enter prompt content..."
+            />
+            {content && (
+              <div className="jd-flex jd-justify-between jd-text-xs jd-text-muted-foreground">
+                <span>{content.length} characters</span>
+                <span>{content.split('\n').length} lines</span>
+              </div>
+            )}
+          </div>
         </div>
+
+        <MetadataSection
+          availableMetadataBlocks={{}}
+          metadata={metadata}
+          expandedMetadata={expandedMetadata}
+          setExpandedMetadata={setExpandedMetadata}
+          activeSecondaryMetadata={activeSecondaryMetadata}
+          metadataCollapsed={metadataCollapsed}
+          setMetadataCollapsed={setMetadataCollapsed}
+          secondaryMetadataCollapsed={secondaryMetadataCollapsed}
+          setSecondaryMetadataCollapsed={setSecondaryMetadataCollapsed}
+          onSingleMetadataChange={handleSingleMetadataChange}
+          onCustomChange={handleCustomChange}
+          onAddMetadataItem={handleAddMetadataItem}
+          onRemoveMetadataItem={handleRemoveMetadataItem}
+          onUpdateMetadataItem={handleUpdateMetadataItem}
+          onReorderMetadataItems={handleReorderMetadataItems}
+          onAddSecondaryMetadata={addSecondaryMetadata}
+          onRemoveSecondaryMetadata={removeSecondaryMetadata}
+          onSaveBlock={() => {}}
+          showPrimary={false}
+          showSecondary
+        />
 
         <div className="jd-pt-2">
           <button


### PR DESCRIPTION
## Summary
- split MetadataSection into primary and secondary sections
- show Primary metadata before main content
- wrap main content with styled container and show stats
- display Additional metadata below content

## Testing
- `npm run lint` *(fails: no-unused-vars and no-explicit-any errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6846ef1e11088325a8eedb44ee97bb94