### PR TITLE
Fix slash command trigger behaviour

### DIFF
--- a/src/components/prompts/blocks/quick-selector/QuickBlockSelector.tsx
+++ b/src/components/prompts/blocks/quick-selector/QuickBlockSelector.tsx
@@ -40,6 +40,7 @@ interface QuickBlockSelectorProps {
   targetElement: HTMLElement;
   onOpenFullDialog: () => void;
   cursorPosition?: number; // Store the original cursor position
+  triggerLength?: number;
 }
 
 export const QuickBlockSelector: React.FC<QuickBlockSelectorProps> = ({
@@ -47,7 +48,8 @@ export const QuickBlockSelector: React.FC<QuickBlockSelectorProps> = ({
   onClose,
   targetElement,
   onOpenFullDialog,
-  cursorPosition
+  cursorPosition,
+  triggerLength
 }) => {
   const shadowRoot = useShadowRoot();
   const { blocks, loading } = useBlocks();
@@ -136,7 +138,7 @@ export const QuickBlockSelector: React.FC<QuickBlockSelectorProps> = ({
     }
   }, [activeIndex]);
 
-  const { insertBlock } = useBlockInsertion(targetElement, cursorPosition, onClose);
+  const { insertBlock } = useBlockInsertion(targetElement, cursorPosition, onClose, triggerLength);
   const handleSelectBlock = (block: Block) => insertBlock(block);
 
   const openFullDialog = () => {

--- a/src/components/prompts/blocks/quick-selector/index.ts
+++ b/src/components/prompts/blocks/quick-selector/index.ts
@@ -12,6 +12,8 @@ export interface QuickBlockSelectorProps {
   onClose: () => void;
   targetElement: HTMLElement;
   onOpenFullDialog: () => void;
+  cursorPosition?: number;
+  triggerLength?: number;
 }
 
 export interface BlockItemProps {

--- a/src/components/prompts/blocks/quick-selector/useBlockInsertion.ts
+++ b/src/components/prompts/blocks/quick-selector/useBlockInsertion.ts
@@ -10,7 +10,8 @@ import { insertTextAtCursor } from '@/utils/templates/placeholderUtils';
 export function useBlockInsertion(
   targetElement: HTMLElement,
   cursorPosition?: number,
-  onClose?: () => void
+  onClose?: () => void,
+  triggerLength?: number
 ) {
   const insertingRef = useRef(false);
 
@@ -20,74 +21,105 @@ export function useBlockInsertion(
     const content = getLocalizedContent(block.content);
     let text = buildPromptPart(block.type || 'custom', content);
 
-    let currentContent = '';
-    if (targetElement instanceof HTMLTextAreaElement) {
-      currentContent = targetElement.value;
-    } else if (targetElement.isContentEditable) {
-      currentContent = targetElement.textContent || '';
-    }
-
-    if (typeof cursorPosition === 'number' && currentContent.length > 0) {
-      const beforeCursorRaw = currentContent.substring(0, cursorPosition);
-      const afterCursorRaw = currentContent.substring(cursorPosition);
-
-      const beforeCursor = beforeCursorRaw.trim();
-      const afterCursor = afterCursorRaw.trim();
-
-      if (beforeCursor.length > 0 && !beforeCursorRaw.endsWith('\n')) {
-        text = '\n\n' + text;
-      }
-
-      if (afterCursor.length > 0 && !text.endsWith('\n')) {
-        text = text + '\n\n';
-      } else if (afterCursor.length === 0 && !text.endsWith('\n')) {
-        text = text + '\n';
-      }
-    } else if (currentContent.length > 0) {
-      text = text + '\n';
-    }
-
     if (onClose) onClose();
 
     setTimeout(() => {
       try {
         targetElement.focus();
 
+        // Remove the //j trigger if present
+        if (typeof cursorPosition === 'number' && typeof triggerLength === 'number' && triggerLength > 0) {
+          if (targetElement instanceof HTMLTextAreaElement) {
+            const value = targetElement.value;
+            const before = value.slice(0, cursorPosition);
+            const after = value.slice(cursorPosition + triggerLength);
+            targetElement.value = before + after;
+            targetElement.setSelectionRange(cursorPosition, cursorPosition);
+            targetElement.dispatchEvent(new Event('input', { bubbles: true }));
+            targetElement.dispatchEvent(new Event('change', { bubbles: true }));
+          } else if (targetElement.isContentEditable) {
+            const textContent = targetElement.textContent || '';
+            const before = textContent.slice(0, cursorPosition);
+            const after = textContent.slice(cursorPosition + triggerLength);
+            targetElement.textContent = before + after;
+            // place cursor
+            try {
+              const selection = window.getSelection();
+              if (selection) {
+                const range = document.createRange();
+                const walker = document.createTreeWalker(targetElement, NodeFilter.SHOW_TEXT, null);
+                let currentPos = 0;
+                let targetNode = walker.nextNode();
+                while (targetNode && currentPos + (targetNode.textContent?.length || 0) < cursorPosition) {
+                  currentPos += targetNode.textContent?.length || 0;
+                  targetNode = walker.nextNode();
+                }
+                if (targetNode) {
+                  const offset = cursorPosition - currentPos;
+                  const nodeLength = targetNode.textContent?.length || 0;
+                  const safeOffset = Math.max(0, Math.min(offset, nodeLength));
+                  range.setStart(targetNode, safeOffset);
+                  range.setEnd(targetNode, safeOffset);
+                  selection.removeAllRanges();
+                  selection.addRange(range);
+                }
+              }
+            } catch (error) {
+              console.warn('Failed to adjust cursor in contenteditable:', error);
+            }
+            targetElement.dispatchEvent(new Event('input', { bubbles: true }));
+          }
+        }
+
+        let currentContent = '';
+        if (targetElement instanceof HTMLTextAreaElement) {
+          currentContent = targetElement.value;
+        } else if (targetElement.isContentEditable) {
+          currentContent = targetElement.textContent || '';
+        }
+
+        if (typeof cursorPosition === 'number' && currentContent.length > 0) {
+          const beforeCursorRaw = currentContent.substring(0, cursorPosition);
+          const afterCursorRaw = currentContent.substring(cursorPosition);
+
+          const beforeCursor = beforeCursorRaw.trim();
+          const afterCursor = afterCursorRaw.trim();
+
+          if (beforeCursor.length > 0 && !beforeCursorRaw.endsWith('\n')) {
+            text = '\n\n' + text;
+          }
+
+          if (afterCursor.length > 0 && !text.endsWith('\n')) {
+            text = text + '\n\n';
+          } else if (afterCursor.length === 0 && !text.endsWith('\n')) {
+            text = text + '\n';
+          }
+        } else if (currentContent.length > 0) {
+          text = text + '\n';
+        }
+
         if (
           targetElement instanceof HTMLTextAreaElement &&
           typeof cursorPosition === 'number'
         ) {
-          const safePosition = Math.max(
-            0,
-            Math.min(cursorPosition, targetElement.value.length)
-          );
+          const safePosition = Math.max(0, Math.min(cursorPosition, targetElement.value.length));
           targetElement.setSelectionRange(safePosition, safePosition);
         }
 
         if (targetElement.isContentEditable && typeof cursorPosition === 'number') {
           const textContent = targetElement.textContent || '';
-          const safePosition = Math.max(
-            0,
-            Math.min(cursorPosition, textContent.length)
-          );
+          const safePosition = Math.max(0, Math.min(cursorPosition, textContent.length));
 
           try {
             const selection = window.getSelection();
             if (selection) {
               const range = document.createRange();
-              const walker = document.createTreeWalker(
-                targetElement,
-                NodeFilter.SHOW_TEXT,
-                null
-              );
+              const walker = document.createTreeWalker(targetElement, NodeFilter.SHOW_TEXT, null);
 
               let currentPos = 0;
               let targetNode = walker.nextNode();
 
-              while (
-                targetNode &&
-                currentPos + (targetNode.textContent?.length || 0) < safePosition
-              ) {
+              while (targetNode && currentPos + (targetNode.textContent?.length || 0) < safePosition) {
                 currentPos += targetNode.textContent?.length || 0;
                 targetNode = walker.nextNode();
               }

--- a/src/services/ui/QuickSelectorManager.ts
+++ b/src/services/ui/QuickSelectorManager.ts
@@ -8,7 +8,7 @@ export class QuickSelectorManager {
   private container: HTMLDivElement | null = null;
   public isOpen = false;
 
-  open(position: { x: number; y: number }, targetElement: HTMLElement, cursorPosition?: number) {
+  open(position: { x: number; y: number }, targetElement: HTMLElement, cursorPosition?: number, triggerLength?: number) {
     this.close();
     this.container = document.createElement('div');
     this.container.id = 'jaydai-quick-selector';
@@ -20,6 +20,7 @@ export class QuickSelectorManager {
         onClose: () => this.close(),
         targetElement,
         cursorPosition,
+        triggerLength,
         onOpenFullDialog: () => {
           if (window.dialogManager && typeof window.dialogManager.openDialog === 'function') {
             window.dialogManager.openDialog(DIALOG_TYPES.INSERT_BLOCK);


### PR DESCRIPTION
## Summary
- don't remove `//j` trigger until a block is selected
- keep trigger length in quick selector props
- remove trigger when inserting block

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68595263a69483258f402d7aa251c1f2