### PR TITLE
Fix adding secondary metadata

### DIFF
--- a/src/utils/prompts/metadataUtils.ts
+++ b/src/utils/prompts/metadataUtils.ts
@@ -241,11 +241,12 @@ export function getActiveSecondaryMetadata(metadata: PromptMetadata): Set<Metada
       }
     } else {
       // For single metadata types (audience, output_format, tone_style)
-      const blockId = metadata[type];
-      
-      // Include if the field has been initialized (exists in metadata object)
-      // This means either a block was selected, custom value exists, or it was added to the form
-      if (blockId) {
+      const hasField = Object.prototype.hasOwnProperty.call(metadata, type);
+      const hasCustom =
+        metadata.values && Object.prototype.hasOwnProperty.call(metadata.values, type as SingleMetadataType);
+
+      // Include if the field exists (even with blockId 0) or a custom value is present
+      if (hasField || hasCustom) {
         activeSet.add(type);
       }
     }


### PR DESCRIPTION
## Summary
- ensure secondary metadata card shows when added

## Testing
- `pnpm exec eslint src/utils/prompts/metadataUtils.ts` *(fails: 22 errors)*

------
https://chatgpt.com/codex/tasks/task_b_6854473b3b008325be0b2de5e71e30af