### PR TITLE
Improve folder and template item layout

### DIFF
--- a/src/components/prompts/folders/FolderItem.tsx
+++ b/src/components/prompts/folders/FolderItem.tsx
@@ -251,14 +251,24 @@ export const FolderItem: React.FC<FolderItemProps> = ({
           {folder.description ? (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="jd-text-sm jd-truncate jd-block">{folder.name}</span>
+                <span
+                  className="jd-text-sm jd-truncate jd-block"
+                  title={folder.name}
+                >
+                  {folder.name}
+                </span>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="jd-max-w-xs jd-z-50">
                 <p>{folder.description}</p>
               </TooltipContent>
             </Tooltip>
           ) : (
-            <span className="jd-text-sm jd-truncate jd-block">{folder.name}</span>
+            <span
+              className="jd-text-sm jd-truncate jd-block"
+              title={folder.name}
+            >
+              {folder.name}
+            </span>
           )}
         </div>
 
@@ -270,7 +280,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
         )}
 
         {/* Action Buttons */}
-        <div className="jd-flex jd-items-center jd-gap-1">
+        <div className="jd-ml-auto jd-flex jd-items-center jd-gap-1">
           {/* Pin Button */}
           {showPinControls && onTogglePin && (
             <PinButton

--- a/src/components/prompts/templates/TemplateItem.tsx
+++ b/src/components/prompts/templates/TemplateItem.tsx
@@ -118,7 +118,10 @@ export const TemplateItem: React.FC<TemplateItemProps> = ({
         {template.description ? (
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="jd-text-sm jd-truncate jd-font-medium">
+              <div
+                className="jd-text-sm jd-truncate jd-font-medium"
+                title={displayName}
+              >
                 {displayName}
               </div>
             </TooltipTrigger>
@@ -127,7 +130,10 @@ export const TemplateItem: React.FC<TemplateItemProps> = ({
             </TooltipContent>
           </Tooltip>
         ) : (
-          <div className="jd-text-sm jd-truncate jd-font-medium">
+          <div
+            className="jd-text-sm jd-truncate jd-font-medium"
+            title={displayName}
+          >
             {displayName}
           </div>
         )}
@@ -149,7 +155,7 @@ export const TemplateItem: React.FC<TemplateItemProps> = ({
       </div>
       
       {/* Action Buttons */}
-      <div className="jd-ml-2 jd-flex jd-items-center jd-gap-1">
+      <div className="jd-ml-auto jd-flex jd-items-center jd-gap-1">
         {/* Pin Button */}
         {shouldShowPinControls && (
           <TooltipProvider>


### PR DESCRIPTION
## Summary
- align pin button container to right side
- show full title on hover with browser tooltip for folders and templates

## Testing
- `pnpm lint` *(fails: 496 problems)*
- `pnpm type-check`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_685582ef6f6c8325a4b018b8fff84731