### PR TITLE
Fix create block dialog stacking order

### DIFF
--- a/src/components/prompts/blocks/quick-selector/QuickBlockSelector.tsx
+++ b/src/components/prompts/blocks/quick-selector/QuickBlockSelector.tsx
@@ -158,7 +158,7 @@ export const QuickBlockSelector: React.FC<QuickBlockSelectorProps> = ({
     <div
       ref={containerRef}
       className={cn(
-        'jd-fixed jd-z-[2147483647] jd-w-[400px] jd-h-[480px]',
+        'jd-fixed jd-z-[10000] jd-w-[400px] jd-h-[480px]',
         'jd-bg-background jd-border jd-rounded-lg jd-shadow-xl',
         'jd-flex jd-flex-col jd-animate-in jd-fade-in jd-slide-in-from-bottom-2',
         isDark ? 'jd-border-gray-700' : 'jd-border-gray-200'
@@ -176,8 +176,8 @@ export const QuickBlockSelector: React.FC<QuickBlockSelectorProps> = ({
         margin: 0,
         padding: 0,
         boxSizing: 'border-box',
-        // Ensure it's above everything
-        zIndex: 2147483647,
+        // Ensure it's above page content but below dialogs
+        zIndex: 10000,
         position: 'fixed'
       }}
     >

--- a/src/extension/content/content.css
+++ b/src/extension/content/content.css
@@ -219,9 +219,9 @@
   animation-name: jd-fadeIn, jd-slideInFromBottom;
 }
 
-/* Ensure the quick selector is above all other elements */
+/* Ensure the quick selector appears above page content but below dialogs */
 #jaydai-quick-selector {
-  z-index: 2147483647; /* Maximum z-index */
+  z-index: 10000;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- ensure quick block selector has lower z-index than dialogs

## Testing
- `npm run lint` *(fails: 531 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685bc94726c88325a093f1cf5cc08830