### PR TITLE
Fix metadata block creation visibility

### DIFF
--- a/src/components/dialogs/prompts/TemplateEditorDialog/TemplateEditorContext.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/TemplateEditorContext.tsx
@@ -25,6 +25,7 @@ export interface TemplateEditorContextValue extends MetadataUIState {
   // Blocks - simplified
   blockContentCache: Record<number, string>;
   availableMetadataBlocks: Record<MetadataType, Block[]>;
+  addNewBlock: (block: Block) => void;
 }
 
 const TemplateEditorContext = createContext<TemplateEditorContextValue | undefined>(undefined);

--- a/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
@@ -102,7 +102,8 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
       content,
       setContent,
       blockContentCache,
-      availableMetadataBlocks
+      availableMetadataBlocks,
+      addNewBlock
     }),
     [
       metadata,
@@ -118,7 +119,8 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
       content,
       setContent,
       blockContentCache,
-      availableMetadataBlocks
+      availableMetadataBlocks,
+      addNewBlock
     ]
   );
 

--- a/src/components/prompts/blocks/MetadataCard.tsx
+++ b/src/components/prompts/blocks/MetadataCard.tsx
@@ -67,7 +67,7 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
   const iconColors = getBlockIconColors(config.blockType, isDarkMode);
   const Icon = getBlockTypeIcon(config.blockType);
   const { openDialog } = useDialogManager();
-  const { metadata, setMetadata } = useTemplateEditor();
+  const { metadata, setMetadata, addNewBlock } = useTemplateEditor();
 
   const value =
     !isMultipleMetadataType(type)
@@ -99,6 +99,7 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
       openDialog(DIALOG_TYPES.CREATE_BLOCK, {
         initialType: config.blockType,
         onBlockCreated: b => {
+          addNewBlock(b);
           setMetadata(prev =>
             updateSingleMetadata(prev, type as SingleMetadataType, b.id)
           );
@@ -123,6 +124,7 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
       openDialog(DIALOG_TYPES.CREATE_BLOCK, {
         initialType: config.blockType,
         onBlockCreated: b => {
+          addNewBlock(b);
           setMetadata(prev =>
             updateMetadataItem(prev, type as MultipleMetadataType, id, {
               blockId: b.id,
@@ -153,6 +155,7 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
       openDialog(DIALOG_TYPES.CREATE_BLOCK, {
         initialType: config.blockType,
         onBlockCreated: b => {
+          addNewBlock(b);
           setMetadata(prev =>
             addMetadataItem(prev, type as MultipleMetadataType, {
               blockId: b.id,


### PR DESCRIPTION
## Summary
- expose `addNewBlock` in template editor context
- provide `addNewBlock` from template dialog
- update `MetadataCard` to register new blocks when created

## Testing
- `npm run lint` *(fails: several eslint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6854f386c8688325b632f8df08739bb9