### PR TITLE
Implement scrollable templates panel

### DIFF
--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -1,6 +1,6 @@
 // src/components/panels/TemplatesPanel/index.tsx
 import React, { useCallback, memo, useMemo, useState } from 'react';
-import { FolderOpen, RefreshCw, PlusCircle, FileText, Plus, ChevronLeft, ChevronRight, ArrowLeft } from "lucide-react";
+import { FolderOpen, RefreshCw, PlusCircle, FileText, Plus, ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Separator } from "@/components/ui/separator";
@@ -43,8 +43,8 @@ interface FolderNavigation {
   currentFolder: TemplateFolder | null;
 }
 
-// Pagination constants
-const ITEMS_PER_PAGE = 5;
+// Scroll batch size
+const ITEMS_PER_BATCH = 20;
 
 /**
  * Updated TemplatesPanel with new structure:
@@ -66,10 +66,10 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
     currentFolder: null
   });
   
-  // Pagination states
-  const [userPage, setUserPage] = useState(0);
-  const [companyPage, setCompanyPage] = useState(0);
-  const [mixedPage, setMixedPage] = useState(0);
+  // Visible item counts for scrollable sections
+  const [userVisibleCount, setUserVisibleCount] = useState(ITEMS_PER_BATCH);
+  const [companyVisibleCount, setCompanyVisibleCount] = useState(ITEMS_PER_BATCH);
+  const [mixedVisibleCount, setMixedVisibleCount] = useState(ITEMS_PER_BATCH);
 
   // Data fetching
   const { 
@@ -175,7 +175,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
       path: [...prev.path, { id: folder.id, name: folder.name }],
       currentFolder: folder
     }));
-    setUserPage(0); // Reset pagination when navigating
+    setUserVisibleCount(ITEMS_PER_BATCH); // Reset visible count when navigating
   }, []);
 
   const navigateBack = useCallback(() => {
@@ -191,12 +191,12 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
         currentFolder: newCurrentFolder
       };
     });
-    setUserPage(0);
+    setUserVisibleCount(ITEMS_PER_BATCH);
   }, [userFolders]);
 
   const navigateToRoot = useCallback(() => {
     setUserFolderNav({ path: [], currentFolder: null });
-    setUserPage(0);
+    setUserVisibleCount(ITEMS_PER_BATCH);
   }, []);
 
   // Helper function to find folder by ID
@@ -234,15 +234,11 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
     return items;
   }, [userFolders, userFolderNav.currentFolder]);
 
-  // Pagination helpers
-  const paginateItems = useCallback((items: any[], page: number) => {
-    const startIdx = page * ITEMS_PER_PAGE;
-    const endIdx = startIdx + ITEMS_PER_PAGE;
+  // Helper to slice visible items
+  const getVisibleItems = useCallback((items: any[], count: number) => {
     return {
-      items: items.slice(startIdx, endIdx),
-      totalPages: Math.ceil(items.length / ITEMS_PER_PAGE),
-      hasNext: endIdx < items.length,
-      hasPrev: page > 0
+      items: items.slice(0, count),
+      hasMore: count < items.length
     };
   }, []);
 
@@ -333,10 +329,10 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
     );
   }
 
-  // Get paginated data
-  const userItems = paginateItems(getCurrentUserItems, userPage);
-  const companyItems = paginateItems(companyFolders, companyPage);
-  const mixedItems = paginateItems(mixedFolders, mixedPage);
+  // Get visible data for each section
+  const userItems = getVisibleItems(getCurrentUserItems, userVisibleCount);
+  const companyItems = getVisibleItems(companyFolders, companyVisibleCount);
+  const mixedItems = getVisibleItems(mixedFolders, mixedVisibleCount);
 
   return (
     <BasePanel
@@ -399,7 +395,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
           ) : (
             <>
               {/* Items display */}
