### PR TITLE
Refactor dialog usage to unified template system

### DIFF
--- a/src/components/dialogs/DialogRegistry.ts
+++ b/src/components/dialogs/DialogRegistry.ts
@@ -3,8 +3,6 @@
 export const DIALOG_TYPES = {
   // Existing dialog types
   SETTINGS: 'settings',
-  CREATE_TEMPLATE: 'createTemplate',
-  EDIT_TEMPLATE: 'editTemplate',
   CREATE_FOLDER: 'createFolder',
   FOLDER_MANAGER: 'folderManager',
   UNIFIED_TEMPLATE: 'unifiedTemplate',
@@ -24,21 +22,6 @@ export type DialogType = typeof DIALOG_TYPES[keyof typeof DIALOG_TYPES];
 export interface DialogProps {
   [DIALOG_TYPES.SETTINGS]: Record<string, never>;
   
-  [DIALOG_TYPES.CREATE_TEMPLATE]: {
-    formData?: any;
-    onFormChange?: (formData: any) => void;
-    onSave?: (formData: any) => Promise<boolean>;
-    userFolders?: any[];
-    selectedFolder?: any;
-  };
-  
-  [DIALOG_TYPES.EDIT_TEMPLATE]: {
-    template: any;
-    formData?: any;
-    onFormChange?: (formData: any) => void;
-    onSave?: (formData: any) => Promise<boolean>;
-    userFolders?: any[];
-  };
   
   [DIALOG_TYPES.CREATE_FOLDER]: {
     onSaveFolder?: (folderData: any) => Promise<any>;
@@ -58,11 +41,6 @@ export interface DialogProps {
     onSuccess?: () => void;
   };
   
-  [DIALOG_TYPES.PLACEHOLDER_EDITOR]: {
-    content: string;
-    title?: string;
-    onComplete: (content: string) => void;
-  };
   
   [DIALOG_TYPES.CONFIRMATION]: {
     title?: string;

--- a/src/hooks/dialogs/useDialog.ts
+++ b/src/hooks/dialogs/useDialog.ts
@@ -18,9 +18,11 @@ export function useOpenDialog() {
   return {
     openSettings: () => openDialog('settings', {}),
     
-    openCreateTemplate: (props: any) => openDialog('createTemplate', props),
-    
-    openEditTemplate: (props: any) => openDialog('editTemplate', props),
+    openCreateTemplate: (props: any = {}) =>
+      openDialog('unifiedTemplate', { ...props, mode: 'create' }),
+
+    openEditTemplate: (props: any = {}) =>
+      openDialog('unifiedTemplate', { ...props, mode: 'edit' }),
     
     openCreateFolder: (props: any) => openDialog('createFolder', props),
     

--- a/src/hooks/dialogs/useDialogActions.ts
+++ b/src/hooks/dialogs/useDialogActions.ts
@@ -8,12 +8,14 @@ export function useDialogActions() {
   const openSettings = useCallback(() => openDialog(DIALOG_TYPES.SETTINGS, {}), [openDialog]);
 
   const openCreateTemplate = useCallback(
-    (props?: any) => openDialog(DIALOG_TYPES.CREATE_TEMPLATE, props),
+    (props?: any) =>
+      openDialog(DIALOG_TYPES.UNIFIED_TEMPLATE, { ...props, mode: 'create' }),
     [openDialog]
   );
 
   const openEditTemplate = useCallback(
-    (props?: any) => openDialog(DIALOG_TYPES.EDIT_TEMPLATE, props),
+    (props?: any) =>
+      openDialog(DIALOG_TYPES.UNIFIED_TEMPLATE, { ...props, mode: 'edit' }),
     [openDialog]
   );
 

--- a/src/hooks/prompts/actions/useTemplateActions.ts
+++ b/src/hooks/prompts/actions/useTemplateActions.ts
@@ -136,8 +136,11 @@ const useTemplate = useCallback(async (template: Template) => {
     };
 
 
-    // Open the placeholder editor dialog
-    openDialog(DIALOG_TYPES.PLACEHOLDER_EDITOR, dialogData);
+    // Open the unified template dialog in customize mode
+    openDialog(DIALOG_TYPES.UNIFIED_TEMPLATE, {
+      ...dialogData,
+      mode: 'customize'
+    });
     trackEvent(EVENTS.PLACEHOLDER_EDITOR_OPENED, {
       template_id: template.id,
       template_name: template.title,
@@ -202,7 +205,7 @@ const useTemplate = useCallback(async (template: Template) => {
       }
     };
     
-    openDialog(DIALOG_TYPES.CREATE_TEMPLATE, dialogData);
+    openDialog(DIALOG_TYPES.UNIFIED_TEMPLATE, { ...dialogData, mode: 'create' });
   }, [openDialog, createTemplateMutation, queryClient]);
   
   /**
@@ -264,7 +267,7 @@ const useTemplate = useCallback(async (template: Template) => {
       // The saving will be handled by the dialog's internal logic
     };
     
-    openDialog(DIALOG_TYPES.EDIT_TEMPLATE, dialogData);
+    openDialog(DIALOG_TYPES.UNIFIED_TEMPLATE, { ...dialogData, mode: 'edit' });
     trackEvent(EVENTS.TEMPLATE_EDIT_DIALOG_OPENED, {
       template_id: template.id,
       template_name: template.title,

--- a/src/types/dialog.ts
+++ b/src/types/dialog.ts
@@ -8,8 +8,6 @@ import { Template } from './services/api';
 // Enum of dialog types (use these constants rather than string literals)
 export const DIALOG_TYPES = {
   SETTINGS: 'settings',
-  CREATE_TEMPLATE: 'createTemplate',
-  EDIT_TEMPLATE: 'editTemplate',
   CREATE_FOLDER: 'createFolder',
   FOLDER_MANAGER: 'folderManager',
   UNIFIED_TEMPLATE: 'unifiedTemplate',

--- a/src/types/prompts/templates.ts
+++ b/src/types/prompts/templates.ts
@@ -73,8 +73,6 @@ export interface TemplateFolder {
    * Dialog types registry - needed for certain Dialog operations
    */
   export const DIALOG_TYPES = {
-    CREATE_TEMPLATE: 'createTemplate',
-    EDIT_TEMPLATE: 'editTemplate',
     CREATE_FOLDER: 'createFolder',
     FOLDER_MANAGER: 'folderManager',
     SETTINGS: 'settings',


### PR DESCRIPTION
## Summary
- route create/edit dialog functions to UnifiedTemplateDialog
- update template action hooks to open UnifiedTemplateDialog
- trim old dialog types from registry and shared enums

## Testing
- `npm run type-check`
- `npm run lint` *(fails: 481 errors, 23 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_6852db8e7b488325a2328cc0cfb43d2c