### PR TITLE
Fix dialog stacking order

### DIFF
--- a/src/components/dialogs/DialogProvider.tsx
+++ b/src/components/dialogs/DialogProvider.tsx
@@ -61,7 +61,6 @@ export const DialogProvider: React.FC<{children: React.ReactNode}> = ({ children
       <CreateTemplateDialog />
       <CreateFolderDialog />
       <FolderManagerDialog />
-      <CustomizeTemplateDialog />
       <CreateBlockDialog />
       <InsertBlockDialog />
       <AuthDialog />
@@ -69,6 +68,8 @@ export const DialogProvider: React.FC<{children: React.ReactNode}> = ({ children
       <ConfirmationDialog />
       <EnhancedStatsDialog />
       <BrowseMoreFoldersDialog />
+      {/* Place the customize dialog last so it stacks above others */}
+      <CustomizeTemplateDialog />
     </DialogManagerProvider>
   );
 };

--- a/src/components/dialogs/index.tsx
+++ b/src/components/dialogs/index.tsx
@@ -42,12 +42,13 @@ export const DialogProvider: React.FC<{children: React.ReactNode}> = ({ children
       <CreateTemplateDialog />
       <CreateFolderDialog  />
       <FolderManagerDialog />
-      <CustomizeTemplateDialog />
       <AuthDialog />
       <SettingsDialog />
       <ConfirmationDialog />
       <EnhancedStatsDialog />
       <BrowseMoreFoldersDialog />
+      {/* Place the customize dialog last so it appears above others */}
+      <CustomizeTemplateDialog />
     </DialogManagerProvider>
   );
 };


### PR DESCRIPTION
## Summary
- ensure CustomizeTemplateDialog renders after BrowseMoreFoldersDialog so it stacks on top

## Testing
- `npm run lint` *(fails: 527 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68596f43ffa0832598a97cb266d0c3f2