### PR TITLE
Auto-apply template preview edits

### DIFF
--- a/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
@@ -207,34 +207,7 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
     >
       {infoForm}
       
-      {/* **NEW: Unsaved changes notification** */}
-      {hasUnsavedFinalChanges && (
-        <Alert className="jd-mb-4 jd-bg-amber-50 jd-border-amber-200 jd-text-amber-800">
-          <AlertTriangle className="jd-h-4 jd-w-4" />
-          <AlertDescription className="jd-flex jd-items-center jd-justify-between">
-            <span>You have unsaved changes in the preview</span>
-            <div className="jd-flex jd-gap-2">
-              <Button 
-                size="sm" 
-                variant="outline"
-                onClick={handleDiscardChanges}
-                className="jd-h-6 jd-px-2 jd-text-xs"
-              >
-                <RotateCcw className="jd-h-3 jd-w-3 jd-mr-1" />
-                Discard
-              </Button>
-              <Button 
-                size="sm" 
-                onClick={handleApplyChanges}
-                className="jd-h-6 jd-px-2 jd-text-xs jd-bg-amber-600 hover:jd-bg-amber-700"
-              >
-                <Save className="jd-h-3 jd-w-3 jd-mr-1" />
-                Apply
-              </Button>
-            </div>
-          </AlertDescription>
-        </Alert>
-      )}
+      {/* Preview changes now apply automatically */}
 
       <TemplateEditorProvider value={contextValue}>
       <div className="jd-flex jd-flex-col jd-h-full jd-gap-4">

--- a/src/hooks/dialogs/useTemplateDialogBase.ts
+++ b/src/hooks/dialogs/useTemplateDialogBase.ts
@@ -150,40 +150,31 @@ export function useTemplateDialogBase(config: TemplateDialogConfig) {
   // FINAL CONTENT MANAGEMENT - FIXED
   // ============================================================================
   
-  const setFinalPromptContent = useCallback((content: string, markAsChanged: boolean = true) => {
-    console.log('setFinalPromptContent called:', { 
-      content: content.substring(0, 50) + '...', 
-      markAsChanged, 
-      isInitializing: isInitializingRef.current,
-      baseline: baselineContentRef.current.substring(0, 50) + '...'
+  const setFinalPromptContent = useCallback((content: string) => {
+    console.log('setFinalPromptContent called:', {
+      content: content.substring(0, 50) + '...',
+      isInitializing: isInitializingRef.current
     });
-    
-    setState(prev => {
-      // **FIX: Only mark as changed if we're not initializing and content actually differs**
-      const shouldMarkAsChanged = markAsChanged && 
-        !isInitializingRef.current && 
-        content !== baselineContentRef.current;
-      
-      console.log('setFinalPromptContent decision:', { shouldMarkAsChanged });
-      
-      return {
-        ...prev,
-        finalPromptContent: content,
-        hasUnsavedFinalChanges: shouldMarkAsChanged ? true : prev.hasUnsavedFinalChanges
-      };
-    });
+
+    // **Automatically apply preview changes**
+    baselineContentRef.current = content;
+
+    setState(prev => ({
+      ...prev,
+      finalPromptContent: content,
+      hasUnsavedFinalChanges: false
+    }));
   }, []);
 
   const updateBlockContent = useCallback((blockId: number, newContent: string) => {
     console.log('updateBlockContent called:', { blockId, newContent: newContent.substring(0, 50) + '...' });
-    
+
     setState(prev => ({
       ...prev,
       modifiedBlocks: {
         ...prev.modifiedBlocks,
         [blockId]: newContent
-      },
-      hasUnsavedFinalChanges: !isInitializingRef.current
+      }
     }));
   }, []);
 


### PR DESCRIPTION
## Summary
- automatically apply preview edits to final prompt
- drop unsaved changes banner in TemplateEditorDialog

## Testing
- `pnpm lint` *(fails: no-useless-escape, no-explicit-any, etc.)*
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_b_6852b3e66cd08325b056be4cf756184a