### PR TITLE
Allow pinning subfolders

### DIFF
--- a/src/hooks/prompts/queries/folders/usePinnedFolders.ts
+++ b/src/hooks/prompts/queries/folders/usePinnedFolders.ts
@@ -32,17 +32,17 @@ export function usePinnedFolders() {
         promptApi.getFolders('organization', true, true, userLocale)
       ]);
 
-      if (userResponse.success) {
+        if (userResponse.success) {
         const uFolders = (userResponse.data.folders.user || []) as TemplateFolder[];
         userPinned = uFolders
-          .filter(folder => pinnedIds.includes(folder.id) && !folder.parent_folder_id)
+          .filter(folder => pinnedIds.includes(folder.id))
           .map(folder => ({ ...folder, is_pinned: true }));
       }
 
-      if (orgResponse.success) {
+        if (orgResponse.success) {
         const oFolders = (orgResponse.data.folders.organization || []) as TemplateFolder[];
         orgPinned = oFolders
-          .filter(folder => pinnedIds.includes(folder.id) && !folder.parent_folder_id)
+          .filter(folder => pinnedIds.includes(folder.id))
           .map(folder => ({ ...folder, is_pinned: true }));
       }
     }


### PR DESCRIPTION
## Summary
- update pinned folders query logic so subfolders can be pinned

## Testing
- `npm run lint` *(fails: 499 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6859367a398c8325a29f2d2ca118bd31