### PR TITLE
Fix saving of multiple metadata

### DIFF
--- a/src/hooks/dialogs/useCreateTemplateDialog.ts
+++ b/src/hooks/dialogs/useCreateTemplateDialog.ts
@@ -21,6 +21,10 @@ import {
 } from '@/utils/prompts/templateUtils';
 import { getLocalizedContent } from '@/utils/prompts/blockUtils';
 import { useTemplateMetadataHandlers } from '@/hooks/prompts/useTemplateMetadata'; // ✅ Use shared metadata hook
+import {
+  ensureMetadataBlocks,
+  getMetadataBlockMapping
+} from './templateDialogUtils';
 
 export function useCreateTemplateDialog() {
   // ✅ Restore original dialog integration
@@ -158,12 +162,20 @@ export function useCreateTemplateDialog() {
   const handleComplete = async (content: string, metadata: PromptMetadata) => {
     setIsSubmitting(true);
     try {
+      // Ensure all metadata values are persisted as blocks so we can
+      // pass only block ID mappings to the API.
+      const processedMetadata = await ensureMetadataBlocks(metadata);
+      const metadataMapping = getMetadataBlockMapping(processedMetadata, activeTab);
+
+      // Update local state with block IDs so the dialog stays in sync
+      setMetadata(processedMetadata);
+
       const formData = {
         name: name.trim(),
         content: content,
         description: description?.trim(),
         folder_id: selectedFolderId ? parseInt(selectedFolderId, 10) : undefined,
-        metadata: metadata
+        metadata: metadataMapping
       };
 
       let success = false;


### PR DESCRIPTION
## Summary
- ensure constraint/example items are persisted as blocks before saving
- send only block id mapping when creating templates

## Testing
- `npm run lint` *(fails: 470 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_684880c921ec8325b5357ff4570fdb87