### PR TITLE
Track modified metadata in preview edits

### DIFF
--- a/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateTemplateDialog/index.tsx
@@ -49,6 +49,7 @@ export const CreateTemplateDialog: React.FC = () => {
       finalPromptContent={hook.finalPromptContent}
       hasUnsavedFinalChanges={hook.hasUnsavedFinalChanges}
       modifiedBlocks={hook.modifiedBlocks}
+      modifiedMetadata={hook.modifiedMetadata}
       
       // Actions
       setContent={hook.setContent}

--- a/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
@@ -22,6 +22,7 @@ export const CustomizeTemplateDialog: React.FC = () => {
       finalPromptContent={hook.finalPromptContent}
       hasUnsavedFinalChanges={hook.hasUnsavedFinalChanges}
       modifiedBlocks={hook.modifiedBlocks}
+      modifiedMetadata={hook.modifiedMetadata}
       
       // Actions
       setContent={hook.setContent}

--- a/src/components/dialogs/prompts/TemplateEditorDialog/TemplateEditorContext.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/TemplateEditorContext.tsx
@@ -22,6 +22,8 @@ export interface TemplateEditorContextValue extends MetadataUIState {
   setContent: (content: string) => void;
   finalPromptContent: string;
   setFinalPromptContent: (content: string) => void;
+  modifiedBlocks: Record<number, string>;
+  modifiedMetadata: Record<number, string>;
 
   // Blocks
   blockContentCache: Record<number, string>;

--- a/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
@@ -31,6 +31,7 @@ interface TemplateEditorDialogProps {
   finalPromptContent: string;
   hasUnsavedFinalChanges: boolean;
   modifiedBlocks: Record<number, string>;
+  modifiedMetadata: Record<number, string>;
   
   // Actions from base hook
   setContent: (content: string) => void;
@@ -78,6 +79,7 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
   finalPromptContent,
   hasUnsavedFinalChanges,
   modifiedBlocks,
+  modifiedMetadata,
   
   // Actions
   setContent,
@@ -145,7 +147,9 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
       finalPromptContent,
       setFinalPromptContent,
       blockContentCache,
-      availableMetadataBlocks
+      availableMetadataBlocks,
+      modifiedBlocks,
+      modifiedMetadata
     }),
     [
       metadata,
@@ -163,7 +167,9 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
       finalPromptContent,
       setFinalPromptContent,
       blockContentCache,
-      availableMetadataBlocks
+      availableMetadataBlocks,
+      modifiedBlocks,
+      modifiedMetadata
     ]
   );
 

--- a/src/hooks/dialogs/useCreateTemplateDialog.ts
+++ b/src/hooks/dialogs/useCreateTemplateDialog.ts
@@ -27,13 +27,13 @@ export function useCreateTemplateDialog() {
       // **NEW: Handle block modifications for create mode**
       let finalMetadata = metadata;
       
-      if (!isEditMode && baseHook.modifiedBlocks && Object.keys(baseHook.modifiedBlocks).length > 0) {
-        console.log('Creating new blocks for modifications:', baseHook.modifiedBlocks);
+      if (!isEditMode && baseHook.modifiedMetadata && Object.keys(baseHook.modifiedMetadata).length > 0) {
+        console.log('Creating new blocks for modifications:', baseHook.modifiedMetadata);
         
         // Create new blocks for modified content
         const newBlocksMap: Record<number, number> = {}; // originalId -> newId
         
-        for (const [originalBlockIdStr, newContent] of Object.entries(baseHook.modifiedBlocks)) {
+        for (const [originalBlockIdStr, newContent] of Object.entries(baseHook.modifiedMetadata)) {
           const originalBlockId = parseInt(originalBlockIdStr, 10);
           
           try {


### PR DESCRIPTION
## Summary
- add `modifiedMetadata` state to template dialog base
- detect metadata block changes and store in state
- expose new state via template editor context
- pass metadata changes through create/customize dialogs
- update create template logic to create blocks only for metadata changes

## Testing
- `npm run lint` *(fails: many unrelated lint errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6853f14d8edc83259e5c04f7ed57f697