### PR TITLE
Fix metadata item ordering

### DIFF
--- a/src/utils/prompts/metadataUtils.ts
+++ b/src/utils/prompts/metadataUtils.ts
@@ -113,7 +113,9 @@ export function addMetadataItem(
   
   const key = MULTI_TYPE_KEY_MAP[type];
   const currentItems = (updated as any)[key] || [];
-  (updated as any)[key] = [...currentItems, newItem];
+  // Insert the new item at the beginning so that recently added blocks
+  // always appear before the "add new block" button in the UI.
+  (updated as any)[key] = [newItem, ...currentItems];
   
   return updated;
 }


### PR DESCRIPTION
## Summary
- ensure newly added metadata items appear before the add button

## Testing
- `pnpm lint` *(fails: 482 errors)*
- `pnpm type-check`

------
https://chatgpt.com/codex/tasks/task_b_6850357b27e88325b8a36d31dadee417