### PR TITLE
Fix metadata key handling for examples and constraints

### DIFF
--- a/src/types/prompts/templates.ts
+++ b/src/types/prompts/templates.ts
@@ -7,8 +7,8 @@ export interface TemplateMetadata {
   tone_style?: number;
   output_format?: number;
   audience?: number;
-  examples?: number[];
-  constraints?: number[];
+  example?: number[];
+  constraint?: number[];
 }
 
 export interface Template {


### PR DESCRIPTION
## Summary
- map singular metadata types (`example`, `constraint`) to internal plural keys
- update metadata helper functions to use the mapping
- export singular keys when converting metadata for API
- interpret singular keys when loading metadata
- update TemplateMetadata interface to match API

## Testing
- `npm run type-check`
- `npm run lint` *(fails: 483 errors)*

------
https://chatgpt.com/codex/tasks/task_b_6850204e8f7c8325b660fb40a048f3f6