### PR TITLE
Fix folder creation payload

### DIFF
--- a/src/components/dialogs/prompts/CreateFolderDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateFolderDialog/index.tsx
@@ -10,7 +10,7 @@ import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
 import { toast } from 'sonner';
 import { promptApi } from '@/services/api';
 import { BaseDialog } from '@/components/dialogs/BaseDialog';
-import { getMessage, getCurrentLanguage } from '@/core/utils/i18n';
+import { getMessage } from '@/core/utils/i18n';
 import { useUserFolders } from '@/hooks/prompts';
 import { FolderPicker } from '@/components/prompts/folders';
 import { TemplateFolder } from '@/types/prompts/templates';
@@ -60,11 +60,10 @@ export const CreateFolderDialog: React.FC = () => {
 
     setIsSubmitting(true);
     try {
-      // Prepare folder data
-      const locale = getCurrentLanguage();
+      // Prepare folder data. The backend will handle localization, so send plain strings.
       const folderData = {
-        title: { [locale]: name.trim() },
-        ...(description.trim() ? { description: { [locale]: description.trim() } } : {}),
+        title: name.trim(),
+        ...(description.trim() ? { description: description.trim() } : {}),
         parent_folder_id: parentId,
       };
       

--- a/src/components/dialogs/prompts/FolderManagerDialog/index.tsx
+++ b/src/components/dialogs/prompts/FolderManagerDialog/index.tsx
@@ -9,7 +9,6 @@ import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
 import { BaseDialog } from '@/components/dialogs/BaseDialog';
 import { toast } from 'sonner';
 import { promptApi } from '@/services/api';
-import { getCurrentLanguage } from '@/core/utils/i18n';
 import { TemplateFolder } from '@/types/prompts/templates';
 
 interface FolderManagerData {
@@ -47,10 +46,9 @@ export const FolderManagerDialog: React.FC = () => {
     e.stopPropagation();
     setIsSubmitting(true);
     try {
-      const locale = getCurrentLanguage();
       const res = await promptApi.updateFolder(folder.id, {
-        title: { [locale]: title },
-        ...(description ? { description: { [locale]: description } } : {}),
+        title,
+        ...(description ? { description } : {}),
         parent_folder_id: parentId,
       });
       if (res.success) {

--- a/src/services/api/PromptApi.ts
+++ b/src/services/api/PromptApi.ts
@@ -68,7 +68,7 @@ class PromptApiClient {
     return getUserTemplates();
   }
 
-  async createFolder(folderData: { title: string | Record<string, string>; description?: string | Record<string, string>; parent_folder_id?: number | null }): Promise<any> {
+  async createFolder(folderData: { title: string; description?: string; parent_folder_id?: number | null }): Promise<any> {
     return createFolder(folderData);
   }
 
@@ -76,7 +76,7 @@ class PromptApiClient {
     return deleteFolder(folderId);
   }
 
-  async updateFolder(folderId: number, data: { title?: string | Record<string, string>; description?: string | Record<string, string>; parent_folder_id?: number | null }): Promise<any> {
+  async updateFolder(folderId: number, data: { title?: string; description?: string; parent_folder_id?: number | null }): Promise<any> {
     return updateFolder(folderId, data);
   }
 

--- a/src/services/api/prompts/folders/createFolder.ts
+++ b/src/services/api/prompts/folders/createFolder.ts
@@ -3,11 +3,10 @@
 */
 
 import { apiClient } from "@/services/api/ApiClient";
-import { getCurrentLanguage } from "@/core/utils/i18n";
 
 export async function createFolder(folderData: {
-  title: string | Record<string, string>;
-  description?: string | Record<string, string>;
+  title: string;
+  description?: string;
   parent_folder_id?: number | null;
 }): Promise<any> {
   try {
@@ -18,21 +17,10 @@ export async function createFolder(folderData: {
       };
     }
 
-    const locale = getCurrentLanguage();
     const payload = {
-      ...folderData,
-      title:
-        typeof folderData.title === 'string'
-          ? { [locale]: folderData.title }
-          : folderData.title,
-      ...(folderData.description
-        ? {
-            description:
-              typeof folderData.description === 'string'
-                ? { [locale]: folderData.description }
-                : folderData.description,
-          }
-        : {}),
+      title: folderData.title,
+      ...(folderData.description ? { description: folderData.description } : {}),
+      parent_folder_id: folderData.parent_folder_id ?? null,
     };
 
     const response = await apiClient.request('/prompts/folders', {

--- a/src/services/api/prompts/folders/updateFolder.ts
+++ b/src/services/api/prompts/folders/updateFolder.ts
@@ -1,33 +1,17 @@
 import { apiClient } from "@/services/api/ApiClient";
-import { getCurrentLanguage } from "@/core/utils/i18n";
 
 /**
  * Update an existing folder's data
  */
 export async function updateFolder(
   folderId: number,
-  data: { title?: string | Record<string, string>; description?: string | Record<string, string>; parent_folder_id?: number | null }
+  data: { title?: string; description?: string; parent_folder_id?: number | null }
 ): Promise<{ success: boolean; message?: string; data?: any }> {
   try {
-    const locale = getCurrentLanguage();
     const payload = {
-      ...data,
-      ...(data.title !== undefined
-        ? {
-            title:
-              typeof data.title === 'string'
-                ? { [locale]: data.title }
-                : data.title,
-          }
-        : {}),
-      ...(data.description !== undefined
-        ? {
-            description:
-              typeof data.description === 'string'
-                ? { [locale]: data.description }
-                : data.description,
-          }
-        : {}),
+      ...(data.title !== undefined ? { title: data.title } : {}),
+      ...(data.description !== undefined ? { description: data.description } : {}),
+      parent_folder_id: data.parent_folder_id ?? null,
     };
 
     const response = await apiClient.request(`/prompts/folders/${folderId}`, {


### PR DESCRIPTION
## Summary
- send plain strings when creating/updating folders
- remove unused locale utilities in folder dialogs
- adjust Prompt API to match backend expectations

## Testing
- `npm run lint` *(fails: 483 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6854660252808325b375baef46ebc4d6