### PR TITLE
Refactor metadata handling with context

### DIFF
--- a/src/components/dialogs/prompts/TemplateEditorDialog/TemplateEditorContext.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/TemplateEditorContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext } from 'react';
+import { PromptMetadata, MetadataType } from '@/types/prompts/metadata';
+
+export interface MetadataUIState {
+  expandedMetadata: MetadataType | null;
+  setExpandedMetadata: (type: MetadataType | null) => void;
+  activeSecondaryMetadata: Set<MetadataType>;
+  metadataCollapsed: boolean;
+  setMetadataCollapsed: (collapsed: boolean) => void;
+  secondaryMetadataCollapsed: boolean;
+  setSecondaryMetadataCollapsed: (collapsed: boolean) => void;
+  customValues: Record<string, string>;
+}
+
+export interface TemplateEditorContextValue extends MetadataUIState {
+  metadata: PromptMetadata;
+  setMetadata: (updater: (metadata: PromptMetadata) => PromptMetadata) => void;
+}
+
+const TemplateEditorContext = createContext<TemplateEditorContextValue | undefined>(undefined);
+
+export const TemplateEditorProvider: React.FC<{ value: TemplateEditorContextValue; children: React.ReactNode }> = ({ value, children }) => (
+  <TemplateEditorContext.Provider value={value}>{children}</TemplateEditorContext.Provider>
+);
+
+export const useTemplateEditor = (): TemplateEditorContextValue => {
+  const context = useContext(TemplateEditorContext);
+  if (!context) {
+    throw new Error('useTemplateEditor must be used within a TemplateEditorProvider');
+  }
+  return context;
+};

--- a/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
@@ -13,8 +13,9 @@ import {
   MetadataType, 
   SingleMetadataType, 
   MultipleMetadataType, 
-  MetadataItem 
+  MetadataItem
 } from '@/types/prompts/metadata';
+import { TemplateEditorProvider } from './TemplateEditorContext';
 
 interface TemplateEditorDialogProps {
   // State from base hook
@@ -103,8 +104,9 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
   }, [metadata, content, buildFinalPromptContent, blocksLoading]);
 
 
