### PR TITLE
Add nested folder support

### DIFF
--- a/src/hooks/prompts/queries/folders/useAllFolders.ts
+++ b/src/hooks/prompts/queries/folders/useAllFolders.ts
@@ -10,8 +10,8 @@ export function useAllFolders() {
   
   return useQuery(QUERY_KEYS.ALL_FOLDERS, async () => {
     const [officialResponse, organizationResponse] = await Promise.all([
-      promptApi.getAllFolders('official', false, userLocale),
-      promptApi.getAllFolders('organization', false, userLocale)
+      promptApi.getFolders('official', true, true, userLocale),
+      promptApi.getFolders('organization', true, true, userLocale)
     ]);
 
     if (!officialResponse.success || !organizationResponse.success) {
@@ -19,8 +19,8 @@ export function useAllFolders() {
     }
 
     return {
-      official: officialResponse.folders as TemplateFolder[],
-      organization: organizationResponse.folders as TemplateFolder[]
+      official: (officialResponse.data.folders.official || []) as TemplateFolder[],
+      organization: (organizationResponse.data.folders.organization || []) as TemplateFolder[]
     };
   }, {
     refetchOnWindowFocus: false,

--- a/src/hooks/prompts/queries/folders/useAllFoldersOfType.ts
+++ b/src/hooks/prompts/queries/folders/useAllFoldersOfType.ts
@@ -14,13 +14,13 @@ export function useAllFoldersOfType(folderType: 'official' | 'organization') {
   return useQuery(
     [QUERY_KEYS.ALL_FOLDERS, folderType], // Query key array with type
     async () => {
-      const response = await promptApi.getAllFolders(folderType, false, userLocale);
+      const response = await promptApi.getFolders(folderType, true, true, userLocale);
 
       if (!response.success) {
         throw new Error(response.message || `Failed to fetch ${folderType} folders`);
       }
 
-      return response.data as TemplateFolder[];
+      return (response.data.folders[folderType] || []) as TemplateFolder[];
     },
     {
       refetchOnWindowFocus: false,

--- a/src/hooks/prompts/queries/folders/usePinnedFolders.ts
+++ b/src/hooks/prompts/queries/folders/usePinnedFolders.ts
@@ -18,14 +18,13 @@ export function usePinnedFolders() {
     
     // Get official pinned folders with locale filtering
     const officialIds = metadata.data?.pinned_official_folder_ids || [];
-    console.log('officialIds------------------>>', officialIds);
     let officialFolders: TemplateFolder[] = [];
-    
+
     if (officialIds.length > 0) {
-      const officialResponse = await promptApi.getAllFolders('official', false, userLocale);
-      console.log('officialResponse------------------>>', officialResponse);
+      const officialResponse = await promptApi.getFolders('official', true, true, userLocale);
       if (officialResponse.success) {
-        officialFolders = officialResponse.data
+        const allFolders = (officialResponse.data.folders.official || []) as TemplateFolder[];
+        officialFolders = allFolders
           .filter((folder: TemplateFolder) => officialIds.includes(folder.id))
           .map((folder: TemplateFolder) => ({
             ...folder,
@@ -37,11 +36,12 @@ export function usePinnedFolders() {
     // Get organization pinned folders with locale filtering
     const orgIds = metadata.data?.pinned_organization_folder_ids || [];
     let orgFolders: TemplateFolder[] = [];
-    
+
     if (orgIds.length > 0) {
-      const orgResponse = await promptApi.getAllFolders('organization', false, userLocale);
+      const orgResponse = await promptApi.getFolders('organization', true, true, userLocale);
       if (orgResponse.success) {
-        orgFolders = orgResponse.data
+        const allFolders = (orgResponse.data.folders.organization || []) as TemplateFolder[];
+        orgFolders = allFolders
           .filter((folder: TemplateFolder) => orgIds.includes(folder.id))
           .map((folder: TemplateFolder) => ({
             ...folder,

--- a/src/hooks/prompts/queries/folders/useUserFolders.ts
+++ b/src/hooks/prompts/queries/folders/useUserFolders.ts
@@ -2,45 +2,20 @@
 import { useQuery } from 'react-query';
 import { promptApi } from '@/services/api';
 import { toast } from 'sonner';
-import { QUERY_KEYS } from '@/constants/queryKeys'; // Updated import
+import { getCurrentLanguage } from '@/core/utils/i18n';
+import { QUERY_KEYS } from '@/constants/queryKeys';
 import { TemplateFolder } from '@/types/prompts/templates';
 
 export function useUserFolders() {
+  const locale = getCurrentLanguage();
+
   return useQuery(QUERY_KEYS.USER_FOLDERS, async () => {
-    const response = await promptApi.getUserFolders();
+    const response = await promptApi.getFolders('user', true, true, locale);
     if (!response.success) {
       throw new Error(response.message || 'Failed to load user folders');
     }
-    
-    // Also fetch user templates to properly handle templates with null folder_id
-    const templatesResponse = await promptApi.getUserTemplates();
 
-    if (templatesResponse.success && templatesResponse.data) {
-      // Map folder ID to folder object and track existing template IDs to avoid duplicates
-      const folderMap = new Map<number, { folder: TemplateFolder; idSet: Set<number> }>();
-
-      response.data.forEach((folder: TemplateFolder) => {
-        const templatesArray = Array.isArray(folder.templates) ? folder.templates : [];
-        folder.templates = templatesArray;
-        const idSet = new Set<number>(templatesArray.map(t => t.id));
-        folderMap.set(folder.id, { folder, idSet });
-      });
-
-      // Assign templates to their folders, skipping duplicates and unorganized templates
-      templatesResponse.data.forEach(template => {
-        if (template.folder_id === null) {
-          return; // unorganized template handled elsewhere
-        }
-
-        const mapEntry = folderMap.get(template.folder_id);
-        if (mapEntry && !mapEntry.idSet.has(template.id)) {
-          mapEntry.folder.templates.push(template);
-          mapEntry.idSet.add(template.id);
-        }
-      });
-    }
-    
-    return response.data;
+    return (response.data.folders.user || []) as TemplateFolder[];
   }, {
     refetchOnWindowFocus: false,
     onError: (error: Error) => {

--- a/src/services/api/PromptApi.ts
+++ b/src/services/api/PromptApi.ts
@@ -2,6 +2,7 @@
 import { 
         getAllFolders,
         getUserFolders,
+        getFolders,
         updatePinnedFolders,
         toggleFolderPin,
         createFolder,
@@ -23,6 +24,15 @@ class PromptApiClient {
   
   async getAllFolders(type: string, empty: boolean = false, locale?: string): Promise<any> {
     return getAllFolders(type, empty, locale);
+  }
+
+  async getFolders(
+    type?: string,
+    withSubfolders: boolean = false,
+    withTemplates: boolean = false,
+    locale?: string
+  ): Promise<any> {
+    return getFolders(type, withSubfolders, withTemplates, locale);
   }
   
   async updatePinnedFolders(type: 'official' | 'organization', folderIds: number[]): Promise<any> {

--- a/src/services/api/prompts/folders/getFolders.ts
+++ b/src/services/api/prompts/folders/getFolders.ts
@@ -1,0 +1,46 @@
+import { apiClient } from '@/services/api/ApiClient';
+import { getCurrentLanguage } from '@/core/utils/i18n';
+import { TemplateFolder } from '@/types/prompts/folders';
+import { normalizeFolders } from '@/utils/prompts/folderUtils';
+
+export interface GetFoldersResponse {
+  success: boolean;
+  data: { folders: Record<string, TemplateFolder[]> };
+  message?: string;
+}
+
+export async function getFolders(
+  type?: string,
+  withSubfolders = false,
+  withTemplates = false,
+  locale?: string
+): Promise<GetFoldersResponse> {
+  try {
+    const params = new URLSearchParams();
+    if (type) params.append('type', type);
+    if (withSubfolders) params.append('withSubfolders', 'true');
+    if (withTemplates) params.append('withTemplates', 'true');
+    const userLocale = locale || getCurrentLanguage();
+    if (userLocale) params.append('locale', userLocale);
+
+    const endpoint = `/prompts/folders?${params.toString()}`;
+    const response = await apiClient.request(endpoint);
+
+    if (response && response.success && response.data?.folders) {
+      const normalized: Record<string, TemplateFolder[]> = {};
+      for (const key of Object.keys(response.data.folders)) {
+        normalized[key] = normalizeFolders(response.data.folders[key]);
+      }
+      response.data.folders = normalized;
+    }
+
+    return response as GetFoldersResponse;
+  } catch (error) {
+    console.error('Error fetching folders:', error);
+    return {
+      success: false,
+      data: { folders: {} },
+      message: error instanceof Error ? error.message : 'Unknown error'
+    };
+  }
+}

--- a/src/services/api/prompts/folders/index.ts
+++ b/src/services/api/prompts/folders/index.ts
@@ -1,5 +1,6 @@
 export { getAllFolders } from './getAllFolders';
 export { getUserFolders } from './getUserFolders';
+export { getFolders } from './getFolders';
 export { updatePinnedFolders } from './updatePinnedFolders';
 export { toggleFolderPin } from './toggleFolderPin';
 export { createFolder } from './createFolder';

--- a/src/utils/prompts/folderUtils.ts
+++ b/src/utils/prompts/folderUtils.ts
@@ -93,3 +93,37 @@ export function groupFoldersByType(folders: TemplateFolder[]): {
     }
   );
 }
+
+/**
+ * Normalize folder data coming from the API. The backend uses
+ * the property `subfolders` while the frontend expects `Folders`.
+ * This helper recursively converts the structure so existing
+ * components can render nested folders correctly.
+ */
+export function normalizeFolder(folder: any): TemplateFolder {
+  if (!folder || typeof folder !== 'object') {
+    return {} as TemplateFolder;
+  }
+
+  const { subfolders, templates, ...rest } = folder;
+
+  const normalized: TemplateFolder = {
+    ...(rest as TemplateFolder),
+    templates: Array.isArray(templates) ? templates : [],
+    Folders: []
+  };
+
+  if (Array.isArray(subfolders)) {
+    normalized.Folders = subfolders.map(f => normalizeFolder(f));
+  }
+
+  return normalized;
+}
+
+/**
+ * Normalize an array of folders from the API
+ */
+export function normalizeFolders(folders: any[]): TemplateFolder[] {
+  if (!Array.isArray(folders)) return [];
+  return folders.map(f => normalizeFolder(f));
+}


### PR DESCRIPTION
## Summary
- normalize folder data from API
- add API call for fetching folders with nested data
- update hooks to use new endpoint
- adapt templates panel to display nested folders

## Testing
- `npm run type-check`
- `npm run lint` *(fails: numerous pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_685149dd688483258c74173731d6cafb