### PR TITLE
Add prompt formatter and use in BasicEditor

### DIFF
--- a/src/utils/prompts/promptFormatter.ts
+++ b/src/utils/prompts/promptFormatter.ts
@@ -1,0 +1,38 @@
+import { PromptMetadata } from '@/types/prompts/metadata';
+import {
+  buildCompletePreview,
+  buildCompletePreviewWithBlocks,
+  buildCompletePreviewHtml,
+  buildCompletePreviewHtmlWithBlocks
+} from '@/utils/templates/promptPreviewUtils';
+
+/**
+ * Build the final prompt text from metadata and content.
+ * Optionally resolves block references using the provided block map.
+ */
+export function formatPromptText(
+  metadata: PromptMetadata,
+  content: string,
+  blockMap?: Record<number, string>
+): string {
+  if (blockMap) {
+    return buildCompletePreviewWithBlocks(metadata, content, blockMap);
+  }
+  return buildCompletePreview(metadata, content);
+}
+
+/**
+ * Build the final prompt HTML for preview.
+ * Optionally resolves block references using the provided block map.
+ */
+export function formatPromptHtml(
+  metadata: PromptMetadata,
+  content: string,
+  isDark: boolean,
+  blockMap?: Record<number, string>
+): string {
+  if (blockMap) {
+    return buildCompletePreviewHtmlWithBlocks(metadata, content, blockMap, isDark);
+  }
+  return buildCompletePreviewHtml(metadata, content, isDark);
+}


### PR DESCRIPTION
## Summary
- add a `promptFormatter` utility that unifies prompt text and html building
- use new formatter in `BasicEditor`
- remove old preview helpers from `BasicEditor`

## Testing
- `npm run lint` *(fails: 460 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6848307bdad08325b72563da19c493a8