### PR TITLE
Refactor cursor utilities

### DIFF
--- a/src/utils/pompts/templates/getCursorPosition.ts
+++ b/src/utils/pompts/templates/getCursorPosition.ts
@@ -1,0 +1,3 @@
+export function getCursorPosition(el: HTMLTextAreaElement | HTMLInputElement): { start: number; end: number } {
+  return { start: el.selectionStart || 0, end: el.selectionEnd || 0 };
+}

--- a/src/utils/pompts/templates/setCursorPosition.ts
+++ b/src/utils/pompts/templates/setCursorPosition.ts
@@ -1,7 +1,3 @@
-export function getCursorPosition(el: HTMLTextAreaElement | HTMLInputElement): { start: number; end: number } {
-  return { start: el.selectionStart || 0, end: el.selectionEnd || 0 };
-}
-
 export function setCursorPosition(el: HTMLTextAreaElement | HTMLInputElement, pos: number | { start: number; end: number }): void {
   if (typeof pos === 'number') {
     el.setSelectionRange(pos, pos);

--- a/src/utils/templates/placeholderUtils.ts
+++ b/src/utils/templates/placeholderUtils.ts
@@ -14,7 +14,8 @@ import {
   extractPlaceholders,
   replacePlaceholders
 } from './placeholderHelpers';
-import { getCursorPosition, setCursorPosition } from './cursorUtils';
+import { getCursorPosition } from '@/utils/pompts/templates/getCursorPosition';
+import { setCursorPosition } from '@/utils/pompts/templates/setCursorPosition';
 
 export { highlightPlaceholders, extractPlaceholders, replacePlaceholders, getCursorPosition, setCursorPosition, restoreCursorPositionSafely };
 


### PR DESCRIPTION
## Summary
- create `utils/pompts/templates` directory
- split cursor utility functions into separate files
- update placeholder utilities to use the new paths

## Testing
- `npm run lint` *(fails: 460 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6848758b45c08325a306a4f9de38c940