### PR TITLE
Fix pin toggling in folder browse dialog

### DIFF
--- a/src/components/dialogs/prompts/BrowseMoreFoldersDialog/index.tsx
+++ b/src/components/dialogs/prompts/BrowseMoreFoldersDialog/index.tsx
@@ -2,7 +2,13 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { BaseDialog } from '@/components/dialogs/BaseDialog';
 import { useDialog } from '@/components/dialogs/DialogContext';
 import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
-import { useUserFolders, useOrganizationFolders, usePinnedFolders, useFolderMutations, useTemplateActions } from '@/hooks/prompts';
+import {
+  useUserFolders,
+  useOrganizationFolders,
+  usePinnedFolders,
+  useFolderMutations,
+  useTemplateActions
+} from '@/hooks/prompts';
 import { FolderItem } from '@/components/prompts/folders/FolderItem';
 import { FolderSearch } from '@/components/prompts/folders/FolderSearch';
 import { Separator } from '@/components/ui/separator';
@@ -18,26 +24,52 @@ export const BrowseMoreFoldersDialog: React.FC = () => {
   const { data: userFolders = [], isLoading: loadingUser } = useUserFolders();
   const { data: organizationFolders = [], isLoading: loadingOrg } = useOrganizationFolders();
   const { data: organizations = [] } = useOrganizations();
-  const { refetch: refetchPinned } = usePinnedFolders();
+  const { data: pinnedData, refetch: refetchPinned } = usePinnedFolders();
   const { toggleFolderPin } = useFolderMutations();
   const { useTemplate } = useTemplateActions();
+
+  const pinnedFolderIds = useMemo(() => pinnedData?.pinnedIds || [], [pinnedData]);
+  const [localPinnedIds, setLocalPinnedIds] = useState<number[]>(pinnedFolderIds);
+
+  useEffect(() => {
+    setLocalPinnedIds(pinnedFolderIds);
+  }, [pinnedFolderIds]);
 
   const allFolders = useMemo(() => [...userFolders, ...organizationFolders], [userFolders, organizationFolders]);
   const { searchQuery, setSearchQuery, filteredFolders, clearSearch } = useFolderSearch(allFolders);
 
-  const handleTogglePin = useCallback(async (folderId: number, isPinned: boolean, type: 'user' | 'organization' | 'company') => {
-    try {
-      await toggleFolderPin.mutateAsync({ folderId, isPinned, type });
-      refetchPinned();
-    } catch (error) {
-      console.error('Error toggling pin:', error);
-    }
-  }, [toggleFolderPin, refetchPinned]);
+  const handleTogglePin = useCallback(
+    async (
+      folderId: number,
+      isPinned: boolean,
+      type: 'user' | 'organization' | 'company'
+    ) => {
+      // Optimistically update UI
+      setLocalPinnedIds(prev =>
+        isPinned ? prev.filter(id => id !== folderId) : [...prev, folderId]
+      );
 
-  // Add pinned status from user/organization folders
+      try {
+        await toggleFolderPin.mutateAsync({ folderId, isPinned, type });
+        refetchPinned();
+      } catch (error) {
+        console.error('Error toggling pin:', error);
+        // Revert on error
+        setLocalPinnedIds(prev =>
+          isPinned ? [...prev, folderId] : prev.filter(id => id !== folderId)
+        );
+      }
+    },
+    [toggleFolderPin, refetchPinned]
+  );
+
+  // Add pinned status based on localPinnedIds
   const foldersWithPin = useMemo(() => {
-    return filteredFolders.map(f => ({ ...f, is_pinned: !!f.is_pinned }));
-  }, [filteredFolders]);
+    return filteredFolders.map(f => ({
+      ...f,
+      is_pinned: localPinnedIds.includes(f.id)
+    }));
+  }, [filteredFolders, localPinnedIds]);
 
   if (!isOpen) return null;
 
@@ -72,11 +104,14 @@ export const BrowseMoreFoldersDialog: React.FC = () => {
                   type={folder.type as any}
                   enableNavigation={false}
                   onUseTemplate={useTemplate}
-                  onTogglePin={(id, pinned) => handleTogglePin(id, pinned, folder.type as any)}
+                  onTogglePin={(id, pinned) =>
+                    handleTogglePin(id, pinned, folder.type as any)
+                  }
                   organizations={organizations}
                   showPinControls={true}
                   showEditControls={false}
                   showDeleteControls={false}
+                  pinnedFolderIds={localPinnedIds}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Summary
- update BrowseMoreFoldersDialog to track pinned folders locally
- optimistically update pinned state when pinning/unpinning
- pass pinned IDs to FolderItem so pin button reflects current state

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6859620c620c8325b2d78426758e55de