### PR TITLE
Fix advanced editor button overlap

### DIFF
--- a/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
@@ -202,7 +202,7 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
             )}
           </div>
 
-          <div className="jd-sticky jd-bottom-0 jd-flex jd-justify-end jd-gap-2 jd-p-4 jd-border-t jd-bg-background">
+          <div className="jd-sticky jd-bottom-0 jd-z-20 jd-flex jd-justify-end jd-gap-2 jd-p-4 jd-border-t jd-bg-background">
             <Button variant="outline" onClick={handleClose} disabled={isSubmitting}>
               {getMessage('cancel', undefined, 'Cancel')}
             </Button>


### PR DESCRIPTION
## Summary
- ensure the action buttons are clickable by raising their z-index

## Testing
- `npm run lint` *(fails: 506 errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_685bc22adfb08325a861eacd57c11570