### PR TITLE
Fix template folder fetching

### DIFF
--- a/src/components/prompts/folders/FolderItem.tsx
+++ b/src/components/prompts/folders/FolderItem.tsx
@@ -13,8 +13,8 @@ const ITEMS_PER_PAGE = 5;
 
 interface FolderItemProps {
   folder: TemplateFolder;
-  type: 'official' | 'organization' | 'user';
-  onTogglePin?: (folderId: number, isPinned: boolean) => Promise<void> | void;
+  type: 'official' | 'organization' | 'user' | 'mixed';
+  onTogglePin?: (folderId: number, isPinned: boolean, folderType?: 'official' | 'organization' | 'user') => Promise<void> | void;
   onDeleteFolder?: (folderId: number) => Promise<boolean> | void;
   onUseTemplate?: (template: Template) => void;
   onEditTemplate?: (template: Template) => void;
@@ -106,7 +106,7 @@ const FolderItem: React.FC<FolderItemProps> = ({
       isPinOperationInProgress.current = true;
       setIsPinned(prevPinned => !prevPinned);
       
-      Promise.resolve(onTogglePin(folder.id, isPinned))
+      Promise.resolve(onTogglePin(folder.id, isPinned, folder.type))
         .catch(err => {
           console.error('Pin operation failed:', err);
           setIsPinned(isPinned);

--- a/src/components/prompts/folders/FolderList.tsx
+++ b/src/components/prompts/folders/FolderList.tsx
@@ -6,8 +6,8 @@ import { EmptyMessage } from '@/components/panels/TemplatesPanel/EmptyMessage';
 
 interface FolderListProps {
   folders: TemplateFolder[];
-  type: 'official' | 'organization' | 'user';
-  onTogglePin?: (folderId: number, isPinned: boolean) => Promise<void> | void;
+  type: 'official' | 'organization' | 'user' | 'mixed';
+  onTogglePin?: (folderId: number, isPinned: boolean, folderType?: 'official' | 'organization' | 'user') => Promise<void> | void;
   onDeleteFolder?: (folderId: number) => Promise<boolean> | void;
   onUseTemplate?: (template: Template) => void;
   onEditTemplate?: (template: Template) => void;
@@ -67,7 +67,7 @@ const FolderList: React.FC<FolderListProps> = ({
             key={`folder-${folder.id}-${type}`}
             folder={folder}
             type={type}
-            onTogglePin={onTogglePin}
+            onTogglePin={onTogglePin ? ((id, pinned) => onTogglePin(id, pinned, folder.type)) : undefined}
             onDeleteFolder={onDeleteFolder}
             onUseTemplate={onUseTemplate}
             onEditTemplate={onEditTemplate}

--- a/src/hooks/prompts/queries/folders/index.ts
+++ b/src/hooks/prompts/queries/folders/index.ts
@@ -1,4 +1,4 @@
-export { useUserFolders } from './useUserFolders';
+export { useUserFolders, useCompanyFolders, useMixedFolders } from './useUserCompanyMixedFolders';
 export { usePinnedFolders } from './usePinnedFolders';
 export { useAllFolders } from './useAllFolders';
 export { useAllFoldersOfType } from './useAllFoldersOfType';

--- a/src/hooks/prompts/queries/folders/useAllFoldersOfType.ts
+++ b/src/hooks/prompts/queries/folders/useAllFoldersOfType.ts
@@ -6,9 +6,9 @@ import { QUERY_KEYS } from '@/constants/queryKeys';
 import { TemplateFolder } from '@/types/prompts/templates';
 
 /**
- * Hook to fetch all folders of a specific type (official or organization)
+ * Hook to fetch all folders of a specific type (official, organization or mixed)
  */
-export function useAllFoldersOfType(folderType: 'official' | 'organization') {
+export function useAllFoldersOfType(folderType: 'official' | 'organization' | 'mixed') {
   const userLocale = getCurrentLanguage();
   
   return useQuery(

--- a/src/hooks/prompts/queries/folders/useUserCompanyMixedFolders.ts
+++ b/src/hooks/prompts/queries/folders/useUserCompanyMixedFolders.ts
@@ -1,10 +1,10 @@
-// src/hooks/prompts/queries/folders/useUserFolders.ts
+// src/hooks/prompts/queries/folders/useUserCompanyMixedFolders.ts
 import { useQuery } from 'react-query';
 import { promptApi } from '@/services/api';
 import { toast } from 'sonner';
 import { getCurrentLanguage } from '@/core/utils/i18n';
 import { QUERY_KEYS } from '@/constants/queryKeys';
-import { TemplateFolder, Template } from '@/types/prompts/templates';
+import { TemplateFolder } from '@/types/prompts/templates';
 
 
 
@@ -37,7 +37,7 @@ export function useCompanyFolders() {
     if (!foldersResponse.success) {
       throw new Error(foldersResponse.message || 'Failed to load company folders');
     }
-    return foldersResponse.data.folders.user || [];
+    return foldersResponse.data.folders.company || [];
   }, {
     refetchOnWindowFocus: false,
     onError: (error: Error) => {
@@ -56,7 +56,7 @@ export function useMixedFolders() {
     if (!foldersResponse.success) {
       throw new Error(foldersResponse.message || 'Failed to load mixed folders');
     }
-    return foldersResponse.data.folders.user || [];
+    return foldersResponse.data.folders.mixed || [];
   }, {
     refetchOnWindowFocus: false,
     onError: (error: Error) => {


### PR DESCRIPTION
## Summary
- rename folder query hooks and expose company & mixed folder hooks
- fetch company & mixed folders in TemplatesPanel
- support mixed folder type in BrowseTemplatesPanel

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6851703e9cd48325b8f3d470adcf4210