### PR TITLE
Fix parent folder selection

### DIFF
--- a/src/hooks/prompts/queries/folders/useUserCompanyOrganizationFolders.ts
+++ b/src/hooks/prompts/queries/folders/useUserCompanyOrganizationFolders.ts
@@ -19,7 +19,11 @@ export function useUserFolders() {
       throw new Error(foldersResponse.message || 'Failed to load user folders');
     }
     const folders = foldersResponse.data.folders.user || [];
-    return folders.filter(f => !f.parent_folder_id);
+    // Return the full folder hierarchy including subfolders
+    // Filtering by parent_folder_id stripped nested folders and
+    // prevented selecting a parent folder when creating a new one
+    // causing parent_folder_id to always be null in CreateFolderDialog
+    return folders;
   }, {
     refetchOnWindowFocus: false,
     onError: (error: Error) => {
@@ -39,7 +43,8 @@ export function useCompanyFolders() {
       throw new Error(foldersResponse.message || 'Failed to load company folders');
     }
     const folders = foldersResponse.data.folders.company || [];
-    return folders.filter(f => !f.parent_folder_id);
+    // Return all folders to allow nested selection in folder pickers
+    return folders;
   }, {
     refetchOnWindowFocus: false,
     onError: (error: Error) => {
@@ -59,7 +64,8 @@ export function useOrganizationFolders() {
       throw new Error(foldersResponse.message || 'Failed to load organization folders');
     }
     const folders = foldersResponse.data.folders.organization || [];
-    return folders.filter(f => !f.parent_folder_id);
+    // Return the full hierarchy so nested folders are preserved
+    return folders;
   }, {
     refetchOnWindowFocus: false,
     onError: (error: Error) => {


### PR DESCRIPTION
## Summary
- return nested folders from user/company/organization hooks so FolderPicker has the full hierarchy

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685922dbd2948325b047ec751b78aec0