### PR TITLE
Fix metadata edits sync

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
@@ -1,22 +1,18 @@
 // src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx - Updated
-import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/core/utils/classNames';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
 import {
-  PromptMetadata,
   MetadataType,
-  SingleMetadataType,
-  MultipleMetadataType,
-  MetadataItem,
   Block,
   BlockType
 } from '@/types/prompts/metadata';
 import { MetadataSection } from './MetadataSection';
 import { useTemplateEditor } from '../../TemplateEditorDialog/TemplateEditorContext';
 import { EnhancedEditablePreview } from '@/components/prompts/EnhancedEditablePreview';
-import { Eye, EyeOff, ChevronDown, ChevronUp, Check } from 'lucide-react';
+import { Eye, EyeOff, ChevronDown, ChevronUp } from 'lucide-react';
 
 interface AdvancedEditorProps {
   content: string;
@@ -43,25 +39,25 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   const [showPreview, setShowPreview] = useState(true); // Show by default in advanced mode
   const { metadata } = useTemplateEditor();
 
-  const pendingContentRef = useRef(content);
+  const [pendingContent, setPendingContent] = useState(content);
   const [hasPendingContentChanges, setHasPendingContentChanges] = useState(false);
 
   useEffect(() => {
-    pendingContentRef.current = content;
+    setPendingContent(content);
     setHasPendingContentChanges(false);
   }, [content]);
 
   const handleContentChangeEnhanced = useCallback((value: string) => {
-    pendingContentRef.current = value;
+    setPendingContent(value);
     setHasPendingContentChanges(value !== content);
   }, [content]);
 
   const commitContentChanges = useCallback(() => {
     if (hasPendingContentChanges) {
-      onContentChange(pendingContentRef.current);
+      onContentChange(pendingContent);
       setHasPendingContentChanges(false);
     }
-  }, [hasPendingContentChanges, onContentChange]);
+  }, [hasPendingContentChanges, onContentChange, pendingContent]);
 
   useEffect(() => {
     return () => {
@@ -119,7 +115,7 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
             </h3>
             <div className="jd-relative">
               <Textarea
-                value={pendingContentRef.current}
+                value={pendingContent}
                 onChange={e => handleContentChangeEnhanced(e.target.value)}
                 className="!jd-min-h-[200px] jd-text-sm jd-resize-none jd-transition-all jd-duration-200 focus:jd-ring-2 focus:jd-ring-primary/50"
                 placeholder="Enter your main prompt content here..."
@@ -127,9 +123,9 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
                 onKeyPress={(e) => e.stopPropagation()}
                 onKeyUp={(e) => e.stopPropagation()}
               />
-              {pendingContentRef.current && (
+              {pendingContent && (
                 <div className="jd-absolute jd-bottom-2 jd-right-3 jd-text-xs jd-text-muted-foreground jd-bg-background/80 jd-px-2 jd-py-1 jd-rounded">
-                  {pendingContentRef.current.length} characters
+                  {pendingContent.length} characters
                   {hasPendingContentChanges && (
                     <span className="jd-text-amber-600 jd-ml-2">• Modified</span>
                   )}

--- a/src/hooks/prompts/editors/useEditablePromptPreview.ts
+++ b/src/hooks/prompts/editors/useEditablePromptPreview.ts
@@ -7,8 +7,9 @@ import {
   buildCompletePreviewWithBlocks,
   buildCompletePreviewHtmlWithBlocks,
   buildCompletePreview,
-  buildCompletePreviewHtml 
+  buildCompletePreviewHtml
 } from '@/utils/templates/promptPreviewUtils';
+import { applyBlockOverridesToMetadata } from '@/utils/prompts/metadataUtils';
 
 interface UseEditablePromptPreviewProps {
   metadata: PromptMetadata;
@@ -179,13 +180,38 @@ export function useEditablePromptPreview({
     if (onContentChange && contentOverride !== content) {
       onContentChange(contentOverride);
     }
+    if (
+      onMetadataChange &&
+      Object.keys(blockContentOverrides).length > 0
+    ) {
+      const newMeta = applyBlockOverridesToMetadata(
+        metadata,
+        blockContentOverrides
+      );
+      onMetadataChange(newMeta);
+    }
     // Note: Block overrides are for preview only and shouldn't modify original blocks
-  }, [contentOverride, content, onContentChange]);
+  }, [
+    contentOverride,
+    content,
+    onContentChange,
+    onMetadataChange,
+    blockContentOverrides,
+    metadata
+  ]);
 
   // Check if there are any modifications
   const hasModifications = useMemo(() => {
     return Object.keys(blockContentOverrides).length > 0 || contentOverride !== content;
   }, [blockContentOverrides, contentOverride, content]);
+
+  useEffect(() => {
+    return () => {
+      if (hasModifications) {
+        applyOverrides();
+      }
+    };
+  }, [hasModifications, applyOverrides]);
 
   return {
     // Preview content

--- a/src/utils/prompts/metadataUtils.ts
+++ b/src/utils/prompts/metadataUtils.ts
@@ -448,3 +448,52 @@ export function blockMappingToMetadata(
   
   return metadata;
 }
+
+/**
+ * Apply content overrides keyed by block ID to the metadata structure.
+ * This keeps the original block references while updating the associated
+ * custom values so modified text persists across editors.
+ */
+export function applyBlockOverridesToMetadata(
+  metadata: PromptMetadata,
+  overrides: Record<number, string>
+): PromptMetadata {
+  const updated = cloneMetadata(metadata);
+
+  const singleTypes: SingleMetadataType[] = [
+    'role',
+    'context',
+    'goal',
+    'audience',
+    'output_format',
+    'tone_style'
+  ];
+
+  singleTypes.forEach(type => {
+    const blockId = metadata[type];
+    if (blockId && overrides.hasOwnProperty(blockId)) {
+      if (!updated.values) updated.values = {} as any;
+      updated.values[type] = overrides[blockId];
+    }
+  });
+
+  if (metadata.constraints) {
+    updated.constraints = metadata.constraints.map(item => {
+      if (item.blockId && overrides.hasOwnProperty(item.blockId)) {
+        return { ...item, value: overrides[item.blockId] };
+      }
+      return item;
+    });
+  }
+
+  if (metadata.examples) {
+    updated.examples = metadata.examples.map(item => {
+      if (item.blockId && overrides.hasOwnProperty(item.blockId)) {
+        return { ...item, value: overrides[item.blockId] };
+      }
+      return item;
+    });
+  }
+
+  return updated;
+}


### PR DESCRIPTION
## Summary
- keep block overrides when applying metadata changes
- commit preview edits on unmount
- store pending content in state in AdvancedEditor for better focus handling
- update preview editing logic to push metadata updates

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6852a2a16e708325b9ed428a5f76e1db