### PR TITLE
Fix search resets folder navigation

### DIFF
--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -1,5 +1,5 @@
 // src/components/panels/TemplatesPanel/index.tsx - Enhanced with proper pinning support
-import React, { useCallback, memo, useMemo, useState } from 'react';
+import React, { useCallback, memo, useMemo, useState, useEffect } from 'react';
 import { FolderOpen, RefreshCw, PlusCircle, Plus, ArrowLeft, Home, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -74,6 +74,13 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
     userFolders,
     organizationFolders
   });
+
+  // Reset navigation to root when a search is initiated
+  useEffect(() => {
+    if (searchQuery && !navigation.isAtRoot) {
+      navigation.navigateToRoot();
+    }
+  }, [searchQuery, navigation.isAtRoot, navigation.navigateToRoot]);
 
   // Utility functions for search filtering
   const templateMatchesQuery = useCallback(


### PR DESCRIPTION
## Summary
- reset folder navigation when starting a search so results show

## Testing
- `pnpm lint` *(fails: Unexpected any and other lint errors)*
- `pnpm type-check`

------
https://chatgpt.com/codex/tasks/task_b_6859616aab588325ad0f0bd21d8eb9ef