### PR TITLE
Fix placeholders not applied when inserting templates

### DIFF
--- a/src/components/dialogs/prompts/editors/BasicEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/BasicEditor/index.tsx
@@ -1,5 +1,5 @@
 // src/components/dialogs/prompts/editors/BasicEditor/index.tsx - Simplified Version
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -37,9 +37,13 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
     setContent,
     blockContentCache
   } = useTemplateEditor();
-  
+
   const isDark = useThemeDetector();
   const [showPreview, setShowPreview] = useState(mode === 'customize');
+
+  // Keep a reference to the original content so placeholder replacements do not
+  // accumulate when editing values in the placeholder panel
+  const originalContentRef = useRef(content);
   
   // Utility to gather placeholder keys from content and metadata blocks
   const getPlaceholderKeys = useCallback((): string[] => {
@@ -58,6 +62,7 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
     return [];
   });
 
+
   // Update placeholders when relevant data changes (for customize mode)
   React.useEffect(() => {
     if (mode === 'customize') {
@@ -71,17 +76,30 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
     }
   }, [getPlaceholderKeys, mode]);
 
-  // Simple content with placeholders replaced for preview
-  const previewContent = React.useMemo(() => {
-    let result = content;
-    placeholders.forEach(({ key, value }) => {
-      if (value.trim()) {
-        // Remove the brackets and replace with value
-        result = result.replace(new RegExp(key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), value);
-      }
-    });
-    return result;
-  }, [content, placeholders]);
+  // Build content with placeholders replaced based on the original content
+  const computeContent = useCallback(
+    (list: Placeholder[]) => {
+      let result = originalContentRef.current;
+      list.forEach(({ key, value }) => {
+        if (value.trim()) {
+          const regex = new RegExp(key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+          result = result.replace(regex, value);
+        }
+      });
+      return result;
+    },
+    []
+  );
+
+  const previewContent = React.useMemo(() => computeContent(placeholders), [computeContent, placeholders]);
+
+  // Sync the computed content back to the editor state so it is used when
+  // the user completes the dialog
+  useEffect(() => {
+    if (mode === 'customize') {
+      setContent(previewContent);
+    }
+  }, [previewContent, setContent, mode]);
 
   const updatePlaceholder = useCallback((index: number, value: string) => {
     setPlaceholders(prev => {


### PR DESCRIPTION
## Summary
- ensure BasicEditor replaces placeholders in template content
- sync replaced content back to dialog state so insertions use it

## Testing
- `npm run lint` *(fails: Unable to reach registry)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685bf690ce848325ba1953f30370cdc7