### PR TITLE
Unify template design

### DIFF
--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -2,6 +2,7 @@
 // src/components/panels/TemplatesPanel/index.tsx
 import React, { useCallback, memo, useMemo, useState } from 'react';
 import { FolderOpen, RefreshCw, PlusCircle, FileText, Plus, ArrowLeft, Pencil, Trash2 } from "lucide-react";
+import { PinButton } from '@/components/prompts/folders';
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Separator } from "@/components/ui/separator";
@@ -503,6 +504,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
                         {((item.Folders?.length || 0) + (item.templates?.length || 0))} items
                       </span>
                       <div className="jd-flex jd-items-center jd-gap-2 jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity">
+                        <PinButton isPinned={!!item.is_pinned} onClick={() => {}} className="" />
                         <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); handleEditFolder(item); }}>
                           <Pencil className="jd-h-4 jd-w-4" />
                         </Button>

--- a/src/components/prompts/folders/FolderHeader.tsx
+++ b/src/components/prompts/folders/FolderHeader.tsx
@@ -6,8 +6,8 @@ import { useOrganizationById } from '@/hooks/organizations';
 
 const folderIconColors = {
   user: 'jd-text-blue-500',
-  company: 'jd-text-emerald-500',
-  organization: 'jd-text-purple-500'
+  company: 'jd-text-red-500',
+  organization: 'jd-text-gray-600'
 } as const;
 
 export function FolderHeader({

--- a/src/components/prompts/folders/FolderItem.tsx
+++ b/src/components/prompts/folders/FolderItem.tsx
@@ -141,12 +141,12 @@ const FolderItem: React.FC<FolderItemProps> = ({
   // Create action buttons for folder header
   const actionButtons = (
     <div className="jd-flex jd-items-center jd-gap-2">
-      {showPinControls && onTogglePin && type !== 'user' && (
-        <PinButton 
-          isPinned={isPinned} 
-          onClick={handleTogglePin} 
+      {showPinControls && onTogglePin && (
+        <PinButton
+          isPinned={isPinned}
+          onClick={handleTogglePin}
           disabled={isPinOperationInProgress.current}
-          className="" 
+          className=""
         />
       )}
       

--- a/src/components/prompts/templates/TemplateItem.tsx
+++ b/src/components/prompts/templates/TemplateItem.tsx
@@ -1,6 +1,7 @@
 // src/components/templates/TemplateItem.tsx (Consistent styling)
 import React from 'react';
 import { FileText, Edit, Clock, Activity, Trash2 } from 'lucide-react';
+import { OrganizationImage } from '@/components/organizations';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -10,8 +11,8 @@ import { getMessage } from '@/core/utils/i18n';
 
 const iconColorMap = {
   user: 'jd-text-blue-500',
-  company: 'jd-text-emerald-500',
-  organization: 'jd-text-purple-500'
+  company: 'jd-text-red-500',
+  organization: 'jd-text-gray-600'
 } as const;
 
 interface TemplateItemProps {
@@ -165,6 +166,14 @@ export function TemplateItem({
       onClick={handleTemplateClick}
     >
       <FileText className={`jd-h-4 jd-w-4 jd-mr-2 ${iconColorMap[type]}`} />
+      {type === 'organization' && (
+        <OrganizationImage
+          imageUrl={(template as any).image_url || (template as any).organization?.image_url}
+          organizationName={(template as any).organization?.name || template.title}
+          size="sm"
+          className="jd-mr-2"
+        />
+      )}
       <div className="jd-flex-1 jd-min-w-0">
         <div className="jd-text-sm jd-truncate">
           {displayName}


### PR DESCRIPTION
## Summary
- tweak TemplateItem and FolderHeader colors
- show organization image for org templates
- expose pin button on all folders
- allow pin button visibility in templates panel

## Testing
- `pnpm lint` *(fails: 487 problems)*
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_b_6854efef9e708325b47d9e7976333b4d