### PR TITLE
Disable editing in customize dialog preview

### DIFF
--- a/src/components/dialogs/prompts/editors/BasicEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/BasicEditor/index.tsx
@@ -224,6 +224,7 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
                 isDarkMode={isDark}
                 finalPromptContent={displayContent}
                 onFinalContentChange={handleFinalContentChangeInternal}
+                editable={false}
                 className="jd-h-full jd-overflow-auto"
               />
             </div>

--- a/src/components/prompts/EnhancedEditablePreview.tsx
+++ b/src/components/prompts/EnhancedEditablePreview.tsx
@@ -12,11 +12,12 @@ interface EnhancedEditablePreviewProps {
   blockContentCache?: Record<number, string>;
   isDarkMode: boolean;
   finalPromptContent: string;
-  onFinalContentChange: (content: string) => void;
+  onFinalContentChange?: (content: string) => void;
   className?: string;
   title?: string;
   collapsible?: boolean;
   defaultCollapsed?: boolean;
+  editable?: boolean;
 }
 
 export const EnhancedEditablePreview: React.FC<EnhancedEditablePreviewProps> = ({
@@ -28,7 +29,8 @@ export const EnhancedEditablePreview: React.FC<EnhancedEditablePreviewProps> = (
   className = '',
   title = 'Complete Preview',
   collapsible = false,
-  defaultCollapsed = false
+  defaultCollapsed = false,
+  editable = true
 }) => {
   const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
 
@@ -95,7 +97,7 @@ export const EnhancedEditablePreview: React.FC<EnhancedEditablePreviewProps> = (
       {/* Instructions */}
       {!isCollapsed && (
         <div className="jd-text-xs jd-text-muted-foreground jd-flex jd-items-center jd-gap-4">
-          <span>Click to edit your complete prompt preview</span>
+          <span>{editable ? 'Click to edit your complete prompt preview' : 'Preview of your complete prompt'}</span>
           <div className="jd-flex jd-items-center jd-gap-1">
             <span className="jd-inline-block jd-w-3 jd-h-3 jd-bg-yellow-300 jd-rounded"></span>
             <span>Placeholders</span>
@@ -112,10 +114,10 @@ export const EnhancedEditablePreview: React.FC<EnhancedEditablePreviewProps> = (
           <EditablePromptPreview
             content={finalPromptContent}
             htmlContent={previewHtml}
-            onChange={onFinalContentChange}
+            onChange={editable ? onFinalContentChange : undefined}
             isDark={isDarkMode}
             showColors={true}
-            enableAdvancedEditing={true}
+            enableAdvancedEditing={editable}
           />
         </div>
       )}

--- a/src/components/prompts/TemplatePreview.tsx
+++ b/src/components/prompts/TemplatePreview.tsx
@@ -7,8 +7,9 @@ interface TemplatePreviewProps {
   blockContentCache?: Record<number, string>;
   isDarkMode: boolean;
   finalPromptContent: string;
-  onFinalContentChange: (content: string) => void;
+  onFinalContentChange?: (content: string) => void;
   className?: string;
+  editable?: boolean;
 }
 
 export const TemplatePreview: React.FC<TemplatePreviewProps> = ({
@@ -17,7 +18,8 @@ export const TemplatePreview: React.FC<TemplatePreviewProps> = ({
   isDarkMode,
   finalPromptContent,
   onFinalContentChange,
-  className
+  className,
+  editable = true
 }) => (
   <EnhancedEditablePreview
     metadata={metadata}
@@ -25,6 +27,7 @@ export const TemplatePreview: React.FC<TemplatePreviewProps> = ({
     isDarkMode={isDarkMode}
     finalPromptContent={finalPromptContent}
     onFinalContentChange={onFinalContentChange}
+    editable={editable}
     title="Template Preview"
     collapsible={false}
     className={className}


### PR DESCRIPTION
## Summary
- add `editable` option to `TemplatePreview` and `EnhancedEditablePreview`
- use read-only preview for the customize template dialog

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685437c110108325ba9fec85582dee7d