-  // Create metadata UI state object for AdvancedEditor
-  const metadataUIState = React.useMemo(() => ({
+  const contextValue = React.useMemo(() => ({
+    metadata,
+    setMetadata,
     expandedMetadata,
     setExpandedMetadata,
     activeSecondaryMetadata,
@@ -114,6 +116,8 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
     setSecondaryMetadataCollapsed,
     customValues
   }), [
+    metadata,
+    setMetadata,
     expandedMetadata,
     setExpandedMetadata,
     activeSecondaryMetadata,
@@ -162,6 +166,7 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
       className="jd-max-w-6xl jd-h-[100vh]"
     >
       {infoForm}
+      <TemplateEditorProvider value={contextValue}>
       <div className="jd-flex jd-flex-col jd-h-full jd-gap-4">
         {error && (
           <Alert variant="destructive" className="jd-mb-2">
@@ -194,7 +199,6 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
                 onContentChange={setContent}
                 mode={mode as any}
                 isProcessing={false}
-                metadata={metadata}
                 finalPromptContent={finalPromptContent}
               />
             </TabsContent>
@@ -204,9 +208,6 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
                 content={content}
                 onContentChange={setContent}
                 isProcessing={false}
-                resolvedMetadata={metadata}
-                setMetadata={setMetadata}
-                metadataUIState={metadataUIState}
                 availableMetadataBlocks={availableMetadataBlocks}
                 availableBlocksByType={availableBlocksByType}
                 blockContentCache={blockContentCache}
@@ -239,6 +240,7 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
           </div>
         )}
       </div>
+      </TemplateEditorProvider>
     </BaseDialog>
   );
 };

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/MetadataSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/MetadataSection.tsx
@@ -19,7 +19,6 @@ import { useThemeDetector } from '@/hooks/useThemeDetector';
 
 import { MetadataCard } from '@/components/prompts/blocks/MetadataCard';
 import {
-  PromptMetadata,
   MetadataType,
   SingleMetadataType,
   MultipleMetadataType,
@@ -30,6 +29,7 @@ import {
   isMultipleMetadataType
 } from '@/types/prompts/metadata';
 import { Block } from '@/types/prompts/blocks';
+import { useTemplateEditor } from '../../TemplateEditorDialog/TemplateEditorContext';
 import {
   updateSingleMetadata,
   updateCustomValue,
@@ -52,35 +52,20 @@ const METADATA_ICONS: Record<MetadataType, React.ComponentType<any>> = {
   constraint: Ban
 };
 
-interface MetadataState {
-  expandedMetadata: MetadataType | null;
-  setExpandedMetadata: (type: MetadataType | null) => void;
-  activeSecondaryMetadata: Set<MetadataType>;
-  metadataCollapsed: boolean;
-  setMetadataCollapsed: (collapsed: boolean) => void;
-  secondaryMetadataCollapsed: boolean;
-  setSecondaryMetadataCollapsed: (collapsed: boolean) => void;
-}
-
 interface MetadataSectionProps {
-  // Add metadata as a prop instead of using context
-  metadata: PromptMetadata;
   availableMetadataBlocks: Record<MetadataType, Block[]>;
-  state: MetadataState;
-  setMetadata: (updater: (metadata: PromptMetadata) => PromptMetadata) => void;
   showPrimary?: boolean;
   showSecondary?: boolean;
 }
 
 export const MetadataSection: React.FC<MetadataSectionProps> = ({
-  metadata,
   availableMetadataBlocks,
-  state,
-  setMetadata,
   showPrimary = true,
   showSecondary = true
 }) => {
   const {
+    metadata,
+    setMetadata,
     expandedMetadata,
     setExpandedMetadata,
     activeSecondaryMetadata,
@@ -88,7 +73,7 @@ export const MetadataSection: React.FC<MetadataSectionProps> = ({
     setMetadataCollapsed,
     secondaryMetadataCollapsed,
     setSecondaryMetadataCollapsed
-  } = state;
+  } = useTemplateEditor();
 
   const handleSingleMetadataChange = useCallback(
     (type: SingleMetadataType, value: string) => {

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
@@ -14,6 +14,7 @@ import {
   BlockType
 } from '@/types/prompts/metadata';
 import { MetadataSection } from './MetadataSection';
+import { useTemplateEditor } from '../../TemplateEditorDialog/TemplateEditorContext';
 import EditablePromptPreview from '@/components/prompts/EditablePromptPreview';
 import { Eye, EyeOff, ChevronDown, ChevronUp } from 'lucide-react';
 import {
@@ -27,26 +28,10 @@ import {
   removeSecondaryMetadata
 } from '@/utils/prompts/metadataUtils';
 
-interface MetadataUIState {
-  expandedMetadata: MetadataType | null;
-  setExpandedMetadata: (type: MetadataType | null) => void;
-  activeSecondaryMetadata: Set<MetadataType>;
-  metadataCollapsed: boolean;
-  setMetadataCollapsed: (collapsed: boolean) => void;
-  secondaryMetadataCollapsed: boolean;
-  setSecondaryMetadataCollapsed: (collapsed: boolean) => void;
-  customValues: Record<string, string>;
-}
-
 interface AdvancedEditorProps {
   content: string;
   onContentChange: (value: string) => void;
   isProcessing?: boolean;
-  
-  // Metadata props - passed down from dialog instead of using context
-  resolvedMetadata: PromptMetadata;
-  setMetadata: (updater: (metadata: PromptMetadata) => PromptMetadata) => void;
-  metadataUIState: MetadataUIState;
   
   // Block-related props passed from dialog
   availableMetadataBlocks?: Record<MetadataType, Block[]>;
@@ -60,9 +45,6 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   content,
   onContentChange,
   isProcessing = false,
-  resolvedMetadata,
-  setMetadata,
-  metadataUIState,
   availableMetadataBlocks = {},
   availableBlocksByType = {},
   blockContentCache = {},
@@ -73,6 +55,8 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   const [showPreview, setShowPreview] = useState(false);
 
   const {
+    metadata: resolvedMetadata,
+    setMetadata,
     expandedMetadata,
     setExpandedMetadata,
     activeSecondaryMetadata,
@@ -81,7 +65,7 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
     secondaryMetadataCollapsed,
     setSecondaryMetadataCollapsed,
     customValues
-  } = metadataUIState;
+  } = useTemplateEditor();
 
   const handleSingleMetadataChange = useCallback(
     (type: SingleMetadataType, value: string) => {
@@ -186,21 +170,9 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
       <div className="jd-relative jd-z-10 jd-flex-1 jd-flex jd-flex-col jd-space-y-6 jd-p-6 jd-overflow-y-auto">
         
          {/* 1. PRIMARY METADATA SECTION */}
-         <div className="jd-flex-shrink-0">
+        <div className="jd-flex-shrink-0">
           <MetadataSection
-            metadata={resolvedMetadata}
             availableMetadataBlocks={availableMetadataBlocks}
-            state={{
-              expandedMetadata,
-              setExpandedMetadata,
-              activeSecondaryMetadata,
-              metadataCollapsed,
-              setMetadataCollapsed,
-              secondaryMetadataCollapsed,
-              setSecondaryMetadataCollapsed
-            }}
-            setMetadata={setMetadata}
-            onSaveBlock={onBlockSaved ?? (() => {})}
             showPrimary={true}
             showSecondary={false}
           />
@@ -234,19 +206,7 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
        {/* 3. SECONDARY METADATA SECTION */}
        <div className="jd-flex-shrink-0">
           <MetadataSection
-            metadata={resolvedMetadata}
             availableMetadataBlocks={availableMetadataBlocks}
-            state={{
-              expandedMetadata,
-              setExpandedMetadata,
-              activeSecondaryMetadata,
-              metadataCollapsed,
-              setMetadataCollapsed,
-              secondaryMetadataCollapsed,
-              setSecondaryMetadataCollapsed
-            }}
-            setMetadata={setMetadata}
-            onSaveBlock={onBlockSaved ?? (() => {})}
             showPrimary={false}
             showSecondary={true}
           />

--- a/src/components/dialogs/prompts/editors/BasicEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/BasicEditor/index.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/core/utils/classNames';
 import { Eye, EyeOff, ChevronDown, ChevronUp } from 'lucide-react';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
 import EditablePromptPreview from '@/components/prompts/EditablePromptPreview';
-import { PromptMetadata } from '@/types/prompts/metadata';
+import { useTemplateEditor } from '../../TemplateEditorDialog/TemplateEditorContext';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { PlaceholderPanel } from './PlaceholderPanel';
 import { ContentEditor } from './ContentEditor';
@@ -17,11 +17,6 @@ interface BasicEditorProps {
   onContentChange: (content: string) => void;
   mode?: 'create' | 'customize';
   isProcessing?: boolean;
-  
-  // Metadata props - passed down from dialog
-  metadata: PromptMetadata;
-  
-  // New prop for consistent final content
   finalPromptContent?: string;
 }
 
@@ -34,9 +29,9 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
   onContentChange,
   mode = 'customize',
   isProcessing = false,
-  metadata,
   finalPromptContent
 }) => {
+  const { metadata } = useTemplateEditor();
   const {
     // State
     placeholders,


### PR DESCRIPTION
## Summary
- avoid metadata prop drilling by adding `TemplateEditorContext`
- use the context in `TemplateEditorDialog` and editors

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_684979076e7c8325915468f7a10c9f65