### PR TITLE
Localize remaining welcome strings

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1386,6 +1386,22 @@
     "message": "Try Again",
     "description": "Button text for retrying an action"
   },
+  "initializationError": {
+    "message": "Initialization Error",
+    "description": "Title for initialization errors"
+  },
+  "failedToSaveOnboardingData": {
+    "message": "Failed to save onboarding data",
+    "description": "Error when onboarding data cannot be saved"
+  },
+  "onboardingError": {
+    "message": "An error occurred during onboarding",
+    "description": "Generic onboarding error message"
+  },
+  "pleaseSpecify": {
+    "message": "Please specify...",
+    "description": "Generic placeholder to specify other details"
+  },
   "edit_template": {
     "message": "Edit template",
     "description": "Edit template button text"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1361,6 +1361,22 @@
     "message": "Réessayer",
     "description": "Button text for retrying an action"
   },
+  "initializationError": {
+    "message": "Erreur d'initialisation",
+    "description": "Titre pour les erreurs d'initialisation"
+  },
+  "failedToSaveOnboardingData": {
+    "message": "Échec de l'enregistrement des données d'onboarding",
+    "description": "Erreur lorsque les données d'onboarding ne peuvent pas être enregistrées"
+  },
+  "onboardingError": {
+    "message": "Une erreur s'est produite lors de l'onboarding",
+    "description": "Message d'erreur générique pour l'onboarding"
+  },
+  "pleaseSpecify": {
+    "message": "Veuillez préciser...",
+    "description": "Placeholder générique pour préciser d'autres informations"
+  },
   "edit_template": {
     "message": "Modifier le template",
     "description": "Edit template button text"

--- a/src/components/welcome/ErrorDisplay.tsx
+++ b/src/components/welcome/ErrorDisplay.tsx
@@ -10,8 +10,8 @@ interface ErrorDisplayProps {
   onRetry?: () => void;
 }
 
-export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ 
-  title = 'Initialization Error',
+export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
+  title = getMessage('initializationError', undefined, 'Initialization Error'),
   message,
   onRetry
 }) => {

--- a/src/components/welcome/LoadingSpinner.tsx
+++ b/src/components/welcome/LoadingSpinner.tsx
@@ -7,8 +7,8 @@ interface LoadingSpinnerProps {
   devInfo?: string;
 }
 
-export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ 
-  message = 'Loading...', 
+export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
+  message = getMessage('loading'),
   devInfo
 }) => {
   return (

--- a/src/components/welcome/onboarding/OnboardingFlow.tsx
+++ b/src/components/welcome/onboarding/OnboardingFlow.tsx
@@ -141,16 +141,25 @@ export const OnboardingFlow: React.FC<OnboardingFlowProps> = ({
         // Move to completion step
         setCurrentStep(totalSteps - 1);
       } else {
-        throw new Error(result.message || 'Failed to save onboarding data');
+        throw new Error(
+          result.message ||
+            getMessage('failedToSaveOnboardingData', undefined, 'Failed to save onboarding data')
+        );
       }
     } catch (err) {
       console.error('Onboarding submission error:', err);
-      setError(err instanceof Error ? err.message : 'An error occurred during onboarding');
+      setError(
+        err instanceof Error
+          ? err.message
+          : getMessage('onboardingError', undefined, 'An error occurred during onboarding')
+      );
       
       // Track error event
       trackEvent(EVENTS.ONBOARDING_ERROR, {
         user_id: user?.id,
-        error: err instanceof Error ? err.message : 'Unknown error'
+        error: err instanceof Error
+          ? err.message
+          : getMessage('unknownError')
       });
     } finally {
       setIsSubmitting(false);

--- a/src/components/welcome/onboarding/OtherOptionInput.tsx
+++ b/src/components/welcome/onboarding/OtherOptionInput.tsx
@@ -12,7 +12,7 @@ interface OtherOptionInputProps {
 export const OtherOptionInput: React.FC<OtherOptionInputProps> = ({
   value,
   onChange,
-  placeholder = 'Please specify...'
+  placeholder = getMessage('pleaseSpecify', undefined, 'Please specify...')
 }) => {
   return (
     <motion.div 


### PR DESCRIPTION
## Summary
- add translation strings for onboarding errors and placeholders
- default loading spinner and error display messages use i18n
- use i18n keys for onboarding error handling

## Testing
- `npm run lint` *(fails: 534 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685a89688bf48325a625d7283f4787c9