### PR TITLE
Refactor template dialogs

### DIFF
--- a/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
@@ -1,21 +1,9 @@
-// src/components/dialogs/prompts/CreateTemplateDialog/index.tsx - Updated
-import React, { useState, useEffect, useMemo } from 'react';
-import { Button } from '@/components/ui/button';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { AlertTriangle } from 'lucide-react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { BaseDialog } from '@/components/dialogs/BaseDialog';
+import React from 'react';
 import { getMessage } from '@/core/utils/i18n';
-import { BasicInfoForm } from './BasicInfoForm';
-import { BasicEditor, AdvancedEditor } from '../editors';
 import { useCreateTemplateDialog } from '@/hooks/dialogs/useCreateTemplateDialog';
-import { useBlockManager } from '@/hooks/prompts/editors/useBlockManager';
-import { PromptMetadata, DEFAULT_METADATA } from '@/types/prompts/metadata';
+import { TemplateEditorDialog } from '../TemplateEditorDialog';
+import { BasicInfoForm } from './BasicInfoForm';
 
-/**
- * Dialog for editing template content using blocks with Basic/Advanced modes
- * Now with centralized block management and consistent content resolution
- */
 export const CreateTemplateDialog: React.FC = () => {
   const {
     isOpen,
@@ -28,8 +16,6 @@ export const CreateTemplateDialog: React.FC = () => {
     setDescription,
     content,
     setContent,
-    metadata,
-    setMetadata,
     selectedFolderId,
     handleFolderSelect,
     userFoldersList,
@@ -39,166 +25,39 @@ export const CreateTemplateDialog: React.FC = () => {
     handleClose,
   } = useCreateTemplateDialog();
 
-  // Use the block manager hook
-  const {
-    isLoading: blocksLoading,
-    availableMetadataBlocks,
-    availableBlocksByType,
-    blockContentCache,
-    resolveMetadataToContent,
-    buildFinalPromptContent
-  } = useBlockManager();
+  const infoForm = (
+    <BasicInfoForm
+      name={name}
+      setName={setName}
+      description={description}
+      setDescription={setDescription}
+      selectedFolderId={selectedFolderId}
+      handleFolderSelect={handleFolderSelect}
+      userFoldersList={userFoldersList}
+      validationErrors={validationErrors}
+    />
+  );
 
-  const [activeTab, setActiveTab] = useState<'basic' | 'advanced'>('basic');
-  
-  // Resolve metadata to get actual content from block IDs
-  const resolvedMetadata = useMemo(() => {
-    if (!rawMetadata || blocksLoading) return DEFAULT_METADATA;
-    return resolveMetadataToContent(rawMetadata);
-  }, [rawMetadata, resolveMetadataToContent, blocksLoading]);
-
-  // Build final prompt content that will be consistent across editors
-  const finalPromptContent = useMemo(() => {
-    if (blocksLoading) return '';
-    return buildFinalPromptContent(rawMetadata || DEFAULT_METADATA, content);
-  }, [rawMetadata, content, buildFinalPromptContent, blocksLoading]);
-
-  // Handle completion with resolved content
-  const handleCompleteWithResolvedContent = () => {
+  const onComplete = (finalContent: string) => {
+    // Create dialog saves original content and metadata
     handleComplete(content, rawMetadata);
   };
 
-  // Handle metadata updates (these still work with block IDs)
-  const handleMetadataUpdate = (newMetadata: PromptMetadata) => {
-    handleUpdateMetadata(newMetadata);
-  };
-
-
-
-  if (!isOpen) return null;
-
-  if (error && !isProcessing) {
-    return (
-      <BaseDialog
-        open={isOpen}
-        onOpenChange={(open: boolean) => {
-          if (!open) handleClose();
-        }}
-        title={getMessage('CreateTemplateDialog', undefined, 'Prompt Block Editor')}
-        className="jd-max-w-4xl jd-h-[80vh]"
-      >
-        <div className="jd-flex jd-flex-col jd-items-center jd-justify-center jd-h-64">
-          <Alert variant="destructive" className="jd-mb-4 jd-max-w-md">
-            <AlertTriangle className="jd-h-4 jd-w-4" />
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-          <Button onClick={handleClose} variant="outline">
-            {getMessage('close')}
-          </Button>
-        </div>
-      </BaseDialog>
-    );
-  }
-
-  const isLoading = isProcessing || blocksLoading;
-
   return (
-    <BaseDialog
-      open={isOpen}
-      onOpenChange={(open: boolean) => {
-        if (!open) handleClose();
-      }}
-      title={getMessage('CreateTemplateDialog', undefined, 'Prompt Block Editor')}
-      description={getMessage('CreateTemplateDialogDescription', undefined, 'Build your prompt using blocks')}
-      className="jd-max-w-6xl jd-h-[100vh]"
-    >
-      <BasicInfoForm
-          name={name}
-          setName={setName}
-          description={description}
-          setDescription={setDescription}
-          selectedFolderId={selectedFolderId}
-          handleFolderSelect={handleFolderSelect}
-          userFoldersList={userFoldersList}
-          validationErrors={validationErrors}
-        />
-      <div className="jd-flex jd-flex-col jd-h-full jd-gap-4">
-        {error && (
-          <Alert variant="destructive" className="jd-mb-2">
-            <AlertTriangle className="jd-h-4 jd-w-4 jd-mr-2" />
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        )}
-
-        {isLoading ? (
-          <div className="jd-flex jd-items-center jd-justify-center jd-h-64">
-            <div className="jd-animate-spin jd-h-8 jd-w-8 jd-border-4 jd-border-primary jd-border-t-transparent jd-rounded-full"></div>
-            <span className="jd-ml-3 jd-text-gray-600">
-              {getMessage('loadingTemplate')} {blocksLoading && '& blocks...'}
-            </span>
-          </div>
-        ) : (
-          <Tabs
-            value={activeTab}
-            onValueChange={value => setActiveTab(value as 'basic' | 'advanced')}
-            className="jd-flex-1 jd-flex jd-flex-col"
-          >
-            <TabsList className="jd-grid jd-w-full jd-grid-cols-2 jd-mb-4">
-              <TabsTrigger value="basic">{getMessage('basic')}</TabsTrigger>
-              <TabsTrigger value="advanced">{getMessage('advanced')}</TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="basic" className="jd-flex-1 jd-overflow-y-auto">
-              <BasicEditor
-                content={content}
-                metadata={resolvedMetadata} // Pass resolved metadata with actual content
-                onContentChange={setContent}
-                onUpdateMetadata={handleMetadataUpdate} // This still works with block IDs
-                mode="create"
-                isProcessing={false}
-                // Pass additional props for consistency
-                finalPromptContent={finalPromptContent}
-              />
-            </TabsContent>
-
-            <TabsContent value="advanced" className="jd-flex-1 jd-overflow-y-auto">
-              <AdvancedEditor
-                content={content}
-                metadata={resolvedMetadata || DEFAULT_METADATA} // Pass raw metadata with block IDs
-                onContentChange={setContent}
-                onUpdateMetadata={handleMetadataUpdate}
-                isProcessing={false}
-                // Pass block management props
-                availableMetadataBlocks={availableMetadataBlocks}
-                availableBlocksByType={availableBlocksByType}
-                blockContentCache={blockContentCache}
-                // Pass resolved metadata for preview
-                resolvedMetadata={resolvedMetadata}
-                finalPromptContent={finalPromptContent}
-              />
-            </TabsContent>
-          </Tabs>
-        )}
-
-        <div className="jd-flex jd-justify-end jd-gap-2 jd-pt-4 jd-border-t">
-          <Button variant="outline" onClick={handleClose}>
-            {getMessage('cancel', undefined, 'Cancel')}
-          </Button>
-          <Button 
-            onClick={handleCompleteWithResolvedContent} 
-            disabled={isLoading}
-          >
-            {getMessage('useTemplate', undefined, 'Use Template')}
-          </Button>
-        </div>
-
-        {/* Debug info (remove in production) */}
-        {process.env.NODE_ENV === 'development' && (
-          <div className="jd-text-xs jd-text-gray-500 jd-mt-2">
-            Final content length: {finalPromptContent.length} chars
-          </div>
-        )}
-      </div>
-    </BaseDialog>
+    <TemplateEditorDialog
+      isOpen={isOpen}
+      error={error}
+      rawMetadata={rawMetadata}
+      isProcessing={isProcessing}
+      content={content}
+      setContent={setContent}
+      onUpdateMetadata={handleUpdateMetadata}
+      onComplete={onComplete}
+      onClose={handleClose}
+      dialogTitle={getMessage('CreateTemplateDialog', undefined, 'Prompt Block Editor')}
+      dialogDescription={getMessage('CreateTemplateDialogDescription', undefined, 'Build your prompt using blocks')}
+      mode="create"
+      infoForm={infoForm}
+    />
   );
 };

--- a/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
@@ -1,20 +1,8 @@
-// src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx - Updated
-import React, { useState, useEffect, useMemo } from 'react';
-import { Button } from '@/components/ui/button';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { AlertTriangle } from 'lucide-react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { BaseDialog } from '@/components/dialogs/BaseDialog';
+import React from 'react';
 import { getMessage } from '@/core/utils/i18n';
-import { BasicEditor, AdvancedEditor } from '../editors';
 import { useCustomizeTemplateDialog } from '@/hooks/dialogs/useCustomizeTemplateDialog';
-import { useBlockManager } from '@/hooks/prompts/editors/useBlockManager';
-import { PromptMetadata, DEFAULT_METADATA } from '@/types/prompts/metadata';
+import { TemplateEditorDialog } from '../TemplateEditorDialog';
 
-/**
- * Dialog for editing template content using blocks with Basic/Advanced modes
- * Now with centralized block management and consistent content resolution
- */
 export const CustomizeTemplateDialog: React.FC = () => {
   const {
     isOpen,
@@ -28,156 +16,20 @@ export const CustomizeTemplateDialog: React.FC = () => {
     handleClose,
   } = useCustomizeTemplateDialog();
 
-  // Use the block manager hook
-  const {
-    isLoading: blocksLoading,
-    availableMetadataBlocks,
-    availableBlocksByType,
-    blockContentCache,
-    resolveMetadataToContent,
-    buildFinalPromptContent
-  } = useBlockManager();
-
-  const [activeTab, setActiveTab] = useState<'basic' | 'advanced'>('basic');
-  
-  // Resolve metadata to get actual content from block IDs
-  const resolvedMetadata = useMemo(() => {
-    if (!rawMetadata || blocksLoading) return DEFAULT_METADATA;
-    return resolveMetadataToContent(rawMetadata);
-  }, [rawMetadata, resolveMetadataToContent, blocksLoading]);
-
-  // Build final prompt content that will be consistent across editors
-  const finalPromptContent = useMemo(() => {
-    if (blocksLoading) return '';
-    return buildFinalPromptContent(rawMetadata || DEFAULT_METADATA, content);
-  }, [rawMetadata, content, buildFinalPromptContent, blocksLoading]);
-
-  // Handle completion with resolved content
-  const handleCompleteWithResolvedContent = () => {
-    handleComplete(finalPromptContent);
-  };
-
-  // Handle metadata updates (these still work with block IDs)
-  const handleMetadataUpdate = (newMetadata: PromptMetadata) => {
-    handleUpdateMetadata(newMetadata);
-  };
-
-
-
-  if (!isOpen) return null;
-
-  if (error && !isProcessing) {
-    return (
-      <BaseDialog
-        open={isOpen}
-        onOpenChange={(open: boolean) => {
-          if (!open) handleClose();
-        }}
-        title={getMessage('CustomizeTemplateDialog', undefined, 'Prompt Block Editor')}
-        className="jd-max-w-4xl jd-h-[80vh]"
-      >
-        <div className="jd-flex jd-flex-col jd-items-center jd-justify-center jd-h-64">
-          <Alert variant="destructive" className="jd-mb-4 jd-max-w-md">
-            <AlertTriangle className="jd-h-4 jd-w-4" />
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-          <Button onClick={handleClose} variant="outline">
-            {getMessage('close')}
-          </Button>
-        </div>
-      </BaseDialog>
-    );
-  }
-
-  const isLoading = isProcessing || blocksLoading;
-
   return (
-    <BaseDialog
-      open={isOpen}
-      onOpenChange={(open: boolean) => {
-        if (!open) handleClose();
-      }}
-      title={getMessage('CustomizeTemplateDialog', undefined, 'Prompt Block Editor')}
-      description={getMessage('CustomizeTemplateDialogDescription', undefined, 'Build your prompt using blocks')}
-      className="jd-max-w-6xl jd-h-[100vh]"
-    >
-      <div className="jd-flex jd-flex-col jd-h-full jd-gap-4">
-        {error && (
-          <Alert variant="destructive" className="jd-mb-2">
-            <AlertTriangle className="jd-h-4 jd-w-4 jd-mr-2" />
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        )}
-
-        {isLoading ? (
-          <div className="jd-flex jd-items-center jd-justify-center jd-h-64">
-            <div className="jd-animate-spin jd-h-8 jd-w-8 jd-border-4 jd-border-primary jd-border-t-transparent jd-rounded-full"></div>
-            <span className="jd-ml-3 jd-text-gray-600">
-              {getMessage('loadingTemplate')} {blocksLoading && '& blocks...'}
-            </span>
-          </div>
-        ) : (
-          <Tabs
-            value={activeTab}
-            onValueChange={value => setActiveTab(value as 'basic' | 'advanced')}
-            className="jd-flex-1 jd-flex jd-flex-col"
-          >
-            <TabsList className="jd-grid jd-w-full jd-grid-cols-2 jd-mb-4">
-              <TabsTrigger value="basic">{getMessage('basic')}</TabsTrigger>
-              <TabsTrigger value="advanced">{getMessage('advanced')}</TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="basic" className="jd-flex-1 jd-overflow-y-auto">
-              <BasicEditor
-                content={content}
-                metadata={resolvedMetadata} // Pass resolved metadata with actual content
-                onContentChange={setContent}
-                onUpdateMetadata={handleMetadataUpdate} // This still works with block IDs
-                mode="customize"
-                isProcessing={false}
-                // Pass additional props for consistency
-                finalPromptContent={finalPromptContent}
-              />
-            </TabsContent>
-
-            <TabsContent value="advanced" className="jd-flex-1 jd-overflow-y-auto">
-              <AdvancedEditor
-                content={content}
-                metadata={resolvedMetadata || DEFAULT_METADATA} // Pass raw metadata with block IDs
-                onContentChange={setContent}
-                onUpdateMetadata={handleMetadataUpdate}
-                isProcessing={false}
-                // Pass block management props
-                availableMetadataBlocks={availableMetadataBlocks}
-                availableBlocksByType={availableBlocksByType}
-                blockContentCache={blockContentCache}
-                // Pass resolved metadata for preview
-                resolvedMetadata={resolvedMetadata}
-                finalPromptContent={finalPromptContent}
-              />
-            </TabsContent>
-          </Tabs>
-        )}
-
-        <div className="jd-flex jd-justify-end jd-gap-2 jd-pt-4 jd-border-t">
-          <Button variant="outline" onClick={handleClose}>
-            {getMessage('cancel', undefined, 'Cancel')}
-          </Button>
-          <Button 
-            onClick={handleCompleteWithResolvedContent} 
-            disabled={isLoading}
-          >
-            {getMessage('useTemplate', undefined, 'Use Template')}
-          </Button>
-        </div>
-
-        {/* Debug info (remove in production) */}
-        {process.env.NODE_ENV === 'development' && (
-          <div className="jd-text-xs jd-text-gray-500 jd-mt-2">
-            Final content length: {finalPromptContent.length} chars
-          </div>
-        )}
-      </div>
-    </BaseDialog>
+    <TemplateEditorDialog
+      isOpen={isOpen}
+      error={error}
+      rawMetadata={rawMetadata}
+      isProcessing={isProcessing}
+      content={content}
+      setContent={setContent}
+      onUpdateMetadata={handleUpdateMetadata}
+      onComplete={handleComplete}
+      onClose={handleClose}
+      dialogTitle={getMessage('CustomizeTemplateDialog', undefined, 'Prompt Block Editor')}
+      dialogDescription={getMessage('CustomizeTemplateDialogDescription', undefined, 'Build your prompt using blocks')}
+      mode="customize"
+    />
   );
 };

--- a/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
@@ -1,0 +1,175 @@
+import React, { useState, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { AlertTriangle } from 'lucide-react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { BaseDialog } from '@/components/dialogs/BaseDialog';
+import { getMessage } from '@/core/utils/i18n';
+import { BasicEditor, AdvancedEditor } from '../editors';
+import { useBlockManager } from '@/hooks/prompts/editors/useBlockManager';
+import { PromptMetadata, DEFAULT_METADATA } from '@/types/prompts/metadata';
+
+interface TemplateEditorDialogProps {
+  isOpen: boolean;
+  error: string | null;
+  rawMetadata: PromptMetadata;
+  isProcessing: boolean;
+  content: string;
+  setContent: (content: string) => void;
+  onUpdateMetadata: (metadata: PromptMetadata) => void;
+  onComplete: (finalContent: string) => void;
+  onClose: () => void;
+  dialogTitle: string;
+  dialogDescription: string;
+  mode: 'create' | 'customize';
+  infoForm?: React.ReactNode;
+}
+
+export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
+  isOpen,
+  error,
+  rawMetadata,
+  isProcessing,
+  content,
+  setContent,
+  onUpdateMetadata,
+  onComplete,
+  onClose,
+  dialogTitle,
+  dialogDescription,
+  mode,
+  infoForm
+}) => {
+  const {
+    isLoading: blocksLoading,
+    availableMetadataBlocks,
+    availableBlocksByType,
+    blockContentCache,
+    resolveMetadataToContent,
+    buildFinalPromptContent
+  } = useBlockManager();
+
+  const [activeTab, setActiveTab] = useState<'basic' | 'advanced'>('basic');
+
+  const resolvedMetadata = useMemo(() => {
+    if (!rawMetadata || blocksLoading) return DEFAULT_METADATA;
+    return resolveMetadataToContent(rawMetadata);
+  }, [rawMetadata, resolveMetadataToContent, blocksLoading]);
+
+  const finalPromptContent = useMemo(() => {
+    if (blocksLoading) return '';
+    return buildFinalPromptContent(rawMetadata || DEFAULT_METADATA, content);
+  }, [rawMetadata, content, buildFinalPromptContent, blocksLoading]);
+
+  const handleCompleteWithResolvedContent = () => {
+    onComplete(finalPromptContent);
+  };
+
+  if (!isOpen) return null;
+
+  if (error && !isProcessing) {
+    return (
+      <BaseDialog
+        open={isOpen}
+        onOpenChange={(open: boolean) => {
+          if (!open) onClose();
+        }}
+        title={dialogTitle}
+        className="jd-max-w-4xl jd-h-[80vh]"
+      >
+        <div className="jd-flex jd-flex-col jd-items-center jd-justify-center jd-h-64">
+          <Alert variant="destructive" className="jd-mb-4 jd-max-w-md">
+            <AlertTriangle className="jd-h-4 jd-w-4" />
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+          <Button onClick={onClose} variant="outline">
+            {getMessage('close')}
+          </Button>
+        </div>
+      </BaseDialog>
+    );
+  }
+
+  const isLoading = isProcessing || blocksLoading;
+
+  return (
+    <BaseDialog
+      open={isOpen}
+      onOpenChange={(open: boolean) => {
+        if (!open) onClose();
+      }}
+      title={dialogTitle}
+      description={dialogDescription}
+      className="jd-max-w-6xl jd-h-[100vh]"
+    >
+      {infoForm}
+      <div className="jd-flex jd-flex-col jd-h-full jd-gap-4">
+        {error && (
+          <Alert variant="destructive" className="jd-mb-2">
+            <AlertTriangle className="jd-h-4 jd-w-4 jd-mr-2" />
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        {isLoading ? (
+          <div className="jd-flex jd-items-center jd-justify-center jd-h-64">
+            <div className="jd-animate-spin jd-h-8 jd-w-8 jd-border-4 jd-border-primary jd-border-t-transparent jd-rounded-full"></div>
+            <span className="jd-ml-3 jd-text-gray-600">
+              {getMessage('loadingTemplate')} {blocksLoading && '& blocks...'}
+            </span>
+          </div>
+        ) : (
+          <Tabs
+            value={activeTab}
+            onValueChange={value => setActiveTab(value as 'basic' | 'advanced')}
+            className="jd-flex-1 jd-flex jd-flex-col"
+          >
+            <TabsList className="jd-grid jd-w-full jd-grid-cols-2 jd-mb-4">
+              <TabsTrigger value="basic">{getMessage('basic')}</TabsTrigger>
+              <TabsTrigger value="advanced">{getMessage('advanced')}</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="basic" className="jd-flex-1 jd-overflow-y-auto">
+              <BasicEditor
+                content={content}
+                metadata={resolvedMetadata}
+                onContentChange={setContent}
+                onUpdateMetadata={onUpdateMetadata}
+                mode={mode}
+                isProcessing={false}
+                finalPromptContent={finalPromptContent}
+              />
+            </TabsContent>
+
+            <TabsContent value="advanced" className="jd-flex-1 jd-overflow-y-auto">
+              <AdvancedEditor
+                content={content}
+                metadata={resolvedMetadata || DEFAULT_METADATA}
+                onContentChange={setContent}
+                onUpdateMetadata={onUpdateMetadata}
+                isProcessing={false}
+                availableMetadataBlocks={availableMetadataBlocks}
+                availableBlocksByType={availableBlocksByType}
+                blockContentCache={blockContentCache}
+                resolvedMetadata={resolvedMetadata}
+                finalPromptContent={finalPromptContent}
+              />
+            </TabsContent>
+          </Tabs>
+        )}
+        <div className="jd-flex jd-justify-end jd-gap-2 jd-pt-4 jd-border-t">
+          <Button variant="outline" onClick={onClose}>
+            {getMessage('cancel', undefined, 'Cancel')}
+          </Button>
+          <Button onClick={handleCompleteWithResolvedContent} disabled={isLoading}>
+            {getMessage('useTemplate', undefined, 'Use Template')}
+          </Button>
+        </div>
+        {process.env.NODE_ENV === 'development' && (
+          <div className="jd-text-xs jd-text-gray-500 jd-mt-2">
+            Final content length: {finalPromptContent.length} chars
+          </div>
+        )}
+      </div>
+    </BaseDialog>
+  );
+};


### PR DESCRIPTION
## Summary
- extract `TemplateEditorDialog` as shared component for both template dialogs
- refactor CreateTemplateDialog and CustomizeTemplateDialog to use the new component

## Testing
- `npm run type-check`
- `npm run lint` *(fails: 459 problems)*

------
https://chatgpt.com/codex/tasks/task_b_684818cfd7848325a3f2dfdc277fb420