### PR TITLE
Fix folder description tooltip

### DIFF
--- a/src/components/prompts/folders/FolderItem.tsx
+++ b/src/components/prompts/folders/FolderItem.tsx
@@ -262,26 +262,20 @@ export const FolderItem: React.FC<FolderItemProps> = ({
         {/* Folder Name */}
         <div className="jd-flex-1 jd-min-w-0">
           {folder.description ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className="jd-text-sm jd-truncate jd-block"
-                  title={folder.title}
-                >
-                  {folder.title}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="jd-max-w-xs jd-z-50">
-                <p>{folder.description}</p>
-              </TooltipContent>
-            </Tooltip>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="jd-text-sm jd-truncate jd-block">
+                    {folder.title}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="jd-max-w-xs jd-z-50">
+                  <p>{folder.description}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           ) : (
-            <span
-              className="jd-text-sm jd-truncate jd-block"
-              title={folder.title}
-            >
-              {folder.title}
-            </span>
+            <span className="jd-text-sm jd-truncate jd-block">{folder.title}</span>
           )}
         </div>
 


### PR DESCRIPTION
## Summary
- fix folder description tooltip style in FolderItem

## Testing
- `npm run lint` *(fails: 531 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685bab4a40b88325a54567847feea226