### PR TITLE
Remove official folder type

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -331,8 +331,8 @@
     "description": "Button text to create a new template"
   },
   "officialTemplates": {
-    "message": "Official Templates",
-    "description": "Official templates section title"
+    "message": "Organization Templates",
+    "description": "Organization templates section title"
   },
   "myTemplates": {
     "message": "My Templates",
@@ -521,7 +521,7 @@
     "description": "Browse more modal title"
   },
   "browseMoreDesc": {
-    "message": "Browse and pin official and organization templates",
+    "message": "Browse and pin organization templates",
     "description": "Browse more modal description"
   },
   "pinFolder": {
@@ -557,8 +557,8 @@
     "description": "Refresh button text"
   },
   "noPinnedOfficialTemplates": {
-    "message": "No pinned official templates. Click Browse More to add some.",
-    "description": "Empty state message for official templates section"
+    "message": "No pinned organization templates. Click Browse More to add some.",
+    "description": "Empty state message for organization templates section"
   },
   "noUserTemplates": {
     "message": "No user templates. Create a template to get started.",
@@ -1269,8 +1269,8 @@
     "description": "Button text to contact sales for enterprise features"
   },
   "searchOfficialFolders": {
-    "message": "Search official folders...",
-    "description": "Placeholder text for searching official folders"
+    "message": "Search organization folders...",
+    "description": "Placeholder text for searching organization folders"
   },
   "searchOrganizationFolders": {
     "message": "Search organization folders...",
@@ -1282,7 +1282,7 @@
     "placeholders": {
       "folder_type": {
         "content": "$1",
-        "example": "official"
+        "example": "organization"
       }
     }
   },
@@ -1310,7 +1310,7 @@
     "placeholders": {
       "folder_type": {
         "content": "$1",
-        "example": "official"
+        "example": "organization"
       }
     }
   },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -324,8 +324,8 @@
     "description": "Button text to create a new template"
   },
   "officialTemplates": {
-    "message": "Templates Officiels",
-    "description": "Titre de section templates officiels"
+    "message": "Templates d'organisation",
+    "description": "Titre de section templates d'organisation"
   },
   "myTemplates": {
     "message": "Mes templates",
@@ -430,7 +430,7 @@
     "description": "Titre de la modale Parcourir plus"
   },
   "browseMoreDesc": {
-    "message": "Parcourir et épingler les templates officiels et d'entreprise",
+    "message": "Parcourir et épingler les templates d'organisation",
     "description": "Description de la modale Parcourir plus"
   },
   "pinFolder": {
@@ -466,8 +466,8 @@
     "description": "Button text to refresh templates"
   },
   "noPinnedOfficialTemplates": {
-    "message": "Aucun template officiel épinglé. Cliquez sur 'Voir Plus' pour en ajouter.",
-    "description": "Empty state message for official templates section"
+    "message": "Aucun template d'organisation épinglé. Cliquez sur 'Voir Plus' pour en ajouter.",
+    "description": "Empty state message for organization templates section"
   },
   "noUserTemplates": {
     "message": "Aucun template utilisateur. Créez un template pour commencer.",
@@ -1178,8 +1178,8 @@
     "description": "Button text to contact sales for enterprise features"
   },
   "searchOfficialFolders": {
-    "message": "Rechercher des dossiers officiels...",
-    "description": "Texte d'espace réservé pour la recherche de dossiers officiels"
+    "message": "Rechercher des dossiers d'organisation...",
+    "description": "Texte d'espace réservé pour la recherche de dossiers d'organisation"
   },
   "searchOrganizationFolders": {
     "message": "Rechercher des dossiers d'entreprise...",
@@ -1191,7 +1191,7 @@
     "placeholders": {
       "folder_type": {
         "content": "$1",
-        "example": "officiels"
+        "example": "organisation"
       }
     }
   },
@@ -1219,7 +1219,7 @@
     "placeholders": {
       "folder_type": {
         "content": "$1",
-        "example": "officiel"
+        "example": "organisation"
       }
     }
   },

