### PR TITLE
Add BrowseMoreFolders dialog

### DIFF
--- a/src/components/dialogs/DialogRegistry.ts
+++ b/src/components/dialogs/DialogRegistry.ts
@@ -12,6 +12,9 @@ export const DIALOG_TYPES = {
   CONFIRMATION: 'confirmation',
   ENHANCED_STATS: 'enhancedStats',
 
+  // Dialog for browsing all folders
+  BROWSE_MORE_FOLDERS: 'browseMoreFolders',
+
   // New dialog type for block creation
   CREATE_BLOCK: 'createBlock',
   INSERT_BLOCK: 'insertBlock'
@@ -73,6 +76,8 @@ export interface DialogProps {
   };
   
   [DIALOG_TYPES.ENHANCED_STATS]: Record<string, never>;
+
+  [DIALOG_TYPES.BROWSE_MORE_FOLDERS]: Record<string, never>;
   
   [DIALOG_TYPES.CREATE_BLOCK]: {
     initialType?: string;

--- a/src/components/dialogs/index.tsx
+++ b/src/components/dialogs/index.tsx
@@ -9,6 +9,7 @@ import { AuthDialog } from './auth/AuthDialog';
 import { SettingsDialog } from './settings/SettingsDialog';
 import { ConfirmationDialog } from './common/ConfirmationDialog';
 import { EnhancedStatsDialog } from './analytics/EnhancedStatsDialog';
+import { BrowseMoreFoldersDialog } from './prompts/BrowseMoreFoldersDialog';
 
 /**
  * Main dialog provider that includes all dialog components
@@ -46,6 +47,7 @@ export const DialogProvider: React.FC<{children: React.ReactNode}> = ({ children
       <SettingsDialog />
       <ConfirmationDialog />
       <EnhancedStatsDialog />
+      <BrowseMoreFoldersDialog />
     </DialogContextProvider>
   );
 };
@@ -61,4 +63,5 @@ export { SettingsDialog } from './settings/SettingsDialog';
 export { ConfirmationDialog } from './common/ConfirmationDialog';
 export { EnhancedStatsDialog } from './analytics/EnhancedStatsDialog';
 export { FolderManagerDialog } from './prompts/FolderManagerDialog';
+export { BrowseMoreFoldersDialog } from './prompts/BrowseMoreFoldersDialog';
 export { BaseDialog } from './BaseDialog';

--- a/src/components/dialogs/prompts/BrowseMoreFoldersDialog/index.tsx
+++ b/src/components/dialogs/prompts/BrowseMoreFoldersDialog/index.tsx
@@ -1,0 +1,90 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { BaseDialog } from '@/components/dialogs/BaseDialog';
+import { useDialog } from '@/components/dialogs/DialogContext';
+import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
+import { useUserFolders, useOrganizationFolders, usePinnedFolders, useFolderMutations, useTemplateActions } from '@/hooks/prompts';
+import { FolderItem } from '@/components/prompts/folders/FolderItem';
+import { FolderSearch } from '@/components/prompts/folders/FolderSearch';
+import { Separator } from '@/components/ui/separator';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { useOrganizations } from '@/hooks/organizations';
+import { LoadingState } from '@/components/panels/TemplatesPanel/LoadingState';
+import { EmptyMessage } from '@/components/panels/TemplatesPanel/EmptyMessage';
+import { useFolderSearch } from '@/hooks/prompts/utils/useFolderSearch';
+
+export const BrowseMoreFoldersDialog: React.FC = () => {
+  const { isOpen, dialogProps } = useDialog(DIALOG_TYPES.BROWSE_MORE_FOLDERS);
+
+  const { data: userFolders = [], isLoading: loadingUser } = useUserFolders();
+  const { data: organizationFolders = [], isLoading: loadingOrg } = useOrganizationFolders();
+  const { data: organizations = [] } = useOrganizations();
+  const { refetch: refetchPinned } = usePinnedFolders();
+  const { toggleFolderPin } = useFolderMutations();
+  const { useTemplate } = useTemplateActions();
+
+  const allFolders = useMemo(() => [...userFolders, ...organizationFolders], [userFolders, organizationFolders]);
+  const { searchQuery, setSearchQuery, filteredFolders, clearSearch } = useFolderSearch(allFolders);
+
+  const handleTogglePin = useCallback(async (folderId: number, isPinned: boolean, type: 'user' | 'organization' | 'company') => {
+    try {
+      await toggleFolderPin.mutateAsync({ folderId, isPinned, type });
+      refetchPinned();
+    } catch (error) {
+      console.error('Error toggling pin:', error);
+    }
+  }, [toggleFolderPin, refetchPinned]);
+
+  // Add pinned status from user/organization folders
+  const foldersWithPin = useMemo(() => {
+    return filteredFolders.map(f => ({ ...f, is_pinned: !!f.is_pinned }));
+  }, [filteredFolders]);
+
+  if (!isOpen) return null;
+
+  const loading = loadingUser || loadingOrg;
+
+  return (
+    <BaseDialog
+      open={isOpen}
+      onOpenChange={dialogProps.onOpenChange}
+      title="Browse Folders"
+      className="jd-max-w-lg"
+    >
+      <TooltipProvider>
+        <FolderSearch
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
+          placeholderText="Search folders..."
+          onReset={clearSearch}
+        />
+        <Separator />
+        <div className="jd-overflow-y-auto jd-max-h-[70vh]">
+          {loading ? (
+            <LoadingState message="Loading folders..." />
+          ) : foldersWithPin.length === 0 ? (
+            <EmptyMessage>No folders found</EmptyMessage>
+          ) : (
+            <div className="jd-space-y-1 jd-px-2">
+              {foldersWithPin.map(folder => (
+                <FolderItem
+                  key={`browse-folder-${folder.id}`}
+                  folder={folder}
+                  type={folder.type as any}
+                  enableNavigation={false}
+                  onUseTemplate={useTemplate}
+                  onTogglePin={(id, pinned) => handleTogglePin(id, pinned, folder.type as any)}
+                  organizations={organizations}
+                  showPinControls={true}
+                  showEditControls={false}
+                  showDeleteControls={false}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </TooltipProvider>
+    </BaseDialog>
+  );
+};
+
+export default BrowseMoreFoldersDialog;

--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -128,7 +128,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
   const { toggleFolderPin, deleteFolder, createFolder } = useFolderMutations();
   const { deleteTemplate } = useTemplateMutations();
   const { useTemplate, createTemplate, editTemplate } = useTemplateActions();
-  const { openConfirmation, openFolderManager, openCreateFolder } = useDialogActions();
+  const { openConfirmation, openFolderManager, openCreateFolder, openBrowseMoreFolders } = useDialogActions();
 
   // Enhanced pin handler that works with the navigation system
   const handleTogglePin = useCallback(
@@ -321,12 +321,15 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
 
           {/* Pinned Templates Section using enhanced components */}
           <div>
-            <div className="jd-flex jd-items-center jd-justify-between jd-text-sm jd-font-medium jd-text-muted-foreground jd-mb-2 jd-px-2">
-              <div className="jd-flex jd-items-center">
-                <FolderOpen className="jd-mr-2 jd-h-4 jd-w-4" />
-                {getMessage('pinnedTemplates', undefined, 'Pinned Templates')}
-              </div>
+          <div className="jd-flex jd-items-center jd-justify-between jd-text-sm jd-font-medium jd-text-muted-foreground jd-mb-2 jd-px-2">
+            <div className="jd-flex jd-items-center">
+              <FolderOpen className="jd-mr-2 jd-h-4 jd-w-4" />
+              {getMessage('pinnedTemplates', undefined, 'Pinned Templates')}
             </div>
+            <Button variant="secondary" size="sm" className="jd-h-7 jd-px-2 jd-text-xs" onClick={openBrowseMoreFolders}>
+              {getMessage('browseMore', undefined, 'Browse More')}
+            </Button>
+          </div>
 
             <div className="jd-space-y-1 jd-px-2 jd-max-h-96 jd-overflow-y-auto">
               {[...(filteredPinned.user || []), ...(filteredPinned.organization || [])].length === 0 ? (

--- a/src/hooks/dialogs/useDialogActions.ts
+++ b/src/hooks/dialogs/useDialogActions.ts
@@ -47,6 +47,11 @@ export function useDialogActions() {
     [openDialog]
   );
 
+  const openBrowseMoreFolders = useCallback(
+    () => openDialog(DIALOG_TYPES.BROWSE_MORE_FOLDERS, {}),
+    [openDialog]
+  );
+
   const openCreateBlock = useCallback(
     (props?: any) => openDialog(DIALOG_TYPES.CREATE_BLOCK, props),
     [openDialog]
@@ -67,6 +72,7 @@ export function useDialogActions() {
     openPlaceholderEditor,
     openConfirmation,
     openEnhancedStats,
+    openBrowseMoreFolders,
     openCreateBlock,
     openInsertBlock,
   };


### PR DESCRIPTION
## Summary
- add `BROWSE_MORE_FOLDERS` dialog type
- implement `BrowseMoreFoldersDialog` component and register it
- expose `openBrowseMoreFolders` helper
- link dialog from pinned templates section

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6859334d47b083258a5b550c8c3c09c5