### PR TITLE
Disable editing of template previews

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
@@ -24,7 +24,6 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
     content,
     setContent,
     finalPromptContent,
-    setFinalPromptContent,
     availableMetadataBlocks,
     blockContentCache
   } = useTemplateEditor();
@@ -60,10 +59,6 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   // **NEW: Use final content if available**
   const displayContent = finalPromptContent || content;
 
-  // **NEW: Handle final content changes**
-  const handleFinalContentChangeInternal = useCallback((newContent: string) => {
-    setFinalPromptContent(newContent);
-  }, [setFinalPromptContent]);
 
   const hasPendingChanges = hasPendingContentChanges;
 
@@ -130,8 +125,7 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
                     blockContentCache={blockContentCache}
                     isDarkMode={isDarkMode}
                     finalPromptContent={displayContent}
-                    onFinalContentChange={handleFinalContentChangeInternal}
-                    editable={mode !== 'customize'}
+                    editable={false}
                     className="jd-max-h-[500px] jd-overflow-auto"
                   />
                 </div>

--- a/src/components/dialogs/prompts/editors/BasicEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/BasicEditor/index.tsx
@@ -28,7 +28,6 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
     content,
     setContent,
     finalPromptContent,
-    setFinalPromptContent,
     blockContentCache
   } = useTemplateEditor();
   
@@ -93,10 +92,6 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
   }, [finalPromptContent, modifiedContent, isEditing]);
 
   // Handle final content changes
-  const handleFinalContentChangeInternal = React.useCallback((newContent: string) => {
-    console.log('BasicEditor: Final content changed, length:', newContent?.length);
-    setFinalPromptContent(newContent);
-  }, [setFinalPromptContent]);
 
   // Cleanup effect to commit pending changes when component unmounts
   React.useEffect(() => {
@@ -186,7 +181,7 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
               blockContentCache={blockContentCache}
               isDarkMode={isDark}
               finalPromptContent={displayContent}
-              onFinalContentChange={handleFinalContentChangeInternal}
+              editable={false}
             />
           </div>
         </div>
@@ -221,7 +216,6 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
                 blockContentCache={blockContentCache}
                 isDarkMode={isDark}
                 finalPromptContent={displayContent}
-                onFinalContentChange={handleFinalContentChangeInternal}
                 editable={false}
                 className="jd-h-full jd-overflow-auto"
               />

--- a/src/components/prompts/EnhancedEditablePreview.tsx
+++ b/src/components/prompts/EnhancedEditablePreview.tsx
@@ -31,7 +31,7 @@ export const EnhancedEditablePreview: React.FC<EnhancedEditablePreviewProps> = (
   title = 'Complete Preview',
   collapsible = false,
   defaultCollapsed = false,
-  editable = true
+  editable = false
 }) => {
   const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
 

--- a/src/components/prompts/TemplatePreview.tsx
+++ b/src/components/prompts/TemplatePreview.tsx
@@ -19,7 +19,7 @@ export const TemplatePreview: React.FC<TemplatePreviewProps> = ({
   finalPromptContent,
   onFinalContentChange,
   className,
-  editable = true
+  editable = false
 }) => (
   <EnhancedEditablePreview
     metadata={metadata}


### PR DESCRIPTION
## Summary
- make TemplatePreview read-only by default
- remove edit handlers from BasicEditor and AdvancedEditor
- default EnhancedEditablePreview to non-editable

## Testing
- `npm run lint` *(fails: 511 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685441474a8483259f139ac219f2541b