### PR TITLE
Refactor metadata updates in TemplateEditor

### DIFF
--- a/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
@@ -69,15 +69,8 @@ export const CreateTemplateDialog: React.FC = () => {
       handleComplete={hook.handleComplete}
       handleClose={hook.handleClose}
       
-      // Metadata actions
-      updateSingleMetadataValue={hook.updateSingleMetadataValue}
-      updateCustomMetadataValue={hook.updateCustomMetadataValue}
-      addMultipleMetadataItem={hook.addMultipleMetadataItem}
-      removeMultipleMetadataItem={hook.removeMultipleMetadataItem}
-      updateMultipleMetadataItem={hook.updateMultipleMetadataItem}
-      reorderMultipleMetadataItems={hook.reorderMultipleMetadataItems}
-      addSecondaryMetadataType={hook.addSecondaryMetadataType}
-      removeSecondaryMetadataType={hook.removeSecondaryMetadataType}
+      // Metadata update
+      setMetadata={hook.setMetadata}
       
       // UI state
       expandedMetadata={hook.expandedMetadata}

--- a/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
@@ -25,15 +25,8 @@ export const CustomizeTemplateDialog: React.FC = () => {
       handleComplete={hook.handleComplete}
       handleClose={hook.handleClose}
       
-      // Metadata actions
-      updateSingleMetadataValue={hook.updateSingleMetadataValue}
-      updateCustomMetadataValue={hook.updateCustomMetadataValue}
-      addMultipleMetadataItem={hook.addMultipleMetadataItem}
-      removeMultipleMetadataItem={hook.removeMultipleMetadataItem}
-      updateMultipleMetadataItem={hook.updateMultipleMetadataItem}
-      reorderMultipleMetadataItems={hook.reorderMultipleMetadataItems}
-      addSecondaryMetadataType={hook.addSecondaryMetadataType}
-      removeSecondaryMetadataType={hook.removeSecondaryMetadataType}
+      // Metadata update
+      setMetadata={hook.setMetadata}
       
       // UI state
       expandedMetadata={hook.expandedMetadata}

--- a/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
@@ -32,15 +32,8 @@ interface TemplateEditorDialogProps {
   handleComplete: () => Promise<void>;
   handleClose: () => void;
   
-  // Metadata actions from base hook
-  updateSingleMetadataValue: (type: SingleMetadataType, value: string) => void;
-  updateCustomMetadataValue: (type: SingleMetadataType, value: string) => void;
-  addMultipleMetadataItem: (type: MultipleMetadataType) => void;
-  removeMultipleMetadataItem: (type: MultipleMetadataType, itemId: string) => void;
-  updateMultipleMetadataItem: (type: MultipleMetadataType, itemId: string, updates: Partial<MetadataItem>) => void;
-  reorderMultipleMetadataItems: (type: MultipleMetadataType, newItems: MetadataItem[]) => void;
-  addSecondaryMetadataType: (type: MetadataType) => void;
-  removeSecondaryMetadataType: (type: MetadataType) => void;
+  // Metadata setter for child components
+  setMetadata: (updater: (metadata: PromptMetadata) => PromptMetadata) => void;
   
   // UI state from base hook
   expandedMetadata: MetadataType | null;
@@ -74,16 +67,9 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
   setActiveTab,
   handleComplete,
   handleClose,
-  
-  // Metadata actions
-  updateSingleMetadataValue,
-  updateCustomMetadataValue,
-  addMultipleMetadataItem,
-  removeMultipleMetadataItem,
-  updateMultipleMetadataItem,
-  reorderMultipleMetadataItems,
-  addSecondaryMetadataType,
-  removeSecondaryMetadataType,
+
+  // Metadata
+  setMetadata,
   
   // UI state
   expandedMetadata,
@@ -116,26 +102,6 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
     return buildFinalPromptContent(metadata, content);
   }, [metadata, content, buildFinalPromptContent, blocksLoading]);
 
-  // Create metadata handlers object for AdvancedEditor
-  const metadataHandlers = React.useMemo(() => ({
-    updateSingleMetadataValue,
-    updateCustomMetadataValue,
-    addMultipleMetadataItem,
-    removeMultipleMetadataItem,
-    updateMultipleMetadataItem,
-    reorderMultipleMetadataItems,
-    addSecondaryMetadataType,
-    removeSecondaryMetadataType
-  }), [
-    updateSingleMetadataValue,
-    updateCustomMetadataValue,
-    addMultipleMetadataItem,
-    removeMultipleMetadataItem,
-    updateMultipleMetadataItem,
-    reorderMultipleMetadataItems,
-    addSecondaryMetadataType,
-    removeSecondaryMetadataType
-  ]);
 
   // Create metadata UI state object for AdvancedEditor
   const metadataUIState = React.useMemo(() => ({
@@ -239,7 +205,7 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
                 onContentChange={setContent}
                 isProcessing={false}
                 resolvedMetadata={metadata}
-                metadataHandlers={metadataHandlers}
+                setMetadata={setMetadata}
                 metadataUIState={metadataUIState}
                 availableMetadataBlocks={availableMetadataBlocks}
                 availableBlocksByType={availableBlocksByType}

--- a/src/hooks/dialogs/useTemplateDialogBase.ts
+++ b/src/hooks/dialogs/useTemplateDialogBase.ts
@@ -72,6 +72,9 @@ export interface TemplateDialogActions {
   reorderMultipleMetadataItems: (type: MultipleMetadataType, newItems: MetadataItem[]) => void;
   addSecondaryMetadataType: (type: MetadataType) => void;
   removeSecondaryMetadataType: (type: MetadataType) => void;
+
+  // Direct metadata setter
+  setMetadata: (updater: (metadata: PromptMetadata) => PromptMetadata) => void;
   
   // UI actions
   setActiveTab: (tab: 'basic' | 'advanced') => void;
@@ -206,6 +209,14 @@ export function useTemplateDialogBase(config: TemplateDialogConfig) {
       expandedMetadata: prev.expandedMetadata === type ? null : prev.expandedMetadata
     }));
   }, []);
+
+  // Generic metadata setter for more modular updates
+  const setMetadata = useCallback(
+    (updater: (metadata: PromptMetadata) => PromptMetadata) => {
+      setState(prev => ({ ...prev, metadata: updater(prev.metadata) }));
+    },
+    []
+  );
   
   // ============================================================================
   // UI ACTIONS
@@ -363,6 +374,7 @@ export function useTemplateDialogBase(config: TemplateDialogConfig) {
     reorderMultipleMetadataItems,
     addSecondaryMetadataType,
     removeSecondaryMetadataType,
+    setMetadata,
     
     // UI actions
     setActiveTab,


### PR DESCRIPTION
## Summary
- switch TemplateEditorDialog to use setMetadata instead of several metadata handlers
- pass setMetadata through Create/Customize dialogs
- update AdvancedEditor and MetadataSection to update metadata locally via metadataUtils
- add generic setMetadata function in useTemplateDialogBase

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_684970b7ba048325aaa8e3a26c51065d