### PR TITLE
Add AI tool grid to welcome pages

### DIFF
--- a/src/components/welcome/AIToolGrid.tsx
+++ b/src/components/welcome/AIToolGrid.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { AI_TOOLS } from '@/extension/popup/constants/ai-tools';
+import { ToolCard } from '@/extension/popup/components/ToolCard';
+import { openAiTool } from '@/components/utils/openAiTool';
+
+interface AIToolGridProps {
+  onToolClick?: () => void;
+}
+
+export const AIToolGrid: React.FC<AIToolGridProps> = ({ onToolClick }) => {
+  const handleOpen = (url: string, disabled: boolean) => {
+    if (disabled) return;
+    openAiTool(url);
+    onToolClick?.();
+  };
+
+  return (
+    <div className="jd-grid jd-grid-cols-1 sm:jd-grid-cols-2 md:jd-grid-cols-3 jd-gap-4 jd-max-w-3xl jd-mx-auto">
+      {AI_TOOLS.map((tool) => (
+        <ToolCard key={tool.name} tool={tool} onClick={() => handleOpen(tool.url, tool.disabled)} />
+      ))}
+    </div>
+  );
+};

--- a/src/components/welcome/LoggedInContent.tsx
+++ b/src/components/welcome/LoggedInContent.tsx
@@ -1,10 +1,9 @@
 // Logged in content for authenticated users
 import { getMessage } from '@/core/utils/i18n';
 import { Button } from '@/components/ui/button';
-import { ExternalLink } from 'lucide-react';
-import { openAiTool } from '@/components/utils/openAiTool';
 import { Sparkles } from 'lucide-react';
 import { FeatureGrid } from '@/components/welcome/FeatureGrid';
