### PR TITLE
Fix metadata expansion on dialog open

### DIFF
--- a/src/hooks/dialogs/useTemplateDialogBase.ts
+++ b/src/hooks/dialogs/useTemplateDialogBase.ts
@@ -23,7 +23,8 @@ import {
   removeSecondaryMetadata,
   getActiveSecondaryMetadata,
   extractCustomValues,
-  validateMetadata
+  validateMetadata,
+  getFirstActiveMetadataType
 } from '@/utils/prompts/metadataUtils';
 
 export interface TemplateDialogConfig {
@@ -326,20 +327,24 @@ export function useTemplateDialogBase(config: TemplateDialogConfig) {
       try {
         // Initialize form data
         if (dialogType === 'create') {
+          const meta = initialData.template?.metadata || createMetadata();
           setState(prev => ({
             ...prev,
             name: initialData.template?.title || '',
             description: initialData.template?.description || '',
             content: getLocalizedContent(initialData.template?.content || ''),
             selectedFolderId: initialData.selectedFolder?.id?.toString() || '',
-            metadata: initialData.template?.metadata || createMetadata(),
+            metadata: meta,
+            expandedMetadata: getFirstActiveMetadataType(meta),
             isProcessing: false
           }));
         } else if (dialogType === 'customize') {
+          const meta = initialData.metadata || createMetadata();
           setState(prev => ({
             ...prev,
             content: getLocalizedContent(initialData.content || ''),
-            metadata: initialData.metadata || createMetadata(),
+            metadata: meta,
+            expandedMetadata: getFirstActiveMetadataType(meta),
             isProcessing: false
           }));
         }

--- a/src/utils/prompts/metadataUtils.ts
+++ b/src/utils/prompts/metadataUtils.ts
@@ -268,6 +268,32 @@ export function extractCustomValues(metadata: PromptMetadata): Record<SingleMeta
 }
 
 /**
+ * Get the first metadata type that contains a value. Useful for
+ * automatically expanding metadata sections when editing templates.
+ */
+export function getFirstActiveMetadataType(metadata: PromptMetadata): MetadataType | null {
+  const allTypes: MetadataType[] = [...PRIMARY_METADATA, ...SECONDARY_METADATA];
+
+  for (const type of allTypes) {
+    if (isMultipleMetadataType(type)) {
+      const key = MULTI_TYPE_KEY_MAP[type];
+      if ((metadata as any)[key] && (metadata as any)[key].length > 0) {
+        return type;
+      }
+    } else {
+      const singleType = type as SingleMetadataType;
+      const blockId = metadata[singleType];
+      const customValue = metadata.values?.[singleType];
+      if ((blockId && blockId !== 0) || (customValue && customValue.trim())) {
+        return type;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
  * Validate metadata completeness
  */
 export function validateMetadata(metadata: PromptMetadata): {


### PR DESCRIPTION
## Summary
- automatically select first active metadata when opening template dialogs
- expose helper `getFirstActiveMetadataType` for metadata utils

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_685038d59b248325bb2245b553fecc19