### PR TITLE
Fix template editor state persistence

### DIFF
--- a/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
@@ -198,6 +198,7 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
 
             <TabsContent value="basic" className="jd-flex-1 jd-overflow-y-auto">
               <BasicEditor
+                key={`basic-${activeTab}`}
                 content={content}
                 onContentChange={setContent}
                 mode={mode as any}
@@ -209,6 +210,7 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
 
             <TabsContent value="advanced" className="jd-flex-1 jd-overflow-y-auto">
               <AdvancedEditor
+                key={`advanced-${activeTab}`}
                 content={content}
                 onContentChange={setContent}
                 isProcessing={false}

--- a/src/hooks/dialogs/useCustomizeTemplateDialog.ts
+++ b/src/hooks/dialogs/useCustomizeTemplateDialog.ts
@@ -7,14 +7,16 @@ import { toast } from 'sonner';
 import { getMessage } from '@/core/utils/i18n';
 import { PromptMetadata } from '@/types/prompts/metadata';
 import { buildCompletePrompt } from '@/utils/prompts/promptUtils';
+import { useBlockManager } from '@/hooks/prompts/editors/useBlockManager';
 
 export function useCustomizeTemplateDialog() {
   const { isOpen, data, dialogProps } = useDialog(DIALOG_TYPES.PLACEHOLDER_EDITOR);
+  const { blockContentCache } = useBlockManager();
   
   const handleComplete = async (content: string, metadata: PromptMetadata): Promise<boolean> => {
     try {
       // Build final content with metadata
-      const finalContent = buildCompletePrompt(metadata, content);
+      const finalContent = buildCompletePrompt(metadata, content, blockContentCache);
       
       if (data && data.onComplete) {
         data.onComplete(finalContent);


### PR DESCRIPTION
## Summary
- preserve editor changes when switching tabs by remounting editors
- correctly build final prompt by resolving metadata through block map
- use block manager cache when inserting customized prompts

## Testing
- `npm run lint` *(fails: 514 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6852a9db4b5483259328c341cb8ce5b6