### PR TITLE
Improve template search

### DIFF
--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -87,9 +87,19 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
   const templateMatchesQuery = useCallback(
     (template: Template, query: string) => {
       const q = query.toLowerCase();
+
+      // Handle string or object content
+      let content = '';
+      if (typeof template.content === 'string') {
+        content = template.content;
+      } else if (template.content && typeof template.content === 'object') {
+        content = Object.values(template.content).join(' ');
+      }
+
       return (
         template.title?.toLowerCase().includes(q) ||
-        template.description?.toLowerCase().includes(q)
+        template.description?.toLowerCase().includes(q) ||
+        content.toLowerCase().includes(q)
       );
     },
     []

--- a/src/hooks/prompts/utils/useFolderSearch.ts
+++ b/src/hooks/prompts/utils/useFolderSearch.ts
@@ -17,26 +17,35 @@ export function useFolderSearch(folders: TemplateFolder[] = []) {
   }, [searchQuery]);
   
   // Memoized function to check if a template matches search query
-  const templateMatchesQuery = useCallback((template: Template, query: string): boolean => {
-    const lowerQuery = query.toLowerCase();
-    
-    // Check template title
-    if (template.title?.toLowerCase().includes(lowerQuery)) {
-      return true;
-    }
-    
-    // Check template description
-    if (template.description?.toLowerCase().includes(lowerQuery)) {
-      return true;
-    }
-    
-    // Check template content (optional, can be expensive for large templates)
-    // if (template.content?.toLowerCase().includes(lowerQuery)) {
-    //   return true;
-    // }
-    
-    return false;
-  }, []);
+  const templateMatchesQuery = useCallback(
+    (template: Template, query: string): boolean => {
+      const lowerQuery = query.toLowerCase();
+
+      // Check template title
+      if (template.title?.toLowerCase().includes(lowerQuery)) {
+        return true;
+      }
+
+      // Check template description
+      if (template.description?.toLowerCase().includes(lowerQuery)) {
+        return true;
+      }
+
+      // Check template content
+      let content = '';
+      if (typeof template.content === 'string') {
+        content = template.content;
+      } else if (template.content && typeof template.content === 'object') {
+        content = Object.values(template.content).join(' ');
+      }
+      if (content.toLowerCase().includes(lowerQuery)) {
+        return true;
+      }
+
+      return false;
+    },
+    []
+  );
   
   // Memoized function to check if a folder or its contents match search query
   const folderMatchesQuery = useCallback((folder: TemplateFolder, query: string): boolean => {


### PR DESCRIPTION
## Summary
- include template content when filtering templates
- match content in template folder search helper

## Testing
- `npm run lint` *(fails: 520 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685966e7f20c83258fadbc397d4d15d3