--- a/src/components/panels/BrowseTemplatesPanel/index.tsx
+++ b/src/components/panels/BrowseTemplatesPanel/index.tsx
@@ -55,12 +55,11 @@ const BrowseTemplatesPanel: React.FC<BrowseTemplatesPanelProps> = ({
 
   const { data: organizations = [] } = useOrganizations();
 
-  // Map folder ID to its actual type (official or organization)
+  // Map folder ID to its actual type (organization or company)
   const folderTypeMap = React.useMemo(() => {
-    const map: Record<number, 'official' | 'organization' | 'company'> = {};
+    const map: Record<number, 'organization' | 'company'> = {};
     folders.forEach(f => {
-      const t = (f.type === 'official') ? 'official' : 'organization';
-      map[f.id] = t;
+      map[f.id] = (f.type === 'company') ? 'company' : 'organization';
     });
     return map;
   }, [folders]);
@@ -99,7 +98,7 @@ const BrowseTemplatesPanel: React.FC<BrowseTemplatesPanelProps> = ({
       await toggleFolderPin.mutateAsync({
         folderId,
         isPinned,
-        type: typeToUse as 'official' | 'organization' | 'company'
+        type: typeToUse as 'organization' | 'company'
       });
       
       // Call the onPinChange prop if provided (after successful backend update)
@@ -132,7 +131,7 @@ const BrowseTemplatesPanel: React.FC<BrowseTemplatesPanelProps> = ({
 
   return (
     <BasePanel
-      title={folderType === 'official' ? 'Official Templates' : 'Organization Templates'}
+      title={folderType === 'company' ? 'Company Templates' : 'Organization Templates'}
       icon={FolderOpen}
       showBackButton={true}
       onBack={onBackToTemplates}

--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -49,7 +49,7 @@ interface FolderNavigation {
  * Updated TemplatesPanel with new structure:
  * 1. User folders and templates (with nested navigation)
  * 2. Company folders (pinned)
- * 3. Mixed organization + official folders (pinned)
+ * 3. Organization folders (pinned)
  */
 const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
   showBackButton,
@@ -69,8 +69,8 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
 
   // Data fetching
-  const { 
-    data: pinnedFolders = { official: [], organization: [] }, 
+  const {
+    data: pinnedFolders = { organization: [] },
     isLoading: loadingPinned,
     error: pinnedError,
     refetch: refetchPinned
@@ -143,7 +143,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
       type: 'templatesBrowse',
       props: {
         folderType: 'organization', 
-        pinnedFolderIds: [...pinnedFolders.official.map(f => f.id), ...pinnedFolders.organization.map(f => f.id)],
+        pinnedFolderIds: [...pinnedFolders.organization.map(f => f.id)],
         onPinChange: async (folderId, isPinned, type) => {
           try {
             await toggleFolderPin.mutateAsync({ folderId, isPinned, type });
@@ -288,7 +288,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
     async (
       folderId: number,
       isPinned: boolean,
-      type: 'official' | 'organization' | 'company'
+      type: 'company' | 'organization'
     ) => {
       try {
         await toggleFolderPin.mutateAsync({ folderId, isPinned, type });
@@ -300,12 +300,9 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
     [toggleFolderPin, refetchPinned]
   );
 
-  // Combine official and organization pinned folders
+  // Use organization pinned folders list
   const pinnedFoldersList = useMemo(
-    () => [
-      ...(pinnedFolders.official || []),
-      ...(pinnedFolders.organization || [])
-    ],
+    () => [...(pinnedFolders.organization || [])],
     [pinnedFolders]
   );
 
@@ -419,7 +416,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
                 <TemplateItem
                   key={`search-template-${item.id}`}
                   template={item}
-                  type={item.type as 'official' | 'organization' | 'user'}
+                  type={item.type as 'company' | 'organization' | 'user'}
                   onUseTemplate={useTemplate}
                   onEditTemplate={handleEditTemplate}
                   onDeleteTemplate={handleDeleteTemplate}
@@ -565,10 +562,10 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
 
         <Separator />
 
-        {/* Pinned Official and Organization Section */}
+        {/* Pinned Organization Section */}
         <FolderSection
           title={getMessage('pinnedTemplates', undefined, 'Pinned Templates')}
-          iconType="official"
+          iconType="organization"
           showBrowseMore={true}
           onBrowseMore={handleBrowseMore}
         >

--- a/src/components/prompts/common/ItemList.tsx
+++ b/src/components/prompts/common/ItemList.tsx
@@ -7,7 +7,7 @@ import { Template, TemplateFolder } from '@/types/prompts/templates';
 
 interface ItemListProps {
   items: (TemplateFolder | Template)[];
-  type: 'user' | 'official' | 'organization';
+  type: 'user' | 'company' | 'organization';
   onFolderClick?: (folder: TemplateFolder) => void;
   onTemplateUse?: (template: Template) => void;
   onTemplateEdit?: (template: Template) => void;

--- a/src/components/prompts/folders/FolderItem.tsx
+++ b/src/components/prompts/folders/FolderItem.tsx
@@ -15,7 +15,7 @@ const ITEMS_PER_PAGE = 5;
 interface FolderItemProps {
   folder: TemplateFolder;
   type: 'company' | 'organization' | 'user';
-  onTogglePin?: (folderId: number, isPinned: boolean, folderType?: 'official' | 'organization' | 'user') => Promise<void> | void;
+  onTogglePin?: (folderId: number, isPinned: boolean, folderType?: 'company' | 'organization' | 'user') => Promise<void> | void;
   onDeleteFolder?: (folderId: number) => Promise<boolean> | void;
   onEditFolder?: (folder: TemplateFolder) => void;
   onUseTemplate?: (template: Template) => void;
@@ -141,7 +141,7 @@ const FolderItem: React.FC<FolderItemProps> = ({
   // Create action buttons for folder header
   const actionButtons = (
     <div className="jd-flex jd-items-center jd-gap-2">
-      {showPinControls && onTogglePin && (type === 'official' || type === 'organization') && (
+      {showPinControls && onTogglePin && type !== 'user' && (
         <PinButton 
           isPinned={isPinned} 
           onClick={handleTogglePin} 

--- a/src/components/prompts/folders/FolderSection.tsx
+++ b/src/components/prompts/folders/FolderSection.tsx
@@ -10,7 +10,7 @@ import { Organization } from '@/types/organizations';
 
 interface FolderSectionProps {
   title: string;
-  iconType: 'official' | 'organization' | 'user';
+  iconType: 'company' | 'organization' | 'user';
   onBrowseMore?: () => void;
   onCreateTemplate?: () => void;
   showBrowseMore?: boolean;
@@ -36,7 +36,7 @@ export function FolderSection({
   const renderIcon = () => {
     // ... (renderIcon function remains the same)
      switch (iconType) {
-      case 'official':
+      case 'company':
         return <BookTemplate className="jd-mr-2 jd-h-4 jd-w-4" />;
       case 'organization':
         return <Users className="jd-mr-2 jd-h-4 jd-w-4" />;

--- a/src/components/prompts/templates/TemplateItem.tsx
+++ b/src/components/prompts/templates/TemplateItem.tsx
@@ -10,7 +10,7 @@ import { getMessage } from '@/core/utils/i18n';
 
 interface TemplateItemProps {
   template: Template;
-  type?: 'official' | 'organization' | 'user';
+  type?: 'company' | 'organization' | 'user';
   onEditTemplate?: (template: Template) => void;
   onDeleteTemplate?: (templateId: number) => Promise<boolean> | void;
   onUseTemplate?: (template: Template) => void;

--- a/src/hooks/prompts/actions/useFolderMutations.ts
+++ b/src/hooks/prompts/actions/useFolderMutations.ts
@@ -14,7 +14,7 @@ interface FolderData {
 interface TogglePinParams {
   folderId: number;
   isPinned: boolean;
-  type: 'official' | 'organization';
+  type: 'company' | 'organization';
 }
 
 /**

--- a/src/hooks/prompts/queries/folders/useAllFolders.ts
+++ b/src/hooks/prompts/queries/folders/useAllFolders.ts
@@ -9,17 +9,13 @@ export function useAllFolders() {
   const userLocale = getCurrentLanguage();
   
   return useQuery(QUERY_KEYS.ALL_FOLDERS, async () => {
-    const [officialResponse, organizationResponse] = await Promise.all([
-      promptApi.getFolders('official', true, true, userLocale),
-      promptApi.getFolders('organization', true, true, userLocale)
-    ]);
+    const organizationResponse = await promptApi.getFolders('organization', true, true, userLocale);
 
-    if (!officialResponse.success || !organizationResponse.success) {
+    if (!organizationResponse.success) {
       throw new Error('Failed to fetch folders');
     }
 
     return {
-      official: (officialResponse.data.folders.official || []) as TemplateFolder[],
       organization: (organizationResponse.data.folders.organization || []) as TemplateFolder[]
     };
   }, {

--- a/src/hooks/prompts/queries/folders/useAllFoldersOfType.ts
+++ b/src/hooks/prompts/queries/folders/useAllFoldersOfType.ts
@@ -6,9 +6,9 @@ import { QUERY_KEYS } from '@/constants/queryKeys';
 import { TemplateFolder } from '@/types/prompts/templates';
 
 /**
- * Hook to fetch all folders of a specific type (official, organization, company)
+ * Hook to fetch all folders of a specific type (organization, company)
  */
-export function useAllFoldersOfType(folderType: 'official' | 'organization' | 'company') {
+export function useAllFoldersOfType(folderType: 'organization' | 'company') {
   const userLocale = getCurrentLanguage();
   
   return useQuery(

--- a/src/hooks/prompts/queries/folders/usePinnedFolders.ts
+++ b/src/hooks/prompts/queries/folders/usePinnedFolders.ts
@@ -18,32 +18,10 @@ export function usePinnedFolders() {
     
     // Support both new and legacy metadata structures for pinned folders
     // `pinned_folder_ids` is the newer consolidated field containing all pinned
-    // folder IDs, while the older API used separate arrays for official and
-    // organization folders. To maintain compatibility we merge them so that
-    // folders are returned correctly regardless of which structure the backend
-    // provides.
-
-    const legacyOfficialIds = metadata.data?.pinned_official_folder_ids || [];
+    // folder IDs. Older metadata stored organization folder IDs separately.
     const legacyOrgIds = metadata.data?.pinned_organization_folder_ids || [];
     const genericPinnedIds = metadata.data?.pinned_folder_ids || [];
 
-    // Combine IDs so we can filter folders correctly.
-    const officialIds = Array.from(new Set([...legacyOfficialIds, ...genericPinnedIds]));
-    let officialFolders: TemplateFolder[] = [];
-
-    if (officialIds.length > 0) {
-      const officialResponse = await promptApi.getFolders('official', true, true, userLocale);
-      if (officialResponse.success) {
-        const allFolders = (officialResponse.data.folders.official || []) as TemplateFolder[];
-        officialFolders = allFolders
-          .filter((folder: TemplateFolder) => officialIds.includes(folder.id))
-          .map((folder: TemplateFolder) => ({
-            ...folder,
-            is_pinned: true
-          }));
-      }
-    }
-    
     // Get organization pinned folders with locale filtering. Use the merged set
     // of generic pinned IDs plus any legacy organization specific IDs.
     const orgIds = Array.from(new Set([...legacyOrgIds, ...genericPinnedIds]));
@@ -63,7 +41,6 @@ export function usePinnedFolders() {
     }
     
     return {
-      official: officialFolders,
       organization: orgFolders
     };
   }, {

--- a/src/services/api/PromptApi.ts
+++ b/src/services/api/PromptApi.ts
@@ -36,11 +36,11 @@ class PromptApiClient {
     return getFolders(type, withSubfolders, withTemplates, locale);
   }
   
-  async updatePinnedFolders(type: 'official' | 'organization', folderIds: number[]): Promise<any> {
+  async updatePinnedFolders(type: 'company' | 'organization', folderIds: number[]): Promise<any> {
     return updatePinnedFolders(type, folderIds);
   }
 
-  async toggleFolderPin(folderId: number, isPinned: boolean, type: 'official' | 'organization'): Promise<any> {
+  async toggleFolderPin(folderId: number, isPinned: boolean, type: 'company' | 'organization'): Promise<any> {
     return toggleFolderPin(folderId, isPinned, type);
   }
 

--- a/src/services/api/prompts/folders/getAllFolders.ts
+++ b/src/services/api/prompts/folders/getAllFolders.ts
@@ -10,7 +10,7 @@ interface GetAllFoldersResponse {
 
 /**
    * Get all template folders of a specific type (for browsing)
-   * @param type - Type of folders to fetch (official, organization)
+ * @param type - Type of folders to fetch (company or organization)
    * @param empty - Whether to return folders without templates
    */
 export async function getAllFolders(type: string, empty: boolean = false, locale?: string): Promise<GetAllFoldersResponse> {

--- a/src/services/api/prompts/folders/toggleFolderPin.ts
+++ b/src/services/api/prompts/folders/toggleFolderPin.ts
@@ -4,9 +4,9 @@ import { apiClient } from "@/services/api/ApiClient";
  * Toggle pin status for a single folder
  * @param folderId - ID of the folder to toggle
  * @param isPinned - Current pin status (true if pinned, false if not)
- * @param type - Type of folder (official or organization)
+ * @param type - Type of folder (company or organization)
  */
-export async function toggleFolderPin(folderId: number, isPinned: boolean, type: 'official' | 'organization'): Promise<any> {
+export async function toggleFolderPin(folderId: number, isPinned: boolean, type: 'company' | 'organization'): Promise<any> {
     try {
       // Determine which endpoint to use based on current pin status
       const endpoint = isPinned 

--- a/src/services/api/prompts/folders/updatePinnedFolders.ts
+++ b/src/services/api/prompts/folders/updatePinnedFolders.ts
@@ -1,21 +1,19 @@
 /**
  * Update a user's pinned folder IDs
- * @param type - Type of folders to update (official or organization)
+ * @param type - Type of folders to update (company or organization)
  * @param folderIds - Array of folder IDs to pin
  */
 
 import { apiClient } from "@/services/api/ApiClient";
 
-export async function updatePinnedFolders(type: 'official' | 'organization', folderIds: number[]): Promise<any> {
+export async function updatePinnedFolders(type: 'company' | 'organization', folderIds: number[]): Promise<any> {
     try {
       // Determine which endpoint to use based on folder type
-      const endpoint = type === 'official' 
-        ? '/prompts/folders/update-pinned' 
-        : '/prompts/folders/update-pinned';
+      const endpoint = '/prompts/folders/update-pinned';
       
       // Create payload with the required fields
       const payload = {
-        official_folder_ids: type === 'official' ? folderIds : [],
+        company_folder_ids: type === 'company' ? folderIds : [],
         organization_folder_ids: type === 'organization' ? folderIds : []
       };
             

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -4,7 +4,7 @@
 
 // Panel type definitions
 export type MenuPanelType = 'menu';
-export type TemplatesPanelType = 'templates' | 'browse-official' | 'browse-organization';
+export type TemplatesPanelType = 'templates' | 'browse-organization' | 'browse-company';
 export type NotificationsPanelType = 'notifications';
 export type StatsPanelType = 'stats';
 

--- a/src/types/prompts/folders.ts
+++ b/src/types/prompts/folders.ts
@@ -15,7 +15,7 @@ export interface TemplateFolder {
   name?: string;
   path?: string;
   description?: string | Record<string, string>;
-  type: 'official' | 'organization' | 'user';
+  type: 'company' | 'organization' | 'user';
   templates: Template[];
   Folders?: TemplateFolder[];
   is_pinned?: boolean;

--- a/src/types/prompts/templates.ts
+++ b/src/types/prompts/templates.ts
@@ -23,9 +23,9 @@ export interface Template {
     updated_at?: string;
     last_used_at?: string;
     usage_count?: number;
-    type?: 'official' | 'organization' | 'user';
+    type?: 'company' | 'organization' | 'user';
     language?: string;
-    based_on_official_id?: number | null;
+    based_on_company_id?: number | null;
     metadata?: TemplateMetadata;
   }
   
@@ -45,7 +45,7 @@ export interface TemplateFolder {
   parent_folder_id?: number | null;
   /** @deprecated use `parent_folder_id` */
   parent_id?: number | null;
-  type?: 'official' | 'organization' | 'user';
+  type?: 'company' | 'organization' | 'user';
   is_pinned?: boolean;
 }
   
@@ -66,7 +66,7 @@ export interface TemplateFolder {
     description: '',
     folder: '',
     folder_id: undefined,
-    based_on_official_id: null
+    based_on_company_id: null
   };
   
   /**

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -133,30 +133,6 @@ export type Database = {
         }
         Relationships: []
       }
-      official_folders: {
-        Row: {
-          created_at: string
-          id: number
-          path: string | null
-          tags: string[] | null
-          type: string | null
-        }
-        Insert: {
-          created_at?: string
-          id?: number
-          path?: string | null
-          tags?: string[] | null
-          type?: string | null
-        }
-        Update: {
-          created_at?: string
-          id?: number
-          path?: string | null
-          tags?: string[] | null
-          type?: string | null
-        }
-        Relationships: []
-      }
       organization_folders: {
         Row: {
           created_at: string

--- a/src/utils/prompts/folderUtils.ts
+++ b/src/utils/prompts/folderUtils.ts
@@ -71,23 +71,23 @@ export function compareFoldersByName(a: TemplateFolder, b: TemplateFolder): numb
 }
 
 /**
- * Group folders by type (official, organization, user)
+ * Group folders by type (company, organization, user)
  */
 export function groupFoldersByType(folders: TemplateFolder[]): {
-  official: TemplateFolder[];
   organization: TemplateFolder[];
   user: TemplateFolder[];
+  company: TemplateFolder[];
 } {
   return folders.reduce(
     (acc, folder) => {
-      const type = folder.type as 'official' | 'organization' | 'user';
+      const type = folder.type as 'company' | 'organization' | 'user';
       if (type && acc[type]) {
         acc[type].push(folder);
       }
       return acc;
     },
-    { official: [], organization: [], user: [] } as {
-      official: TemplateFolder[];
+    { company: [], organization: [], user: [] } as {
+      company: TemplateFolder[];
       organization: TemplateFolder[];
       user: TemplateFolder[];
     }


### PR DESCRIPTION
## Summary
- refactor folder types to use `company`, `organization`, and `user`
- update translations for organization folders
- remove outdated `official` handling in panels, hooks, and services

## Testing
- `npm run lint` *(fails: 484 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68546cd93a9c8325b6d93c768a9d444e