### PR TITLE
Show logos for organization folders

### DIFF
--- a/src/components/panels/BrowseTemplatesPanel/index.tsx
+++ b/src/components/panels/BrowseTemplatesPanel/index.tsx
@@ -10,6 +10,7 @@ import {
   useTemplateActions,
   usePinnedFolders
 } from '@/hooks/prompts';
+import { useOrganizations } from '@/hooks/organizations';
 import {
   FolderList,
   FolderSearch
@@ -51,6 +52,8 @@ const BrowseTemplatesPanel: React.FC<BrowseTemplatesPanelProps> = ({
     error,
     refetch: refetchFolders
   } = useAllFoldersOfType(folderType);
+
+  const { data: organizations = [] } = useOrganizations();
 
   // Map folder ID to its actual type (official or organization)
   const folderTypeMap = React.useMemo(() => {
@@ -167,6 +170,7 @@ const BrowseTemplatesPanel: React.FC<BrowseTemplatesPanelProps> = ({
             onTogglePin={handleTogglePin}
             onUseTemplate={useTemplate}
             showPinControls={true}
+            organizations={organizations}
           />
         )}
       </div>

--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -20,6 +20,7 @@ import {
   useTemplateActions
 } from '@/hooks/prompts';
 import { useDialogActions } from '@/hooks/dialogs/useDialogActions';
+import { useOrganizations } from '@/hooks/organizations';
 
 import {
   FolderSection,
@@ -88,6 +89,8 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
     error: companyError,
     refetch: refetchCompany
   } = useCompanyFolders();
+
+  const { data: organizations = [] } = useOrganizations();
 
   console.log("userFolders", userFolders);
 
@@ -554,6 +557,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
                 folders={companyItems as TemplateFolder[]}
                 type="organization"
                 onUseTemplate={useTemplate}
+                organizations={organizations}
               />
             </div>
           )}
@@ -598,6 +602,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
               onTogglePin={handleTogglePin}
               onUseTemplate={useTemplate}
               showPinControls={true}
+              organizations={organizations}
             />
           )}
         </FolderSection>

--- a/src/components/prompts/folders/FolderHeader.tsx
+++ b/src/components/prompts/folders/FolderHeader.tsx
@@ -1,19 +1,22 @@
 // src/components/folders/FolderHeader.tsx
 import { Folder, ChevronDown, ChevronRight } from "lucide-react";
 import { OrganizationImage } from '@/components/organizations';
+import { Organization } from '@/types/organizations';
 
 export function FolderHeader({
   folder,
   isExpanded,
   onToggle,
   actionButtons,
-  level = 0
+  level = 0,
+  organizations
 }: {
   folder: any;
   isExpanded: boolean;
   onToggle: () => void;
   actionButtons: React.ReactNode;
   level?: number;
+  organizations?: Organization[];
 }) {
     return (
       <div 
@@ -28,8 +31,16 @@ export function FolderHeader({
         <span className="jd-text-sm jd-flex-1 jd-truncate">{folder.name}</span>
         {folder.type === 'organization' && level === 0 && (
           <OrganizationImage
-            imageUrl={folder.organization?.image_url || folder.image_url}
-            organizationName={folder.organization?.name || folder.name}
+            imageUrl={
+              organizations?.find(o => o.id === folder.organization_id)?.image_url ||
+              folder.organization?.image_url ||
+              folder.image_url
+            }
+            organizationName={
+              organizations?.find(o => o.id === folder.organization_id)?.name ||
+              folder.organization?.name ||
+              folder.name
+            }
             size="sm"
             className="jd-ml-2"
           />

--- a/src/components/prompts/folders/FolderItem.tsx
+++ b/src/components/prompts/folders/FolderItem.tsx
@@ -1,6 +1,7 @@
 // src/components/folders/FolderItem.tsx
 import React, { useState, memo, useCallback, useRef } from 'react';
 import { Template, TemplateFolder } from '@/types/prompts/templates';
+import { Organization } from '@/types/organizations';
 import { FolderHeader } from './FolderHeader';
 import { TemplateItem } from '@/components/prompts/templates/TemplateItem';
 import { PinButton } from './PinButton';
@@ -24,6 +25,7 @@ interface FolderItemProps {
   showDeleteControls?: boolean;
   level?: number;
   initialExpanded?: boolean;
+  organizations?: Organization[];
 }
 
 /**
@@ -41,7 +43,8 @@ const FolderItem: React.FC<FolderItemProps> = ({
   showPinControls = false,
   showDeleteControls = false,
   level = 0,
-  initialExpanded = false
+  initialExpanded = false,
+  organizations
 }) => {
   const [isExpanded, setIsExpanded] = useState(initialExpanded);
   const [isPinned, setIsPinned] = useState(!!folder.is_pinned);
@@ -195,6 +198,7 @@ const FolderItem: React.FC<FolderItemProps> = ({
         onToggle={toggleExpansion}
         actionButtons={actionButtons}
         level={level}
+        organizations={organizations}
       />
       
       {isExpanded && (
@@ -250,6 +254,7 @@ const FolderItem: React.FC<FolderItemProps> = ({
                     showPinControls={showPinControls}
                     showDeleteControls={showDeleteControls}
                     level={level + 1}
+                    organizations={organizations}
                   />
                 );
               }

--- a/src/components/prompts/folders/FolderList.tsx
+++ b/src/components/prompts/folders/FolderList.tsx
@@ -1,6 +1,7 @@
 // src/components/folders/FolderList.tsx
 import React, { memo, useMemo } from 'react';
 import { Template, TemplateFolder } from '@/types/prompts/templates';
+import { Organization } from '@/types/organizations';
 import FolderItem from './FolderItem';
 import { EmptyMessage } from '@/components/panels/TemplatesPanel/EmptyMessage';
 
@@ -19,6 +20,7 @@ interface FolderListProps {
   searchTerm?: string;
   expandedFolders?: Set<number>;
   onToggleExpand?: (folderId: number) => void;
+  organizations?: Organization[];
 }
 
 /**
@@ -38,7 +40,8 @@ const FolderList: React.FC<FolderListProps> = ({
   emptyMessage,
   searchTerm,
   expandedFolders,
-  onToggleExpand
+  onToggleExpand,
+  organizations
 }) => {
   // Use memo to avoid unnecessary array processing
   const validFolders = useMemo(() => {
@@ -79,6 +82,7 @@ const FolderList: React.FC<FolderListProps> = ({
             showDeleteControls={showDeleteControls}
             initialExpanded={initialExpanded}
             level={0}
+            organizations={organizations}
           />
         );
       })}


### PR DESCRIPTION
## Summary
- pull organization logos for folders
- pass organization data through panels and folder components

## Testing
- `npm run lint` *(fails: ENOTFOUND for registry)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_685469c0f4e483259ff39cff0451045c