### PR TITLE
Fix folder pinning and icons

### DIFF
--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -289,7 +289,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
     async (
       folderId: number,
       isPinned: boolean,
-      type: 'company' | 'organization'
+      type: 'company' | 'organization' | 'user'
     ) => {
       try {
         await toggleFolderPin.mutateAsync({ folderId, isPinned, type });
@@ -504,7 +504,14 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
                         {((item.Folders?.length || 0) + (item.templates?.length || 0))} items
                       </span>
                       <div className="jd-flex jd-items-center jd-gap-2 jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity">
-                        <PinButton isPinned={!!item.is_pinned} onClick={() => {}} className="" />
+                        <PinButton
+                          isPinned={!!item.is_pinned}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleTogglePin(item.id, !!item.is_pinned, 'user');
+                          }}
+                          className=""
+                        />
                         <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); handleEditFolder(item); }}>
                           <Pencil className="jd-h-4 jd-w-4" />
                         </Button>

--- a/src/components/prompts/folders/FolderHeader.tsx
+++ b/src/components/prompts/folders/FolderHeader.tsx
@@ -1,5 +1,5 @@
 // src/components/folders/FolderHeader.tsx
-import { Folder, ChevronDown, ChevronRight } from "lucide-react";
+import { Folder } from "lucide-react";
 import { OrganizationImage } from '@/components/organizations';
 import { Organization } from '@/types/organizations';
 import { useOrganizationById } from '@/hooks/organizations';
@@ -38,10 +38,7 @@ export function FolderHeader({
         className="jd-group jd-flex jd-items-center jd-p-2 hover:jd-bg-accent/60 jd-cursor-pointer jd-rounded-sm"
         onClick={onToggle}
       >
-        {isExpanded ? 
-          <ChevronDown className="jd-h-4 jd-w-4 jd-mr-1 jd-flex-shrink-0" /> : 
-          <ChevronRight className="jd-h-4 jd-w-4 jd-mr-1 jd-flex-shrink-0" />
-        }
+        {/* Removed chevron icons for a cleaner look */}
         <Folder className={`jd-h-4 jd-w-4 jd-mr-2 ${folderIconColors[type || folder.type || 'user']}`} />
         <span className="jd-text-sm jd-flex-1 jd-truncate">{folder.name}</span>
         {folder.type === 'organization' && level === 0 && (

--- a/src/hooks/prompts/actions/useFolderMutations.ts
+++ b/src/hooks/prompts/actions/useFolderMutations.ts
@@ -14,7 +14,7 @@ interface FolderData {
 interface TogglePinParams {
   folderId: number;
   isPinned: boolean;
-  type: 'company' | 'organization';
+  type: 'company' | 'organization' | 'user';
 }
 
 /**

--- a/src/services/api/PromptApi.ts
+++ b/src/services/api/PromptApi.ts
@@ -40,7 +40,7 @@ class PromptApiClient {
     return updatePinnedFolders(type, folderIds);
   }
 
-  async toggleFolderPin(folderId: number, isPinned: boolean, type: 'company' | 'organization'): Promise<any> {
+  async toggleFolderPin(folderId: number, isPinned: boolean, type: 'company' | 'organization' | 'user'): Promise<any> {
     return toggleFolderPin(folderId, isPinned, type);
   }
 

--- a/src/services/api/prompts/folders/toggleFolderPin.ts
+++ b/src/services/api/prompts/folders/toggleFolderPin.ts
@@ -4,9 +4,9 @@ import { apiClient } from "@/services/api/ApiClient";
  * Toggle pin status for a single folder
  * @param folderId - ID of the folder to toggle
  * @param isPinned - Current pin status (true if pinned, false if not)
- * @param type - Type of folder (company or organization)
+ * @param type - Type of folder (company, organization or user)
  */
-export async function toggleFolderPin(folderId: number, isPinned: boolean, type: 'company' | 'organization'): Promise<any> {
+export async function toggleFolderPin(folderId: number, isPinned: boolean, type: 'company' | 'organization' | 'user'): Promise<any> {
     try {
       // Determine which endpoint to use based on current pin status
       const endpoint = isPinned 


### PR DESCRIPTION
## Summary
- align folder headers by removing chevron icons
- allow `toggleFolderPin` to support user folders
- wire pin button for user folders

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6854fa4100d4832599f7aa38da30329f