### PR TITLE
Fix unified template dialog

### DIFF
--- a/src/components/dialogs/prompts/UnifiedTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/UnifiedTemplateDialog/index.tsx
@@ -1,24 +1,43 @@
 // src/components/dialogs/prompts/UnifiedTemplateDialog/index.tsx
-import React from 'react';
+import React, { useEffect } from 'react';
 import { BaseDialog } from '@/components/dialogs/BaseDialog';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { AlertTriangle } from 'lucide-react';
 import { useTemplateEditor } from '@/contexts/TemplateEditorContext';
+import { useDialog } from '@/components/dialogs/DialogContext';
+import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
 import { TemplateDialogHeader } from './TemplateDialogHeader';
 import { TemplateDialogContent } from './TemplateDialogContent';
 import { TemplateDialogFooter } from './TemplateDialogFooter';
 
 export const UnifiedTemplateDialog: React.FC = () => {
   const { state, actions, computed } = useTemplateEditor();
+  const { isOpen, data, dialogProps } = useDialog(DIALOG_TYPES.UNIFIED_TEMPLATE);
 
-  if (!state.dialog.isOpen) return null;
+  useEffect(() => {
+    if (isOpen) {
+      actions.openDialog((data as any)?.mode || 'create', data);
+    } else if (state.dialog.isOpen) {
+      actions.closeDialog();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      actions.closeDialog();
+    }
+    dialogProps.onOpenChange(open);
+  };
 
   // Error state
   if (state.dialog.error && !state.dialog.isProcessing) {
     return (
       <BaseDialog
         open={true}
-        onOpenChange={() => actions.closeDialog()}
+        onOpenChange={handleOpenChange}
         title={computed.dialogTitle}
         className="jd-max-w-4xl jd-h-[80vh]"
       >
@@ -38,7 +57,7 @@ export const UnifiedTemplateDialog: React.FC = () => {
   return (
     <BaseDialog
       open={true}
-      onOpenChange={() => actions.closeDialog()}
+      onOpenChange={handleOpenChange}
       title={computed.dialogTitle}
       description={computed.dialogDescription}
       className="jd-max-w-6xl jd-h-[100vh]"

--- a/src/contexts/TemplateEditorContext.tsx
+++ b/src/contexts/TemplateEditorContext.tsx
@@ -133,6 +133,33 @@ function templateEditorReducer(
         }
       };
 
+    case 'SET_ACTIVE_TAB':
+      return {
+        ...state,
+        content: {
+          ...state.content,
+          activeTab: action.payload
+        }
+      };
+
+    case 'SET_BLOCKS_DATA':
+      return {
+        ...state,
+        blocks: {
+          ...state.blocks,
+          ...action.payload
+        }
+      };
+
+    case 'UPDATE_FORM':
+      return {
+        ...state,
+        form: {
+          ...state.form,
+          ...action.payload
+        }
+      };
+
     case 'UPDATE_BLOCK_CONTENT':
       return {
         ...state,
@@ -220,7 +247,9 @@ interface TemplateEditorContextValue {
     openDialog: (mode: DialogState['mode'], data?: any) => void;
     closeDialog: () => void;
     updateContent: (content: string) => void;
+    updateActiveTab: (tab: 'basic' | 'advanced') => void;
     updateMetadata: (metadata: Partial<PromptMetadata>) => void;
+    updateForm: (form: Partial<FormState>) => void;
     saveTemplate: () => Promise<void>;
     // ... other action creators
   };
@@ -249,8 +278,14 @@ export const TemplateEditorProvider: React.FC<{ children: React.ReactNode }> = (
     updateContent: (content: string) => {
       dispatch({ type: 'UPDATE_CONTENT', payload: content });
     },
+    updateActiveTab: (tab: 'basic' | 'advanced') => {
+      dispatch({ type: 'SET_ACTIVE_TAB', payload: tab });
+    },
     updateMetadata: (metadata: Partial<PromptMetadata>) => {
       dispatch({ type: 'UPDATE_METADATA', payload: metadata });
+    },
+    updateForm: (form: Partial<FormState>) => {
+      dispatch({ type: 'UPDATE_FORM', payload: form });
     },
     saveTemplate: async () => {
       dispatch({ type: 'SET_SUBMITTING', payload: true });


### PR DESCRIPTION
## Summary
- allow unified template dialog to sync with dialog manager
- add missing actions in template editor context
- wire up dialog state to open/close using context

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, etc.)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6852df7949088325a4728069e3600fd2