### PR TITLE
Improve folder selection UX

### DIFF
--- a/src/components/dialogs/prompts/CreateFolderDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateFolderDialog/index.tsx
@@ -47,9 +47,6 @@ export const CreateFolderDialog: React.FC = () => {
   const onFolderCreated = data?.onFolderCreated;
 
   const handleParentSelect = useCallback((folder: TemplateFolder | null, path: string) => {
-    console.log("handleParentSelect--------------------------->");
-    console.log("folder--->", folder);
-    console.log("path--->", path);
     setParentId(folder?.id ?? null);
     setParentPath(path || 'Root');
   }, []);
@@ -189,7 +186,7 @@ export const CreateFolderDialog: React.FC = () => {
               folders={userFolders as TemplateFolder[]}
               onSelect={handleParentSelect}
             />
-            <p className="jd-text-xs jd-text-muted-foreground jd-mt-1">{parentPath}</p>
+            <p className="jd-text-xs jd-text-muted-foreground jd-mt-1">Selected: {parentPath}</p>
           </div>
           
           <div className="jd-flex jd-justify-end jd-space-x-2 jd-pt-4">

--- a/src/components/prompts/folders/FolderNavigation.tsx
+++ b/src/components/prompts/folders/FolderNavigation.tsx
@@ -1,6 +1,6 @@
 // src/components/prompts/folders/FolderNavigation.tsx
 import React from 'react';
-import { FolderOpen, ArrowLeft, Home, ChevronRight } from 'lucide-react';
+import { ArrowLeft, Home, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 interface FolderPath {
@@ -26,17 +26,14 @@ export function FolderNavigation({
   onNavigateToPath,
   className = ''
 }: FolderNavigationProps) {
-  if (path.length === 0) {
-    return null;
-  }
 
   return (
     <div className={`jd-flex jd-items-center jd-gap-1 jd-px-2 jd-py-2 jd-mb-2 jd-bg-accent/20 jd-rounded-md jd-text-xs ${className}`}>
       {/* Home button */}
-      <Button 
-        variant="ghost" 
-        size="sm" 
-        onClick={onNavigateToRoot} 
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onNavigateToRoot}
         className="jd-h-6 jd-px-2 jd-text-muted-foreground hover:jd-text-foreground"
         title="Go to root"
       >
@@ -45,14 +42,24 @@ export function FolderNavigation({
 
       {/* Breadcrumb trail */}
       <div className="jd-flex jd-items-center jd-gap-1 jd-flex-1 jd-min-w-0">
+        <button
+          onClick={onNavigateToRoot}
+          className={`jd-truncate jd-text-left jd-hover:jd-text-foreground jd-transition-colors ${
+            path.length === 0
+              ? 'jd-text-foreground jd-font-medium'
+              : 'jd-text-muted-foreground jd-hover:jd-underline'
+          }`}
+        >
+          Root
+        </button>
         {path.map((folder, index) => (
           <React.Fragment key={folder.id}>
             <ChevronRight className="jd-h-3 jd-w-3 jd-text-muted-foreground jd-flex-shrink-0" />
             <button
               onClick={() => onNavigateToPath(index)}
               className={`jd-truncate jd-text-left jd-hover:jd-text-foreground jd-transition-colors ${
-                index === path.length - 1 
-                  ? 'jd-text-foreground jd-font-medium' 
+                index === path.length - 1
+                  ? 'jd-text-foreground jd-font-medium'
                   : 'jd-text-muted-foreground jd-hover:jd-underline'
               }`}
               title={folder.title}
@@ -64,15 +71,17 @@ export function FolderNavigation({
       </div>
 
       {/* Back button */}
-      <Button 
-        variant="ghost" 
-        size="sm" 
-        onClick={onNavigateBack} 
-        className="jd-h-6 jd-px-2 jd-text-muted-foreground hover:jd-text-foreground jd-flex-shrink-0"
-        title="Go back"
-      >
-        <ArrowLeft className="jd-h-3 jd-w-3" />
-      </Button>
+      {path.length > 0 && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onNavigateBack}
+          className="jd-h-6 jd-px-2 jd-text-muted-foreground hover:jd-text-foreground jd-flex-shrink-0"
+          title="Go back"
+        >
+          <ArrowLeft className="jd-h-3 jd-w-3" />
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/components/prompts/folders/FolderPicker.tsx
+++ b/src/components/prompts/folders/FolderPicker.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { FolderOpen, ChevronRight } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import { FolderNavigation } from './FolderNavigation';
 import { TemplateFolder } from '@/types/prompts/templates';
 
@@ -17,7 +16,6 @@ type NavState = {
 
 export const FolderPicker: React.FC<FolderPickerProps> = ({ folders, onSelect, className = '' }) => {
   const [nav, setNav] = useState<NavState>({ path: [], currentFolder: null });
-  console.log("FOLDERS--->", folders);
 
   const findFolderById = useCallback((list: TemplateFolder[], id?: number): TemplateFolder | null => {
     for (const f of list) {
@@ -70,10 +68,6 @@ export const FolderPicker: React.FC<FolderPickerProps> = ({ folders, onSelect, c
     return nav.currentFolder ? nav.currentFolder.Folders || [] : folders;
   }, [nav.currentFolder, folders]);
 
-  const handleSelect = useCallback(() => {
-    const path = nav.path.map(p => p.title).join(' / ');
-    onSelect(nav.currentFolder, path);
-  }, [nav.path, nav.currentFolder, onSelect]);
 
   return (
     <div className={`jd-space-y-2 ${className}`}>
@@ -98,11 +92,6 @@ export const FolderPicker: React.FC<FolderPickerProps> = ({ folders, onSelect, c
         {currentFolders.length === 0 && (
           <div className="jd-text-xs jd-text-muted-foreground jd-p-2">No subfolders</div>
         )}
-      </div>
-      <div className="jd-flex jd-justify-end">
-        <Button type="button" size="sm" variant="secondary" onClick={handleSelect}>
-          {nav.currentFolder ? `Select "${nav.currentFolder.title}"` : 'Select Root'}
-        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- clean up debug logs and simplify folder picker
- show breadcrumb path even at root and make path clickable
- display currently selected parent folder in create dialog

## Testing
- `npm run type-check`
- `npm run lint` *(fails: 533 problems)*

------
https://chatgpt.com/codex/tasks/task_b_685c13ec25c88325b5745d8e19d6140a