-              <div className="jd-space-y-1 jd-px-2">
+              <div className="jd-space-y-1 jd-px-2 jd-max-h-96 jd-overflow-y-auto">
                 {userItems.items.map((item) => (
                   'templates' in item ? (
                     // It's a folder
@@ -441,32 +437,12 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
                 ))}
               </div>
 
-              {/* User pagination */}
-              {userItems.totalPages > 1 && (
+              {/* Load more */}
+              {userItems.hasMore && (
                 <div className="jd-flex jd-justify-center jd-mt-2">
-                  <div className="jd-flex jd-items-center jd-space-x-1 jd-bg-background/80 jd-border jd-border-border/30 jd-rounded jd-px-1">
-                    <Button 
-                      variant="ghost" 
-                      size="icon" 
-                      onClick={() => setUserPage(p => Math.max(0, p - 1))}
-                      disabled={!userItems.hasPrev}
-                      className="jd-h-6 jd-w-6"
-                    >
-                      <ChevronLeft className="jd-h-4 jd-w-4" />
-                    </Button>
-                    <span className="jd-text-xs jd-text-muted-foreground jd-px-1">
-                      {userPage + 1}/{userItems.totalPages}
-                    </span>
-                    <Button 
-                      variant="ghost" 
-                      size="icon" 
-                      onClick={() => setUserPage(p => Math.min(userItems.totalPages - 1, p + 1))}
-                      disabled={!userItems.hasNext}
-                      className="jd-h-6 jd-w-6"
-                    >
-                      <ChevronRight className="jd-h-4 jd-w-4" />
-                    </Button>
-                  </div>
+                  <Button variant="ghost" size="sm" onClick={() => setUserVisibleCount(c => c + ITEMS_PER_BATCH)}>
+                    {getMessage('loadMore', undefined, 'Load More')}
+                  </Button>
                 </div>
               )}
             </>
@@ -486,38 +462,19 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
               {getMessage('noCompanyAccess', undefined, 'Contact your company admin to access company templates.')}
             </EmptyMessage>
           ) : (
-            <FolderList
-              folders={companyItems.items as TemplateFolder[]}
-              type="organization"
-              onUseTemplate={useTemplate}
-            />
+            <div className="jd-max-h-96 jd-overflow-y-auto">
+              <FolderList
+                folders={companyItems.items as TemplateFolder[]}
+                type="organization"
+                onUseTemplate={useTemplate}
+              />
+            </div>
           )}
-
-          {companyItems.totalPages > 1 && (
+          {companyItems.hasMore && (
             <div className="jd-flex jd-justify-center jd-mt-2">
-              <div className="jd-flex jd-items-center jd-space-x-1 jd-bg-background/80 jd-border jd-border-border/30 jd-rounded jd-px-1">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => setCompanyPage(p => Math.max(0, p - 1))}
-                  disabled={!companyItems.hasPrev}
-                  className="jd-h-6 jd-w-6"
-                >
-                  <ChevronLeft className="jd-h-4 jd-w-4" />
-                </Button>
-                <span className="jd-text-xs jd-text-muted-foreground jd-px-1">
-                  {companyPage + 1}/{companyItems.totalPages}
-                </span>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => setCompanyPage(p => Math.min(companyItems.totalPages - 1, p + 1))}
-                  disabled={!companyItems.hasNext}
-                  className="jd-h-6 jd-w-6"
-                >
-                  <ChevronRight className="jd-h-4 jd-w-4" />
-                </Button>
-              </div>
+              <Button variant="ghost" size="sm" onClick={() => setCompanyVisibleCount(c => c + ITEMS_PER_BATCH)}>
+                {getMessage('loadMore', undefined, 'Load More')}
+              </Button>
             </div>
           )}
         </FolderSection>
@@ -557,7 +514,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
           ) : (
             <>
               {/* Mixed folders display */}
-              <div className="jd-space-y-1 jd-px-2">
+              <div className="jd-space-y-1 jd-px-2 jd-max-h-96 jd-overflow-y-auto">
                 {mixedItems.items.map((folder) => (
                   <div
                     key={`mixed-folder-${folder.id}`}
@@ -586,32 +543,12 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
                 ))}
               </div>
 
-              {/* Mixed pagination */}
-              {mixedItems.totalPages > 1 && (
+              {/* Load more */}
+              {mixedItems.hasMore && (
                 <div className="jd-flex jd-justify-center jd-mt-2">
-                  <div className="jd-flex jd-items-center jd-space-x-1 jd-bg-background/80 jd-border jd-border-border/30 jd-rounded jd-px-1">
-                    <Button 
-                      variant="ghost" 
-                      size="icon" 
-                      onClick={() => setMixedPage(p => Math.max(0, p - 1))}
-                      disabled={!mixedItems.hasPrev}
-                      className="jd-h-6 jd-w-6"
-                    >
-                      <ChevronLeft className="jd-h-4 jd-w-4" />
-                    </Button>
-                    <span className="jd-text-xs jd-text-muted-foreground jd-px-1">
-                      {mixedPage + 1}/{mixedItems.totalPages}
-                    </span>
-                    <Button 
-                      variant="ghost" 
-                      size="icon" 
-                      onClick={() => setMixedPage(p => Math.min(mixedItems.totalPages - 1, p + 1))}
-                      disabled={!mixedItems.hasNext}
-                      className="jd-h-6 jd-w-6"
-                    >
-                      <ChevronRight className="jd-h-4 jd-w-4" />
-                    </Button>
-                  </div>
+                  <Button variant="ghost" size="sm" onClick={() => setMixedVisibleCount(c => c + ITEMS_PER_BATCH)}>
+                    {getMessage('loadMore', undefined, 'Load More')}
+                  </Button>
                 </div>
               )}
             </>


### PR DESCRIPTION
## Summary
- replace pagination in `TemplatesPanel` with scrollable sections
- load templates in batches of 20 for each section

## Testing
- `npm run lint` *(fails: 494 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68526ae088e88325af454d5c4d126afb