+import { AIToolGrid } from '@/components/welcome/AIToolGrid';
 
 interface LoggedInContentProps {
     user: any;
@@ -19,10 +18,6 @@ export const LoggedInContent: React.FC<LoggedInContentProps> = ({
     onShowOnboarding,
     onSignOut
   }) => {
-    // Handler for ChatGPT
-    const handleOpenChatGPT = () => openAiTool('https://chat.openai.com/');
-    // Handler for Claude
-    const handleOpenClaude = () => openAiTool('https://claude.ai/');
     return (
         <>
       <div className="jd-text-center jd-mb-12">
@@ -36,46 +31,11 @@ export const LoggedInContent: React.FC<LoggedInContentProps> = ({
               'You\'re logged in as {0}. You can now launch AI tools with enhanced capabilities.')}
           </p>
           
-          <div className="jd-flex jd-flex-col sm:jd-flex-row jd-gap-4 jd-justify-center">
-            {/* Show ChatGPT and Claude buttons if onboarding is not required */}
+          <div className="jd-flex jd-flex-col jd-items-center jd-gap-4">
             {!onboardingRequired ? (
-              <>
-                <Button 
-                  size="lg"
-                  onClick={handleOpenChatGPT}
-                  className="jd-gap-2 jd-bg-gradient-to-r jd-from-green-600 jd-to-emerald-600 hover:jd-from-green-500 hover:jd-to-emerald-500 jd-transition-all jd-duration-300 jd-py-6 jd-rounded-lg jd-relative jd-overflow-hidden jd-group jd-min-w-52 jd-font-heading"
-                >
-                  <div className="jd-absolute jd-inset-0 jd-w-full jd-h-full jd-bg-gradient-to-r jd-from-green-600/0 jd-via-green-400/10 jd-to-green-600/0 jd-transform jd-skew-x-12 jd-translate-x-full group-hover:jd-translate-x-full jd-transition-transform jd-duration-1000 jd-ease-out"></div>
-                  <span className="jd-flex jd-items-center jd-justify-center jd-text-lg">
-                    <img 
-                      src="https://vetoswvwgsebhxetqppa.supabase.co/storage/v1/object/public/images//chatgpt_logo.png" 
-                      alt="ChatGPT" 
-                      className="jd-h-6 jd-w-6 jd-mr-2" 
-                    />
-                    <span>{getMessage('openChatGPT', undefined, 'Open ChatGPT')}</span>
-                    <ExternalLink className="jd-w-4 jd-h-4 jd-ml-2" />
-                  </span>
-                </Button>
-                <Button 
-                  size="lg"
-                  onClick={handleOpenClaude}
-                  className="jd-gap-2 jd-bg-gradient-to-r jd-from-purple-600 jd-to-indigo-600 hover:jd-from-purple-500 hover:jd-to-indigo-500 jd-transition-all jd-duration-300 jd-py-6 jd-rounded-lg jd-relative jd-overflow-hidden jd-group jd-min-w-52 jd-font-heading"
-                >
-                  <div className="jd-absolute jd-inset-0 jd-w-full jd-h-full jd-bg-gradient-to-r jd-from-purple-600/0 jd-via-indigo-400/10 jd-to-indigo-600/0 jd-transform jd-skew-x-12 jd-translate-x-full group-hover:jd-translate-x-full jd-transition-transform jd-duration-1000 jd-ease-out"></div>
-                  <span className="jd-flex jd-items-center jd-justify-center jd-text-lg">
-                    <img 
-                      src="https://vetoswvwgsebhxetqppa.supabase.co/storage/v1/object/public/images//claude_logo.png" 
-                      alt="Claude" 
-                      className="jd-h-6 jd-w-6 jd-mr-2" 
-                    />
-                    <span>{getMessage('openClaude', undefined, 'Open Claude')}</span>
-                    <ExternalLink className="jd-w-4 jd-h-4 jd-ml-2" />
-                  </span>
-                </Button>
-              </>
+              <AIToolGrid />
             ) : (
-              // Always show Complete Setup button if onboarding is required
-              <Button 
+              <Button
                 size="lg"
                 onClick={onShowOnboarding}
                 className="jd-gap-2 jd-bg-blue-600 hover:jd-bg-blue-700 jd-transition-all jd-duration-300 jd-py-6 jd-rounded-lg jd-min-w-52 jd-font-heading"
@@ -85,8 +45,8 @@ export const LoggedInContent: React.FC<LoggedInContentProps> = ({
                 </span>
               </Button>
             )}
-            
-            <Button 
+
+            <Button
               variant="outline"
               onClick={onSignOut}
               className="jd-border-gray-700 jd-text-white hover:jd-bg-gray-800 jd-min-w-32 jd-font-heading"

--- a/src/components/welcome/onboarding/steps/CompletionStep.tsx
+++ b/src/components/welcome/onboarding/steps/CompletionStep.tsx
@@ -2,9 +2,10 @@
 import React, { useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
-import { CheckCircle2, ArrowRight, ExternalLink, Sparkles, Star } from 'lucide-react';
+import { CheckCircle2, Sparkles, Star } from 'lucide-react';
 import { getMessage } from '@/core/utils/i18n';
 import { trackEvent, EVENTS } from '@/utils/amplitude';
+import { AIToolGrid } from '@/components/welcome/AIToolGrid';
 
 interface CompletionStepProps {
   onComplete: () => void;
@@ -16,24 +17,13 @@ export const CompletionStep: React.FC<CompletionStepProps> = ({ onComplete }) =>
     trackEvent(EVENTS.ONBOARDING_COMPLETED);
   }, []);
 
-  // Handle button click
-  const handleGoToChatGPT = () => {
-    trackEvent(EVENTS.ONBOARDING_GOTO_CHATGPT);
-    
-    // Open ChatGPT in a new tab
-    window.open('https://chat.openai.com', '_blank');
-    
-    // Call the completion callback
-    onComplete();
-  };
-
-  const handleGoToClaude = () => {
-    trackEvent(EVENTS.ONBOARDING_COMPLETED);
-    
-    // Open Claude in a new tab
-    window.open('https://claude.ai', '_blank');
-    
-    // Call the completion callback
+  const handleOpenTool = (url: string, trackChatGPT = false) => {
+    if (trackChatGPT) {
+      trackEvent(EVENTS.ONBOARDING_GOTO_CHATGPT);
+    } else {
+      trackEvent(EVENTS.ONBOARDING_COMPLETED);
+    }
+    window.open(url, '_blank');
     onComplete();
   };
   
@@ -119,44 +109,23 @@ export const CompletionStep: React.FC<CompletionStepProps> = ({ onComplete }) =>
         </p>
       </motion.div>
       
-      <motion.div 
-        className="jd-pt-6 jd-flex jd-flex-col sm:jd-flex-row jd-gap-4"
+      <motion.div
+        className="jd-pt-6 jd-w-full"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 0.6 }}
       >
-        <Button 
-          onClick={handleGoToChatGPT} 
-          className="jd-bg-gradient-to-r jd-from-green-600 jd-to-emerald-600 hover:jd-from-green-500 hover:jd-to-emerald-500 jd-text-white jd-font-heading jd-py-6 jd-px-8 jd-gap-2 jd-shadow-lg hover:jd-shadow-green-500/25 jd-transition-all jd-duration-200"
-          size="lg"
-        >
-          <svg className="jd-h-5 jd-w-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM12 5C13.66 5 15 6.34 15 8C15 9.66 13.66 11 12 11C10.34 11 9 9.66 9 8C9 6.34 10.34 5 12 5ZM12 19.2C9.5 19.2 7.29 17.92 6 15.98C6.03 13.99 10 12.9 12 12.9C13.99 12.9 17.97 13.99 18 15.98C16.71 17.92 14.5 19.2 12 19.2Z" fill="white"/>
-          </svg>
-          {getMessage('goToChatGPT', undefined, 'Go to ChatGPT')}
-          <ExternalLink className="jd-h-5 jd-w-5" />
-        </Button>
-
-        <Button 
-          onClick={handleGoToClaude} 
-          className="jd-bg-gradient-to-r jd-from-green-600 jd-to-emerald-600 hover:jd-from-green-500 hover:jd-to-emerald-500 jd-text-white jd-font-heading jd-py-6 jd-px-8 jd-gap-2 jd-shadow-lg hover:jd-shadow-green-500/25 jd-transition-all jd-duration-200"
-          size="lg"
-        >
-          <svg className="jd-h-5 jd-w-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM12 5C13.66 5 15 6.34 15 8C15 9.66 13.66 11 12 11C10.34 11 9 9.66 9 8C9 6.34 10.34 5 12 5ZM12 19.2C9.5 19.2 7.29 17.92 6 15.98C6.03 13.99 10 12.9 12 12.9C13.99 12.9 17.97 13.99 18 15.98C16.71 17.92 14.5 19.2 12 19.2Z" fill="white"/>
-          </svg>
-          {getMessage('goToClaude', undefined, 'Go to Claude')}
-          <ExternalLink className="jd-h-5 jd-w-5" />
-        </Button>
-        
-        <Button 
-          onClick={onComplete} 
-          variant="outline"
-          className="jd-border-gray-700 jd-text-white hover:jd-bg-gray-800 jd-font-heading jd-transition-all jd-duration-200"
-          size="lg"
-        >
-          {getMessage('returnToHome', undefined, 'Return to Home')}
-        </Button>
+        <AIToolGrid onToolClick={onComplete} />
+        <div className="jd-flex jd-justify-center jd-mt-4">
+          <Button
+            onClick={onComplete}
+            variant="outline"
+            className="jd-border-gray-700 jd-text-white hover:jd-bg-gray-800 jd-font-heading jd-transition-all jd-duration-200"
+            size="lg"
+          >
+            {getMessage('returnToHome', undefined, 'Return to Home')}
+          </Button>
+        </div>
       </motion.div>
     </motion.div>
   );


### PR DESCRIPTION
## Summary
- show AI tool grid in welcome page and onboarding completion
- reuse popup logos with new `AIToolGrid` component

## Testing
- `npm run lint` *(fails: 534 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685a890d3b208325a2370824531825b9