### PR TITLE
Filter root folders

### DIFF
--- a/src/hooks/prompts/navigation/useFolderNavigation.ts
+++ b/src/hooks/prompts/navigation/useFolderNavigation.ts
@@ -47,9 +47,12 @@ export function useFolderNavigation(data: UnifiedFolderData) {
 
   // Get the root folders (user + organization combined)
   const rootFolders = useMemo(() => {
+    const filterRoot = (folders: TemplateFolder[]) =>
+      folders.filter(f => !f.parent_folder_id);
+
     return [
-      ...data.userFolders.map(folder => ({ ...folder, rootType: 'user' as const })),
-      ...data.organizationFolders.map(folder => ({ ...folder, rootType: 'organization' as const }))
+      ...filterRoot(data.userFolders).map(folder => ({ ...folder, rootType: 'user' as const })),
+      ...filterRoot(data.organizationFolders).map(folder => ({ ...folder, rootType: 'organization' as const }))
     ];
   }, [data.userFolders, data.organizationFolders]);
 

--- a/src/hooks/prompts/queries/folders/usePinnedFolders.ts
+++ b/src/hooks/prompts/queries/folders/usePinnedFolders.ts
@@ -35,14 +35,14 @@ export function usePinnedFolders() {
       if (userResponse.success) {
         const uFolders = (userResponse.data.folders.user || []) as TemplateFolder[];
         userPinned = uFolders
-          .filter(folder => pinnedIds.includes(folder.id))
+          .filter(folder => pinnedIds.includes(folder.id) && !folder.parent_folder_id)
           .map(folder => ({ ...folder, is_pinned: true }));
       }
 
       if (orgResponse.success) {
         const oFolders = (orgResponse.data.folders.organization || []) as TemplateFolder[];
         orgPinned = oFolders
-          .filter(folder => pinnedIds.includes(folder.id))
+          .filter(folder => pinnedIds.includes(folder.id) && !folder.parent_folder_id)
           .map(folder => ({ ...folder, is_pinned: true }));
       }
     }

--- a/src/hooks/prompts/queries/folders/useUserCompanyOrganizationFolders.ts
+++ b/src/hooks/prompts/queries/folders/useUserCompanyOrganizationFolders.ts
@@ -18,7 +18,8 @@ export function useUserFolders() {
     if (!foldersResponse.success) {
       throw new Error(foldersResponse.message || 'Failed to load user folders');
     }
-    return foldersResponse.data.folders.user || [];
+    const folders = foldersResponse.data.folders.user || [];
+    return folders.filter(f => !f.parent_folder_id);
   }, {
     refetchOnWindowFocus: false,
     onError: (error: Error) => {
@@ -37,7 +38,8 @@ export function useCompanyFolders() {
     if (!foldersResponse.success) {
       throw new Error(foldersResponse.message || 'Failed to load company folders');
     }
-    return foldersResponse.data.folders.company || [];
+    const folders = foldersResponse.data.folders.company || [];
+    return folders.filter(f => !f.parent_folder_id);
   }, {
     refetchOnWindowFocus: false,
     onError: (error: Error) => {
@@ -56,7 +58,8 @@ export function useOrganizationFolders() {
     if (!foldersResponse.success) {
       throw new Error(foldersResponse.message || 'Failed to load organization folders');
     }
-    return foldersResponse.data.folders.organization || [];
+    const folders = foldersResponse.data.folders.organization || [];
+    return folders.filter(f => !f.parent_folder_id);
   }, {
     refetchOnWindowFocus: false,
     onError: (error: Error) => {


### PR DESCRIPTION
## Summary
- show only top level folders in navigation and pinned sections
- filter folders in folder queries to exclude non-root folders

## Testing
- `npm run lint` *(fails: 496 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68554e3927bc8325ab40dd34a7e34026