### PR TITLE
Fix folder creation data format

### DIFF
--- a/src/components/dialogs/prompts/CreateFolderDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateFolderDialog/index.tsx
@@ -10,7 +10,7 @@ import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
 import { toast } from 'sonner';
 import { promptApi } from '@/services/api';
 import { BaseDialog } from '@/components/dialogs/BaseDialog';
-import { getMessage } from '@/core/utils/i18n';
+import { getMessage, getCurrentLanguage } from '@/core/utils/i18n';
 import { useUserFolders } from '@/hooks/prompts';
 import { FolderPicker } from '@/components/prompts/folders';
 import { TemplateFolder } from '@/types/prompts/templates';
@@ -61,9 +61,10 @@ export const CreateFolderDialog: React.FC = () => {
     setIsSubmitting(true);
     try {
       // Prepare folder data
+      const locale = getCurrentLanguage();
       const folderData = {
-        title: name.trim(),
-        description: description.trim(),
+        title: { [locale]: name.trim() },
+        ...(description.trim() ? { description: { [locale]: description.trim() } } : {}),
         parent_folder_id: parentId,
       };
       

--- a/src/components/dialogs/prompts/FolderManagerDialog/index.tsx
+++ b/src/components/dialogs/prompts/FolderManagerDialog/index.tsx
@@ -9,6 +9,7 @@ import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
 import { BaseDialog } from '@/components/dialogs/BaseDialog';
 import { toast } from 'sonner';
 import { promptApi } from '@/services/api';
+import { getCurrentLanguage } from '@/core/utils/i18n';
 import { TemplateFolder } from '@/types/prompts/templates';
 
 interface FolderManagerData {
@@ -46,9 +47,10 @@ export const FolderManagerDialog: React.FC = () => {
     e.stopPropagation();
     setIsSubmitting(true);
     try {
+      const locale = getCurrentLanguage();
       const res = await promptApi.updateFolder(folder.id, {
-        title,
-        description,
+        title: { [locale]: title },
+        ...(description ? { description: { [locale]: description } } : {}),
         parent_folder_id: parentId,
       });
       if (res.success) {

--- a/src/services/api/PromptApi.ts
+++ b/src/services/api/PromptApi.ts
@@ -68,7 +68,7 @@ class PromptApiClient {
     return getUserTemplates();
   }
 
-  async createFolder(folderData: { title: string; description?: string; parent_folder_id?: number | null }): Promise<any> {
+  async createFolder(folderData: { title: string | Record<string, string>; description?: string | Record<string, string>; parent_folder_id?: number | null }): Promise<any> {
     return createFolder(folderData);
   }
 
@@ -76,7 +76,7 @@ class PromptApiClient {
     return deleteFolder(folderId);
   }
 
-  async updateFolder(folderId: number, data: { title?: string; description?: string; parent_folder_id?: number | null }): Promise<any> {
+  async updateFolder(folderId: number, data: { title?: string | Record<string, string>; description?: string | Record<string, string>; parent_folder_id?: number | null }): Promise<any> {
     return updateFolder(folderId, data);
   }
 

--- a/src/services/api/prompts/folders/createFolder.ts
+++ b/src/services/api/prompts/folders/createFolder.ts
@@ -3,10 +3,11 @@
 */
 
 import { apiClient } from "@/services/api/ApiClient";
+import { getCurrentLanguage } from "@/core/utils/i18n";
 
 export async function createFolder(folderData: {
-  title: string;
-  description?: string;
+  title: string | Record<string, string>;
+  description?: string | Record<string, string>;
   parent_folder_id?: number | null;
 }): Promise<any> {
   try {
@@ -17,9 +18,26 @@ export async function createFolder(folderData: {
       };
     }
 
+    const locale = getCurrentLanguage();
+    const payload = {
+      ...folderData,
+      title:
+        typeof folderData.title === 'string'
+          ? { [locale]: folderData.title }
+          : folderData.title,
+      ...(folderData.description
+        ? {
+            description:
+              typeof folderData.description === 'string'
+                ? { [locale]: folderData.description }
+                : folderData.description,
+          }
+        : {}),
+    };
+
     const response = await apiClient.request('/prompts/folders', {
       method: 'POST',
-      body: JSON.stringify(folderData),
+      body: JSON.stringify(payload),
     });
     return response;
   } catch (error) {

--- a/src/services/api/prompts/folders/updateFolder.ts
+++ b/src/services/api/prompts/folders/updateFolder.ts
@@ -1,16 +1,38 @@
 import { apiClient } from "@/services/api/ApiClient";
+import { getCurrentLanguage } from "@/core/utils/i18n";
 
 /**
  * Update an existing folder's data
  */
 export async function updateFolder(
   folderId: number,
-  data: { title?: string; description?: string; parent_folder_id?: number | null }
+  data: { title?: string | Record<string, string>; description?: string | Record<string, string>; parent_folder_id?: number | null }
 ): Promise<{ success: boolean; message?: string; data?: any }> {
   try {
+    const locale = getCurrentLanguage();
+    const payload = {
+      ...data,
+      ...(data.title !== undefined
+        ? {
+            title:
+              typeof data.title === 'string'
+                ? { [locale]: data.title }
+                : data.title,
+          }
+        : {}),
+      ...(data.description !== undefined
+        ? {
+            description:
+              typeof data.description === 'string'
+                ? { [locale]: data.description }
+                : data.description,
+          }
+        : {}),
+    };
+
     const response = await apiClient.request(`/prompts/folders/${folderId}`, {
       method: 'PUT',
-      body: JSON.stringify(data)
+      body: JSON.stringify(payload)
     });
     return response;
   } catch (error) {


### PR DESCRIPTION
## Summary
- send current language name and description when creating or updating folders
- expose the same localized types from PromptApi

## Testing
- `npm run lint` *(fails: 484 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68544f11570c8325896b998567af2805