### PR TITLE
Unify folder item visuals

### DIFF
--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -555,6 +555,8 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
                 type="organization"
                 onUseTemplate={useTemplate}
                 organizations={organizations}
+                showPinControls={true}
+                onTogglePin={handleTogglePin}
               />
             </div>
           )}

--- a/src/components/prompts/folders/FolderHeader.tsx
+++ b/src/components/prompts/folders/FolderHeader.tsx
@@ -4,13 +4,20 @@ import { OrganizationImage } from '@/components/organizations';
 import { Organization } from '@/types/organizations';
 import { useOrganizationById } from '@/hooks/organizations';
 
+const folderIconColors = {
+  user: 'jd-text-blue-500',
+  company: 'jd-text-emerald-500',
+  organization: 'jd-text-purple-500'
+} as const;
+
 export function FolderHeader({
   folder,
   isExpanded,
   onToggle,
   actionButtons,
   level = 0,
-  organizations
+  organizations,
+  type
 }: {
   folder: any;
   isExpanded: boolean;
@@ -18,6 +25,7 @@ export function FolderHeader({
   actionButtons: React.ReactNode;
   level?: number;
   organizations?: Organization[];
+  type?: 'company' | 'organization' | 'user';
 }) {
   const { data: organization } = useOrganizationById(folder?.organization_id);
 
@@ -34,7 +42,7 @@ export function FolderHeader({
           <ChevronDown className="jd-h-4 jd-w-4 jd-mr-1 jd-flex-shrink-0" /> : 
           <ChevronRight className="jd-h-4 jd-w-4 jd-mr-1 jd-flex-shrink-0" />
         }
-        <Folder className="jd-h-4 jd-w-4 jd-mr-2 jd-text-muted-foreground" />
+        <Folder className={`jd-h-4 jd-w-4 jd-mr-2 ${folderIconColors[type || folder.type || 'user']}`} />
         <span className="jd-text-sm jd-flex-1 jd-truncate">{folder.name}</span>
         {folder.type === 'organization' && level === 0 && (
           <OrganizationImage

--- a/src/components/prompts/folders/FolderItem.tsx
+++ b/src/components/prompts/folders/FolderItem.tsx
@@ -199,6 +199,7 @@ const FolderItem: React.FC<FolderItemProps> = ({
         actionButtons={actionButtons}
         level={level}
         organizations={organizations}
+        type={type}
       />
       
       {isExpanded && (

--- a/src/components/prompts/templates/TemplateItem.tsx
+++ b/src/components/prompts/templates/TemplateItem.tsx
@@ -8,6 +8,12 @@ import { Template } from '@/types/prompts/templates';
 import { useTemplateActions } from '@/hooks/prompts'; // Updated import from hooks directly
 import { getMessage } from '@/core/utils/i18n';
 
+const iconColorMap = {
+  user: 'jd-text-blue-500',
+  company: 'jd-text-emerald-500',
+  organization: 'jd-text-purple-500'
+} as const;
+
 interface TemplateItemProps {
   template: Template;
   type?: 'company' | 'organization' | 'user';
@@ -158,7 +164,7 @@ export function TemplateItem({
       className={`jd-flex jd-items-center jd-p-2 hover:jd-bg-accent/60 jd-rounded-sm jd-cursor-pointer jd-group ${isProcessing ? 'jd-opacity-50' : ''}`}
       onClick={handleTemplateClick}
     >
-      <FileText className="jd-h-4 jd-w-4 jd-mr-2 jd-text-muted-foreground" />
+      <FileText className={`jd-h-4 jd-w-4 jd-mr-2 ${iconColorMap[type]}`} />
       <div className="jd-flex-1 jd-min-w-0">
         <div className="jd-text-sm jd-truncate">
           {displayName}


### PR DESCRIPTION
## Summary
- style folder icons using consistent color mapping
- expose folder type to FolderHeader for color styling
- allow pinning company folders in TemplatesPanel
- color template icons based on item type

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6854e777c35883258acf24d225fd7f99