### PR TITLE
Add folder manager dialog

### DIFF
--- a/src/components/dialogs/DialogRegistry.ts
+++ b/src/components/dialogs/DialogRegistry.ts
@@ -6,6 +6,7 @@ export const DIALOG_TYPES = {
   CREATE_TEMPLATE: 'createTemplate',
   EDIT_TEMPLATE: 'editTemplate',
   CREATE_FOLDER: 'createFolder',
+  FOLDER_MANAGER: 'folderManager',
   PLACEHOLDER_EDITOR: 'placeholderEditor',
   AUTH: 'auth',
   CONFIRMATION: 'confirmation',
@@ -42,6 +43,12 @@ export interface DialogProps {
   [DIALOG_TYPES.CREATE_FOLDER]: {
     onSaveFolder?: (folderData: any) => Promise<any>;
     onFolderCreated?: (folder: any) => void;
+  };
+
+  [DIALOG_TYPES.FOLDER_MANAGER]: {
+    folder: any;
+    userFolders: any[];
+    onUpdated?: (folder: any) => void;
   };
   
   [DIALOG_TYPES.AUTH]: {

--- a/src/components/dialogs/index.tsx
+++ b/src/components/dialogs/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { DialogProvider as DialogContextProvider } from './DialogContext';
 import { CreateTemplateDialog } from './prompts/CreateTemplateDialog';
 import { CreateFolderDialog } from './prompts/CreateFolderDialog';
+import { FolderManagerDialog } from './prompts/FolderManagerDialog';
 import { CustomizeTemplateDialog } from './prompts/CustomizeTemplateDialog';
 import { AuthDialog } from './auth/AuthDialog';
 import { SettingsDialog } from './settings/SettingsDialog';
@@ -39,6 +40,7 @@ export const DialogProvider: React.FC<{children: React.ReactNode}> = ({ children
       {/* Register all dialogs here */}
       <CreateTemplateDialog />
       <CreateFolderDialog  />
+      <FolderManagerDialog />
       <CustomizeTemplateDialog />
       <AuthDialog />
       <SettingsDialog />
@@ -58,4 +60,5 @@ export { AuthDialog } from './auth/AuthDialog';
 export { SettingsDialog } from './settings/SettingsDialog';
 export { ConfirmationDialog } from './common/ConfirmationDialog';
 export { EnhancedStatsDialog } from './analytics/EnhancedStatsDialog';
+export { FolderManagerDialog } from './prompts/FolderManagerDialog';
 export { BaseDialog } from './BaseDialog';

--- a/src/components/dialogs/prompts/FolderManagerDialog/index.tsx
+++ b/src/components/dialogs/prompts/FolderManagerDialog/index.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { useDialog } from '@/components/dialogs/DialogContext';
+import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
+import { BaseDialog } from '@/components/dialogs/BaseDialog';
+import { toast } from 'sonner';
+import { promptApi } from '@/services/api';
+import { TemplateFolder } from '@/types/prompts/templates';
+
+interface FolderManagerData {
+  folder: TemplateFolder;
+  userFolders: TemplateFolder[];
+  onUpdated?: (folder: TemplateFolder) => void;
+}
+
+export const FolderManagerDialog: React.FC = () => {
+  const { isOpen, data, dialogProps } = useDialog(DIALOG_TYPES.FOLDER_MANAGER);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [parentId, setParentId] = useState<number | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const dialogData = (data || {}) as FolderManagerData;
+  const folder = dialogData.folder;
+  const folders = dialogData.userFolders || [];
+
+  useEffect(() => {
+    if (isOpen && folder) {
+      setName(folder.name || '');
+      setDescription(folder.description || '');
+      setParentId(folder.parent_id ?? null);
+      setIsSubmitting(false);
+    }
+  }, [isOpen, folder]);
+
+  if (!isOpen || !folder) return null;
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsSubmitting(true);
+    try {
+      const res = await promptApi.updateFolder(folder.id, {
+        name,
+        description,
+        parent_id: parentId
+      });
+      if (res.success) {
+        toast.success('Folder updated');
+        if (dialogData.onUpdated) {
+          dialogData.onUpdated({ ...folder, name, description, parent_id: parentId });
+        }
+        dialogProps.onOpenChange(false);
+      } else {
+        toast.error(res.message || 'Failed to update');
+      }
+    } catch (error) {
+      console.error('Error updating folder:', error);
+      toast.error('Failed to update folder');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <BaseDialog
+      open={isOpen}
+      onOpenChange={dialogProps.onOpenChange}
+      title="Edit Folder"
+      description="Update folder information"
+      className="jd-max-w-xl"
+    >
+      <form onSubmit={handleSave} className="jd-space-y-4 jd-mt-4">
+        <div>
+          <label className="jd-text-sm jd-font-medium">Name</label>
+          <Input value={name} onChange={(e) => setName(e.target.value)} className="jd-mt-1" />
+        </div>
+        <div>
+          <label className="jd-text-sm jd-font-medium">Description</label>
+          <Textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={3} className="jd-mt-1" />
+        </div>
+        <div>
+          <label className="jd-text-sm jd-font-medium">Parent Folder</label>
+          <Select value={parentId ? String(parentId) : ''} onValueChange={(val) => setParentId(val ? parseInt(val) : null)}>
+            <SelectTrigger className="jd-mt-1">
+              <SelectValue placeholder="None" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">None</SelectItem>
+              {folders.filter(f => f.id !== folder.id).map(f => (
+                <SelectItem key={f.id} value={String(f.id)}>{f.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="jd-flex jd-justify-end jd-gap-2 jd-pt-4">
+          <Button type="button" variant="outline" onClick={() => dialogProps.onOpenChange(false)} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting || !name.trim()}>Save</Button>
+        </div>
+      </form>
+    </BaseDialog>
+  );
+};
+
+export default FolderManagerDialog;

--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -1,6 +1,6 @@
 // src/components/panels/TemplatesPanel/index.tsx
 import React, { useCallback, memo, useMemo, useState } from 'react';
-import { FolderOpen, RefreshCw, PlusCircle, FileText, Plus, ArrowLeft } from "lucide-react";
+import { FolderOpen, RefreshCw, PlusCircle, FileText, Plus, ArrowLeft, Pencil, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Separator } from "@/components/ui/separator";
@@ -102,7 +102,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
   const { toggleFolderPin, deleteFolder } = useFolderMutations();
   const { deleteTemplate } = useTemplateMutations();
   const { useTemplate, createTemplate, editTemplate, createFolderAndTemplate } = useTemplateActions();
-  const { openConfirmation } = useDialogActions();
+  const { openConfirmation, openFolderManager } = useDialogActions();
 
   // Loading and error states
   const { isLoading, hasError, errorMessage } = useMemo(() => ({
@@ -263,6 +263,10 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
     });
     return Promise.resolve(false);
   }, [openConfirmation, deleteFolder, refetchUser]);
+
+  const handleEditFolder = useCallback((folder: TemplateFolder) => {
+    openFolderManager({ folder, userFolders });
+  }, [openFolderManager, userFolders]);
 
   const handleEditTemplate = useCallback((template: Template) => {
     editTemplate(template);
@@ -469,16 +473,19 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
                         {((item.Folders?.length || 0) + (item.templates?.length || 0))} items
                       </span>
                       <div className="jd-flex jd-items-center jd-gap-2 jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity">
-                        <Button 
-                          variant="ghost" 
-                          size="sm" 
+                        <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); handleEditFolder(item); }}>
+                          <Pencil className="jd-h-4 jd-w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
                           className="jd-text-red-500 hover:jd-text-red-600 hover:jd-bg-red-100 jd-dark:hover:jd-bg-red-900/30"
                           onClick={(e) => {
                             e.stopPropagation();
                             handleDeleteFolder(item.id);
                           }}
                         >
-                          <FileText className="jd-h-4 jd-w-4" />
+                          <Trash2 className="jd-h-4 jd-w-4" />
                         </Button>
                       </div>
                     </div>

--- a/src/components/prompts/folders/FolderItem.tsx
+++ b/src/components/prompts/folders/FolderItem.tsx
@@ -16,6 +16,7 @@ interface FolderItemProps {
   type: 'company' | 'organization' | 'user';
   onTogglePin?: (folderId: number, isPinned: boolean, folderType?: 'official' | 'organization' | 'user') => Promise<void> | void;
   onDeleteFolder?: (folderId: number) => Promise<boolean> | void;
+  onEditFolder?: (folder: TemplateFolder) => void;
   onUseTemplate?: (template: Template) => void;
   onEditTemplate?: (template: Template) => void;
   onDeleteTemplate?: (templateId: number) => Promise<boolean> | void;
@@ -33,6 +34,7 @@ const FolderItem: React.FC<FolderItemProps> = ({
   type,
   onTogglePin,
   onDeleteFolder,
+  onEditFolder,
   onUseTemplate,
   onEditTemplate,
   onDeleteTemplate,
@@ -125,6 +127,13 @@ const FolderItem: React.FC<FolderItemProps> = ({
       onDeleteFolder(folder.id);
     }
   }, [folder.id, onDeleteFolder]);
+
+  const handleEditFolder = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (onEditFolder) {
+      onEditFolder(folder);
+    }
+  }, [folder, onEditFolder]);
   
   // Create action buttons for folder header
   const actionButtons = (
@@ -140,6 +149,20 @@ const FolderItem: React.FC<FolderItemProps> = ({
       
       {type === 'user' && (
         <div className="jd-flex jd-items-center jd-gap-2 jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity">
+          {onEditFolder && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="ghost" size="sm" onClick={handleEditFolder}>
+                    <Pencil className="jd-h-4 jd-w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p>Edit folder</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
           {showDeleteControls && onDeleteFolder && (
             <TooltipProvider>
               <Tooltip>

--- a/src/components/prompts/folders/FolderList.tsx
+++ b/src/components/prompts/folders/FolderList.tsx
@@ -9,6 +9,7 @@ interface FolderListProps {
   type: 'company' | 'organization' | 'user';
   onTogglePin?: (folderId: number, isPinned: boolean, folderType?: 'company' | 'organization' | 'user') => Promise<void> | void;
   onDeleteFolder?: (folderId: number) => Promise<boolean> | void;
+  onEditFolder?: (folder: TemplateFolder) => void;
   onUseTemplate?: (template: Template) => void;
   onEditTemplate?: (template: Template) => void;
   onDeleteTemplate?: (templateId: number) => Promise<boolean> | void;
@@ -28,6 +29,7 @@ const FolderList: React.FC<FolderListProps> = ({
   type,
   onTogglePin,
   onDeleteFolder,
+  onEditFolder,
   onUseTemplate,
   onEditTemplate,
   onDeleteTemplate,
@@ -69,6 +71,7 @@ const FolderList: React.FC<FolderListProps> = ({
             type={type}
             onTogglePin={onTogglePin ? ((id, pinned) => onTogglePin(id, pinned, folder.type)) : undefined}
             onDeleteFolder={onDeleteFolder}
+            onEditFolder={onEditFolder}
             onUseTemplate={onUseTemplate}
             onEditTemplate={onEditTemplate}
             onDeleteTemplate={onDeleteTemplate}

--- a/src/hooks/dialogs/useDialogActions.ts
+++ b/src/hooks/dialogs/useDialogActions.ts
@@ -22,6 +22,11 @@ export function useDialogActions() {
     [openDialog]
   );
 
+  const openFolderManager = useCallback(
+    (props?: any) => openDialog(DIALOG_TYPES.FOLDER_MANAGER, props),
+    [openDialog]
+  );
+
   const openAuth = useCallback(
     (props?: any) => openDialog(DIALOG_TYPES.AUTH, props),
     [openDialog]
@@ -57,6 +62,7 @@ export function useDialogActions() {
     openCreateTemplate,
     openEditTemplate,
     openCreateFolder,
+    openFolderManager,
     openAuth,
     openPlaceholderEditor,
     openConfirmation,

--- a/src/services/api/PromptApi.ts
+++ b/src/services/api/PromptApi.ts
@@ -6,7 +6,8 @@ import {
         updatePinnedFolders,
         toggleFolderPin,
         createFolder,
-        deleteFolder
+        deleteFolder,
+        updateFolder
       } from './prompts/folders';
 import {
         createTemplate,
@@ -73,6 +74,10 @@ class PromptApiClient {
 
   async deleteFolder(folderId: number): Promise<{ success: boolean; message?: string; data?: any }> {
     return deleteFolder(folderId);
+  }
+
+  async updateFolder(folderId: number, data: { name?: string; description?: string; parent_id?: number | null }): Promise<any> {
+    return updateFolder(folderId, data);
   }
 
   async trackTemplateUsage(templateId: number): Promise<any> {

--- a/src/services/api/prompts/folders/index.ts
+++ b/src/services/api/prompts/folders/index.ts
@@ -5,3 +5,4 @@ export { updatePinnedFolders } from './updatePinnedFolders';
 export { toggleFolderPin } from './toggleFolderPin';
 export { createFolder } from './createFolder';
 export { deleteFolder } from './deleteFolder';
+export { updateFolder } from './updateFolder';

--- a/src/services/api/prompts/folders/updateFolder.ts
+++ b/src/services/api/prompts/folders/updateFolder.ts
@@ -1,0 +1,23 @@
+import { apiClient } from "@/services/api/ApiClient";
+
+/**
+ * Update an existing folder's data
+ */
+export async function updateFolder(
+  folderId: number,
+  data: { name?: string; description?: string; parent_id?: number | null }
+): Promise<{ success: boolean; message?: string; data?: any }> {
+  try {
+    const response = await apiClient.request(`/prompts/folders/${folderId}`, {
+      method: 'PUT',
+      body: JSON.stringify(data)
+    });
+    return response;
+  } catch (error) {
+    console.error('Error updating folder:', error);
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : 'Unknown error'
+    };
+  }
+}

--- a/src/types/dialog.ts
+++ b/src/types/dialog.ts
@@ -11,6 +11,7 @@ export const DIALOG_TYPES = {
   CREATE_TEMPLATE: 'createTemplate',
   EDIT_TEMPLATE: 'editTemplate',
   CREATE_FOLDER: 'createFolder',
+  FOLDER_MANAGER: 'folderManager',
   PLACEHOLDER_EDITOR: 'placeholderEditor',
   AUTH: 'auth',
   CONFIRMATION: 'confirmation'
@@ -71,4 +72,10 @@ export interface PlaceholderEditorData {
 export interface FolderDialogData {
   onSaveFolder: (folderData: { name: string; path: string; description: string }) => Promise<any>;
   onFolderCreated?: (folder: any) => void;
+}
+
+export interface FolderManagerData {
+  folder: any;
+  userFolders: any[];
+  onUpdated?: (folder: any) => void;
 }

--- a/src/types/prompts/templates.ts
+++ b/src/types/prompts/templates.ts
@@ -71,6 +71,7 @@ export interface Template {
     CREATE_TEMPLATE: 'createTemplate',
     EDIT_TEMPLATE: 'editTemplate',
     CREATE_FOLDER: 'createFolder',
+    FOLDER_MANAGER: 'folderManager',
     SETTINGS: 'settings',
     AUTH: 'auth',
     PLACEHOLDER_EDITOR: 'placeholderEditor',


### PR DESCRIPTION
## Summary
- support managing folders with FolderManagerDialog
- allow editing folder parent info via prompt API
- expose new dialog actions
- wire edit buttons in template panel and folder items

## Testing
- `npm run lint` *(fails: 506 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6852877b269883259c478e2900290b03