### PR TITLE
Add Block Builder option and quick //j tip

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -254,6 +254,10 @@
     "message": "Notifications",
     "description": "Notifications menu item"
   },
+  "blockBuilder": {
+    "message": "Block Builder",
+    "description": "Menu item for block builder"
+  },
   "aiNews": {
     "message": "AI News",
     "description": "Élément de menu AI News"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -251,6 +251,10 @@
     "message": "Notifications",
     "description": "Menu item for notifications"
   },
+  "blockBuilder": {
+    "message": "Constructeur de Blocs",
+    "description": "Menu item for block builder"
+  },
   "aiNews": {
     "message": "Actualités IA",
     "description": "Menu item for AI news"

--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -390,6 +390,9 @@ export const InsertBlockDialog: React.FC = () => {
       description="Select and arrange blocks to create your perfect prompt"
       className="jd-max-w-7xl jd-max-h-[90vh]"
     >
+      <p className="jd-text-xs jd-text-muted-foreground jd-mb-2">
+        Tip: type <span className="jd-font-mono">//j</span> in the prompt area to quickly add blocks.
+      </p>
       <div className="jd-flex jd-h-full jd-gap-6">
         {/* Left Panel - Block Library */}
         <div className="jd-flex-1 jd-flex jd-flex-col jd-min-w-0">

--- a/src/components/panels/MenuPanel/index.tsx
+++ b/src/components/panels/MenuPanel/index.tsx
@@ -1,7 +1,7 @@
 // src/components/panels/MenuPanel/index.tsx
 
 import React from 'react';
-import { FileText, Bell, BarChart, Save } from "lucide-react";
+import { FileText, Bell, BarChart, Save, Blocks } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { usePanelNavigation } from '@/core/contexts/PanelNavigationContext';
@@ -9,6 +9,7 @@ import BasePanel from '../BasePanel';
 import { getMessage } from '@/core/utils/i18n';
 import { toast } from 'sonner';
 import { trackEvent, EVENTS } from '@/utils/amplitude';
+import { useDialogActions } from '@/hooks/dialogs/useDialogActions';
 
 // Define a type for our menu items
 type MenuItem = {
@@ -62,6 +63,7 @@ const MenuPanel: React.FC<MenuPanelProps> = ({
   notificationCount,
 }) => {
   const { pushPanel } = usePanelNavigation();
+  const { openInsertBlock } = useDialogActions();
 
   // Navigate to a specific panel
   const navigateToPanel = (panelType: 'templates' | 'notifications' | 'stats') => {
@@ -82,6 +84,12 @@ const MenuPanel: React.FC<MenuPanelProps> = ({
       icon: <FileText className="jd-h-4 jd-w-4" />,
       label: getMessage('templates', undefined, 'Templates'),
       action: () => navigateToPanel('templates')
+    },
+    {
+      id: 'blockBuilder',
+      icon: <Blocks className="jd-h-4 jd-w-4" />,
+      label: getMessage('blockBuilder', undefined, 'Block Builder'),
+      action: () => openInsertBlock()
     },
     {
       id: 'stats',


### PR DESCRIPTION
## Summary
- add menu translations for Block Builder
- expose Insert Block dialog via new Block Builder menu option
- hint users about the `//j` shortcut in InsertBlockDialog

## Testing
- `pnpm lint` *(fails: 476 errors)*
- `pnpm type-check`

------
https://chatgpt.com/codex/tasks/task_b_68544a4b5e80832585d7820c084b546a