### PR TITLE
Prefill metadata IDs when opening dialogs

### DIFF
--- a/src/hooks/dialogs/useCreateTemplateDialog.ts
+++ b/src/hooks/dialogs/useCreateTemplateDialog.ts
@@ -32,7 +32,7 @@ import {
   updateMetadataItem,
   reorderMetadataItems
 } from './templateDialogUtils';
-import { prefillMetadataFromMapping } from '@/utils/templates/metadataPrefill';
+import { prefillMetadataFromMapping, parseMetadataIds } from '@/utils/templates/metadataPrefill';
 
 export function useCreateTemplateDialog() {
   const createDialog = useDialog('createTemplate');
@@ -82,6 +82,8 @@ export function useCreateTemplateDialog() {
         ]);
 
         if (currentTemplate.metadata) {
+          // Set IDs immediately so metadata cards show selections right away
+          setMetadata(parseMetadataIds(currentTemplate.metadata));
           prefillMetadataFromMapping(currentTemplate.metadata).then(setMetadata);
         }
       } else {

--- a/src/hooks/dialogs/useCustomizeTemplateDialog.ts
+++ b/src/hooks/dialogs/useCustomizeTemplateDialog.ts
@@ -25,7 +25,7 @@ import {
   updateMetadataItem,
   reorderMetadataItems
 } from './templateDialogUtils';
-import { prefillMetadataFromMapping } from '@/utils/templates/metadataPrefill';
+import { prefillMetadataFromMapping, parseMetadataIds } from '@/utils/templates/metadataPrefill';
 
 export function useCustomizeTemplateDialog() {
   const { isOpen, data, dialogProps } = useDialog('placeholderEditor');
@@ -64,14 +64,15 @@ export function useCustomizeTemplateDialog() {
           // ✅ Handle metadata properly
           if (data.metadata && Object.keys(data.metadata).length > 0) {
             console.log('Processing template metadata:', data.metadata);
+            // Set IDs immediately for UI selection
+            templateMetadata = parseMetadataIds(data.metadata);
             try {
-              // Convert the metadata mapping back to metadata structure
+              // Convert the metadata mapping back to full metadata structure
               templateMetadata = await prefillMetadataFromMapping(data.metadata);
               console.log('Prefilled metadata:', templateMetadata);
             } catch (metadataError) {
               console.error('Error processing metadata:', metadataError);
-              // Don't fail completely, just use default metadata
-              templateMetadata = { ...DEFAULT_METADATA };
+              // Don't fail completely, just use IDs-only metadata
             }
           }
 

--- a/src/utils/templates/metadataPrefill.ts
+++ b/src/utils/templates/metadataPrefill.ts
@@ -1,9 +1,9 @@
 // src/utils/templates/metadataPrefill.ts
 import { blocksApi } from '@/services/api/BlocksApi';
-import { 
-  PromptMetadata, 
-  DEFAULT_METADATA, 
-  PRIMARY_METADATA, 
+import {
+  PromptMetadata,
+  DEFAULT_METADATA,
+  PRIMARY_METADATA,
   SECONDARY_METADATA,
   SingleMetadataType,
   MultipleMetadataType,
@@ -11,6 +11,39 @@ import {
   generateMetadataItemId
 } from '@/types/prompts/metadata';
 import { getCurrentLanguage } from '@/core/utils/i18n';
+
+// Quickly convert a metadata mapping to a PromptMetadata object using only IDs.
+// This allows dialogs to immediately display selected metadata before block
+// content has been fetched.
+export function parseMetadataIds(
+  metadataMapping: Record<string, number | number[]>
+): PromptMetadata {
+  const metadata: PromptMetadata = {
+    ...DEFAULT_METADATA,
+    values: {}
+  };
+
+  for (const [type, value] of Object.entries(metadataMapping)) {
+    if (typeof value === 'number') {
+      if (value && value > 0) {
+        (metadata as any)[type] = value;
+      }
+    } else if (Array.isArray(value)) {
+      const items = value
+        .filter(id => id && typeof id === 'number' && id > 0)
+        .map(id => ({
+          id: generateMetadataItemId(),
+          blockId: id,
+          value: ''
+        }));
+      if (items.length > 0) {
+        (metadata as any)[type] = items;
+      }
+    }
+  }
+
+  return metadata;
+}
 
 export async function prefillMetadataFromMapping(
   metadataMapping: Record<string, number | number[]>


### PR DESCRIPTION
## Summary
- add `parseMetadataIds` helper to quickly parse metadata mapping
- ensure Create/Edit and Customize dialogs set metadata IDs immediately

## Testing
- `npm run lint` *(fails: 432 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_684708db5a548325a8b7aff2cf00e44f