### PR TITLE
Support nested pinned folders

### DIFF
--- a/src/hooks/prompts/queries/folders/useAllPinnedFolders.ts
+++ b/src/hooks/prompts/queries/folders/useAllPinnedFolders.ts
@@ -9,12 +9,15 @@ import { TemplateFolder } from '@/types/prompts/templates';
  * Useful for determining pin status of folders in search results
  */
 export function useAllPinnedFolders() {
-  const { data: pinnedFolders = { user: [], organization: [] } } = usePinnedFolders();
+  const { data: pinnedFolders = { user: [], organization: [], pinnedIds: [] } } = usePinnedFolders();
   const { data: userFolders = [] } = useUserFolders();
   const { data: organizationFolders = [] } = useOrganizationFolders();
 
   // Get all pinned folder IDs in a flat array
   const allPinnedFolderIds = useMemo(() => {
+    if (pinnedFolders.pinnedIds && pinnedFolders.pinnedIds.length > 0) {
+      return pinnedFolders.pinnedIds;
+    }
     const userPinnedIds = (pinnedFolders.user || []).map(folder => folder.id);
     const organizationPinnedIds = (pinnedFolders.organization || []).map(folder => folder.id);
     return [...userPinnedIds, ...organizationPinnedIds];

--- a/src/hooks/prompts/queries/folders/usePinnedFolders.ts
+++ b/src/hooks/prompts/queries/folders/usePinnedFolders.ts
@@ -20,6 +20,7 @@ export function usePinnedFolders() {
     const genericIds = metadata.data?.pinned_folder_ids || [];
     const legacyOrgIds = metadata.data?.pinned_organization_folder_ids || [];
 
+    // Consolidate and deduplicate all pinned folder IDs
     const pinnedIds = Array.from(new Set([...genericIds, ...legacyOrgIds]));
 
     let userPinned: TemplateFolder[] = [];
@@ -47,9 +48,12 @@ export function usePinnedFolders() {
       }
     }
 
+    // Return pinned folders along with the raw ID list so other hooks
+    // can easily determine pin status for nested folders
     return {
       user: userPinned,
-      organization: orgPinned
+      organization: orgPinned,
+      pinnedIds
     };
   }, {
     refetchOnWindowFocus: false,


### PR DESCRIPTION
## Summary
- expose raw pinned folder IDs in `usePinnedFolders`
- update `useAllPinnedFolders` to use these IDs so nested pinned folders display correctly

## Testing
- `npm run lint` *(fails: many eslint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68595cd3f38c8325b7850c05066d0f70