### PR TITLE
Show organization info on template customization

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1489,5 +1489,19 @@
   "noContentBlocks": { "message": "No content blocks yet", "description": "Message when no blocks exist" },
   "errorProcessingTemplate": { "message": "Failed to process template content. Please try again.", "description": "Error message when template processing fails" },
   "errorProcessingTemplateToast": { "message": "Failed to process template content", "description": "Toast message for processing error" },
+  "organizationTemplateNotice": {
+    "message": "Template provided by your organization",
+    "description": "Notice shown when customizing an organization template"
+  },
+  "organizationTemplateNoticeWithName": {
+    "message": "Template provided by $ORGANIZATION$",
+    "description": "Notice shown when customizing an organization template with its name",
+    "placeholders": {
+      "organization": {
+        "content": "$1",
+        "example": "ACME Corp"
+      }
+    }
+  },
   "cannotRemoveLastBlock": { "message": "Cannot remove the last block. Templates must have at least one block.", "description": "Warning when trying to remove last block" }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1472,5 +1472,19 @@
   "noContentBlocks": { "message": "Aucun bloc de contenu", "description": "Message lorsqu'aucun bloc n'est présent" },
   "errorProcessingTemplate": { "message": "Impossible de traiter le contenu du modèle. Veuillez réessayer.", "description": "Message d'erreur lors du traitement du modèle" },
   "errorProcessingTemplateToast": { "message": "Échec du traitement du modèle", "description": "Toast d'erreur de traitement" },
+  "organizationTemplateNotice": {
+    "message": "Template proposé par votre organisation",
+    "description": "Message affiché lors de la personnalisation d'un template d'organisation"
+  },
+  "organizationTemplateNoticeWithName": {
+    "message": "Template proposé par $ORGANIZATION$",
+    "description": "Message affiché lors de la personnalisation d'un template d'organisation avec son nom",
+    "placeholders": {
+      "organization": {
+        "content": "$1",
+        "example": "ACME"
+      }
+    }
+  },
   "cannotRemoveLastBlock": { "message": "Impossible de supprimer le dernier bloc. Le modèle doit comporter au moins un bloc.", "description": "Avertissement lors de la suppression du dernier bloc" }
 }

--- a/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
@@ -1,11 +1,33 @@
 // src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx - Updated
-import React from 'react';
+import React, { useMemo } from 'react';
 import { getMessage } from '@/core/utils/i18n';
 import { useCustomizeTemplateDialog } from '@/hooks/dialogs/useCustomizeTemplateDialog';
 import { TemplateEditorDialog } from '../TemplateEditorDialog';
+import { OrganizationImage } from '@/components/organizations';
+import { Alert } from '@/components/ui/alert';
 
 export const CustomizeTemplateDialog: React.FC = () => {
   const hook = useCustomizeTemplateDialog();
+
+  const infoForm = useMemo(() => {
+    if (hook.data?.type === 'organization') {
+      const orgName = hook.data.organization?.name as string | undefined;
+      const imageUrl = hook.data.organization?.image_url || hook.data.image_url;
+      const text = orgName
+        ? getMessage('organizationTemplateNoticeWithName', orgName, `Template provided by ${orgName}`)
+        : getMessage('organizationTemplateNotice', undefined, 'Template provided by your organization');
+
+      return (
+        <Alert className="jd-flex jd-items-center jd-gap-2 jd-mb-4 jd-bg-muted/60">
+          {imageUrl && (
+            <OrganizationImage imageUrl={imageUrl} organizationName={orgName || ''} size="sm" className="jd-mr-2" />
+          )}
+          <span className="jd-text-sm">{text}</span>
+        </Alert>
+      );
+    }
+    return null;
+  }, [hook.data]);
 
   return (
     <TemplateEditorDialog
@@ -52,6 +74,7 @@ export const CustomizeTemplateDialog: React.FC = () => {
       dialogTitle={getMessage('CustomizeTemplateDialog', undefined, 'Customize Template')}
       dialogDescription={getMessage('CustomizeTemplateDialogDescription', undefined, 'Customize your prompt template')}
       mode="customize"
+      infoForm={infoForm}
     />
   );
 };

--- a/src/hooks/dialogs/useCustomizeTemplateDialog.ts
+++ b/src/hooks/dialogs/useCustomizeTemplateDialog.ts
@@ -105,6 +105,7 @@ export function useCustomizeTemplateDialog() {
   return {
     ...baseHook,
     isOpen,
-    dialogProps
+    dialogProps,
+    data
   };
 }

--- a/src/hooks/prompts/actions/useTemplateActions.ts
+++ b/src/hooks/prompts/actions/useTemplateActions.ts
@@ -136,6 +136,8 @@ const useTemplate = useCallback(async (template: Template) => {
       title: template.title || 'Untitled Template',
       type: template.type,
       id: template.id,
+      organization: (template as any).organization,
+      image_url: (template as any).image_url,
       onComplete: handleTemplateComplete
     };
 


### PR DESCRIPTION
## Summary
- add new organization notice messages in EN and FR locales
- include organization info when opening placeholder editor
- expose dialog data in `useCustomizeTemplateDialog`
- display organization logo and message in `CustomizeTemplateDialog`

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68593c517df48325969ebdda16530c41