### PR TITLE
Add organization image to folder header

### DIFF
--- a/src/components/prompts/folders/FolderHeader.tsx
+++ b/src/components/prompts/folders/FolderHeader.tsx
@@ -1,7 +1,20 @@
 // src/components/folders/FolderHeader.tsx
 import { Folder, ChevronDown, ChevronRight } from "lucide-react";
+import { OrganizationImage } from '@/components/organizations';
 
-export function FolderHeader({ folder, isExpanded, onToggle, actionButtons }: { folder: any, isExpanded: boolean, onToggle: () => void, actionButtons: React.ReactNode }) {
+export function FolderHeader({
+  folder,
+  isExpanded,
+  onToggle,
+  actionButtons,
+  level = 0
+}: {
+  folder: any;
+  isExpanded: boolean;
+  onToggle: () => void;
+  actionButtons: React.ReactNode;
+  level?: number;
+}) {
     return (
       <div 
         className="jd-group jd-flex jd-items-center jd-p-2 hover:jd-bg-accent/60 jd-cursor-pointer jd-rounded-sm"
@@ -13,6 +26,14 @@ export function FolderHeader({ folder, isExpanded, onToggle, actionButtons }: { 
         }
         <Folder className="jd-h-4 jd-w-4 jd-mr-2 jd-text-muted-foreground" />
         <span className="jd-text-sm jd-flex-1 jd-truncate">{folder.name}</span>
+        {folder.type === 'organization' && level === 0 && (
+          <OrganizationImage
+            imageUrl={folder.organization?.image_url || folder.image_url}
+            organizationName={folder.organization?.name || folder.name}
+            size="sm"
+            className="jd-ml-2"
+          />
+        )}
         
         {folder.templates?.length > 0 && (
           <span className="jd-text-xs jd-text-muted-foreground jd-mr-2">

--- a/src/components/prompts/folders/FolderItem.tsx
+++ b/src/components/prompts/folders/FolderItem.tsx
@@ -194,6 +194,7 @@ const FolderItem: React.FC<FolderItemProps> = ({
         isExpanded={isExpanded}
         onToggle={toggleExpansion}
         actionButtons={actionButtons}
+        level={level}
       />
       
       {isExpanded && (


### PR DESCRIPTION
## Summary
- show organization image in FolderHeader for top level org folders
- plumb level prop through FolderItem

## Testing
- `npm run lint` *(fails: react rule plugins missing)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68544e2279e48325994c1ab8e7b878eb