### PR TITLE
Align pin buttons to left

### DIFF
--- a/src/components/prompts/folders/FolderItem.tsx
+++ b/src/components/prompts/folders/FolderItem.tsx
@@ -1,20 +1,35 @@
 // src/components/prompts/folders/FolderItem.tsx - Enhanced to pass organization context to templates
-import React, { useState, useCallback, useMemo } from 'react';
-import { FolderOpen, ChevronRight, ChevronDown, Edit, Trash2, PlusCircle, Plus, ArrowLeft, Home } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { PinButton } from '@/components/prompts/common/PinButton';
-import { OrganizationImage } from '@/components/organizations';
-import { TemplateFolder, Template } from '@/types/prompts/templates';
-import { Organization } from '@/types/organizations';
-import { TemplateItem } from '@/components/prompts/templates/TemplateItem';
-import { EmptyMessage } from '@/components/panels/TemplatesPanel/EmptyMessage';
-import { getMessage } from '@/core/utils/i18n';
+import React, { useState, useCallback, useMemo } from "react";
+import {
+  FolderOpen,
+  ChevronRight,
+  ChevronDown,
+  Edit,
+  Trash2,
+  PlusCircle,
+  Plus,
+  ArrowLeft,
+  Home,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { PinButton } from "@/components/prompts/common/PinButton";
+import { OrganizationImage } from "@/components/organizations";
+import { TemplateFolder, Template } from "@/types/prompts/templates";
+import { Organization } from "@/types/organizations";
+import { TemplateItem } from "@/components/prompts/templates/TemplateItem";
+import { EmptyMessage } from "@/components/panels/TemplatesPanel/EmptyMessage";
+import { getMessage } from "@/core/utils/i18n";
 
 const folderIconColors = {
-  user: 'jd-text-gray-600',
-  company: 'jd-text-red-500',
-  organization: 'jd-text-orange-500'
+  user: "jd-text-gray-600",
+  company: "jd-text-red-500",
+  organization: "jd-text-orange-500",
 } as const;
 
 interface NavigationPath {
@@ -24,12 +39,16 @@ interface NavigationPath {
 
 interface FolderItemProps {
   folder: TemplateFolder;
-  type: 'user' | 'company' | 'organization';
+  type: "user" | "company" | "organization";
   level?: number;
   isExpanded?: boolean;
   onToggleExpand?: (folderId: number) => void;
   onNavigateToFolder?: (folder: TemplateFolder) => void;
-  onTogglePin?: (folderId: number, isPinned: boolean, type: 'user' | 'company' | 'organization') => void;
+  onTogglePin?: (
+    folderId: number,
+    isPinned: boolean,
+    type: "user" | "company" | "organization",
+  ) => void;
   onEditFolder?: (folder: TemplateFolder) => void;
   onDeleteFolder?: (folderId: number) => void;
   onUseTemplate?: (template: any) => void;
@@ -40,7 +59,7 @@ interface FolderItemProps {
   showEditControls?: boolean;
   showDeleteControls?: boolean;
   enableNavigation?: boolean;
-  
+
   // Navigation props
   navigationPath?: NavigationPath[];
   onNavigateBack?: () => void;
@@ -49,7 +68,7 @@ interface FolderItemProps {
   onCreateTemplate?: () => void;
   onCreateFolder?: () => void;
   showNavigationHeader?: boolean;
-  
+
   // Pinned folder IDs for proper pin state calculation
   pinnedFolderIds?: number[];
 }
@@ -75,7 +94,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
   showEditControls = false,
   showDeleteControls = false,
   enableNavigation = false,
-  
+
   // Navigation props
   navigationPath = [],
   onNavigateBack,
@@ -84,16 +103,18 @@ export const FolderItem: React.FC<FolderItemProps> = ({
   onCreateTemplate,
   onCreateFolder,
   showNavigationHeader = false,
-  
+
   // Pinned folder IDs
-  pinnedFolderIds = []
+  pinnedFolderIds = [],
 }) => {
   // Local expansion state for when no external control is provided
   const [localExpanded, setLocalExpanded] = useState(false);
   const expanded = onToggleExpand ? isExpanded : localExpanded;
 
   // Get organization data for display
-  const organization = organizations?.find(org => org.id === folder.organization_id) || folder.organization;
+  const organization =
+    organizations?.find((org) => org.id === folder.organization_id) ||
+    folder.organization;
 
   // Calculate folder contents
   const subfolders = folder.Folders || [];
@@ -108,7 +129,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
 
   // Determine if this folder shows organization image
   const folderShowsOrgImage = useMemo(() => {
-    return type === 'organization' && level === 0 && organization?.image_url;
+    return type === "organization" && level === 0 && organization?.image_url;
   }, [type, level, organization?.image_url]);
 
   // Handle folder click
@@ -120,32 +141,46 @@ export const FolderItem: React.FC<FolderItemProps> = ({
     } else {
       setLocalExpanded(!localExpanded);
     }
-  }, [enableNavigation, onNavigateToFolder, onToggleExpand, folder.id, localExpanded]);
+  }, [
+    enableNavigation,
+    onNavigateToFolder,
+    onToggleExpand,
+    folder.id,
+    localExpanded,
+  ]);
 
   // Handle pin toggle with proper state
-  const handleTogglePin = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (onTogglePin) {
-      onTogglePin(folder.id, isPinned, type);
-    }
-  }, [onTogglePin, folder.id, isPinned, type]);
+  const handleTogglePin = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (onTogglePin) {
+        onTogglePin(folder.id, isPinned, type);
+      }
+    },
+    [onTogglePin, folder.id, isPinned, type],
+  );
 
   // Handle edit folder
-  const handleEditFolder = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (onEditFolder) {
-      onEditFolder(folder);
-    }
-  }, [onEditFolder, folder]);
+  const handleEditFolder = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (onEditFolder) {
+        onEditFolder(folder);
+      }
+    },
+    [onEditFolder, folder],
+  );
 
   // Handle delete folder
-  const handleDeleteFolder = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (onDeleteFolder) {
-      onDeleteFolder(folder.id);
-    }
-  }, [onDeleteFolder, folder.id]);
-
+  const handleDeleteFolder = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (onDeleteFolder) {
+        onDeleteFolder(folder.id);
+      }
+    },
+    [onDeleteFolder, folder.id],
+  );
 
   return (
     <div className="jd-folder-container">
@@ -155,7 +190,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
           <div className="jd-flex jd-items-center jd-justify-between jd-text-sm jd-font-medium jd-text-muted-foreground jd-mb-2">
             <div className="jd-flex jd-items-center">
               <FolderOpen className="jd-mr-2 jd-h-4 jd-w-4" />
-              {isAtRoot ? 'My Templates' : folder.title}
+              {isAtRoot ? "My Templates" : folder.title}
             </div>
             <div className="jd-flex jd-items-center jd-gap-1">
               {onCreateTemplate && (
@@ -163,7 +198,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
                   variant="secondary"
                   size="sm"
                   onClick={onCreateTemplate}
-                  title={getMessage('newTemplate', undefined, 'New Template')}
+                  title={getMessage("newTemplate", undefined, "New Template")}
                 >
                   <PlusCircle className="jd-h-4 jd-w-4" />
                 </Button>
@@ -173,7 +208,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
                   variant="secondary"
                   size="sm"
                   onClick={onCreateFolder}
-                  title={getMessage('newFolder', undefined, 'New Folder')}
+                  title={getMessage("newFolder", undefined, "New Folder")}
                 >
                   <Plus className="jd-h-4 jd-w-4" />
                 </Button>
@@ -185,17 +220,17 @@ export const FolderItem: React.FC<FolderItemProps> = ({
           {!isAtRoot && (
             <div className="jd-flex jd-items-center jd-gap-1 jd-px-2 jd-py-2 jd-mb-2 jd-bg-accent/20 jd-rounded-md jd-text-xs">
               {onNavigateToRoot && (
-                <Button 
-                  variant="ghost" 
-                  size="sm" 
-                  onClick={onNavigateToRoot} 
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={onNavigateToRoot}
                   className="jd-h-6 jd-px-2 jd-text-muted-foreground hover:jd-text-foreground"
                   title="Go to root"
                 >
                   <Home className="jd-h-4 jd-w-4" />
                 </Button>
               )}
-              
+
               <div className="jd-flex jd-items-center jd-gap-1 jd-flex-1 jd-min-w-0">
                 {navigationPath.map((pathFolder, index) => (
                   <React.Fragment key={pathFolder.id}>
@@ -203,9 +238,9 @@ export const FolderItem: React.FC<FolderItemProps> = ({
                     <button
                       onClick={() => onNavigateToPathIndex?.(index)}
                       className={`jd-truncate jd-font-medium jd-text-left jd-hover:jd-text-foreground jd-transition-colors ${
-                        index === navigationPath.length - 1 
-                          ? 'jd-text-foreground jd-font-medium' 
-                          : 'jd-text-muted-foreground jd-hover:jd-underline'
+                        index === navigationPath.length - 1
+                          ? "jd-text-foreground jd-font-medium"
+                          : "jd-text-muted-foreground jd-hover:jd-underline"
                       }`}
                       title={pathFolder.title}
                     >
@@ -216,10 +251,10 @@ export const FolderItem: React.FC<FolderItemProps> = ({
               </div>
 
               {onNavigateBack && (
-                <Button 
-                  variant="ghost" 
-                  size="sm" 
-                  onClick={onNavigateBack} 
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={onNavigateBack}
                   className="jd-h-6 jd-px-2 jd-text-muted-foreground hover:jd-text-foreground jd-flex-shrink-0"
                   title="Go back"
                 >
@@ -232,20 +267,35 @@ export const FolderItem: React.FC<FolderItemProps> = ({
       )}
 
       {/* Folder Header */}
-      <div 
+      <div
         className="jd-group jd-flex jd-items-center hover:jd-bg-accent/60 jd-cursor-pointer jd-rounded-sm jd-transition-colors"
         onClick={handleFolderClick}
         style={{ paddingLeft: `${level * 16 + 8}px` }}
       >
+        {showPinControls && (
+          <div className="jd-mr-2 jd-flex-shrink-0">
+            <PinButton
+              isPinned={isPinned}
+              onClick={handleTogglePin}
+              className={
+                isPinned
+                  ? ""
+                  : "jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity"
+              }
+            />
+          </div>
+        )}
         {/* Expansion/Navigation Icon */}
         {enableNavigation ? (
           <div className="jd-h-4 jd-flex-shrink-0" />
         ) : totalItems > 0 ? (
-          expanded ? 
-            <ChevronDown className="jd-h-4 jd-w-4 jd-mr-1 jd-flex-shrink-0" /> : 
+          expanded ? (
+            <ChevronDown className="jd-h-4 jd-w-4 jd-mr-1 jd-flex-shrink-0" />
+          ) : (
             <ChevronRight className="jd-h-4 jd-w-4 jd-mr-1 jd-flex-shrink-0" />
+          )
         ) : (
-          <div/>
+          <div />
         )}
 
         {/* Organization Image (for organization folders) */}
@@ -257,7 +307,9 @@ export const FolderItem: React.FC<FolderItemProps> = ({
             className="jd-mr-2"
           />
         ) : (
-          <FolderOpen className={`jd-h-4 jd-w-4 jd-mr-2 jd-flex-shrink-0 ${folderIconColors[type]}`} />
+          <FolderOpen
+            className={`jd-h-4 jd-w-4 jd-mr-2 jd-flex-shrink-0 ${folderIconColors[type]}`}
+          />
         )}
 
         {/* Folder Name */}
@@ -276,76 +328,57 @@ export const FolderItem: React.FC<FolderItemProps> = ({
               </Tooltip>
             </TooltipProvider>
           ) : (
-            <span className="jd-text-sm jd-truncate jd-block jd-font-medium">{folder.title}</span>
+            <span className="jd-text-sm jd-truncate jd-block jd-font-medium">
+              {folder.title}
+            </span>
           )}
         </div>
 
         {/* Action Buttons */}
-        {(type === 'user' && (showEditControls || showDeleteControls || showPinControls)) && (
-          <div className="jd-flex jd-gap-1 jd-items-center jd-gap-2 jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity jd-duration-200">
-            {/* Edit Button */}
-            {showEditControls && onEditFolder && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button 
-                      variant="ghost" 
-                      size="xs" 
-                      onClick={handleEditFolder} 
-                    >
-                      <Edit className="jd-h-4 jd-w-4 jd-text-blue-600 hover:jd-text-blue-700 hover:jd-bg-blue-100 jd-dark:jd-text-blue-400 jd-dark:hover:jd-text-blue-300 jd-dark:hover:jd-bg-blue-900/30" />
+        {type === "user" &&
+          (showEditControls || showDeleteControls || showPinControls) && (
+            <div className="jd-flex jd-gap-1 jd-items-center jd-gap-2 jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity jd-duration-200">
+              {/* Edit Button */}
+              {showEditControls && onEditFolder && (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        onClick={handleEditFolder}
+                      >
+                        <Edit className="jd-h-4 jd-w-4 jd-text-blue-600 hover:jd-text-blue-700 hover:jd-bg-blue-100 jd-dark:jd-text-blue-400 jd-dark:hover:jd-text-blue-300 jd-dark:hover:jd-bg-blue-900/30" />
                       </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    <p>Edit folder</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-            
-            {/* Delete Button */}
-            {showDeleteControls && onDeleteFolder && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button 
-                      variant="ghost" 
-                      size="xs" 
-                      onClick={handleDeleteFolder}
-                    >
-                      <Trash2 className="jd-h-4 jd-w-4 jd-text-red-500 hover:jd-text-red-600 hover:jd-bg-red-100 jd-dark:hover:jd-bg-red-900/30" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    <p>Delete folder</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      <p>Edit folder</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              )}
 
-
-        {showPinControls && onTogglePin && !isPinned && (
-            <div className={`jd-ml-auto  jd-items-center jd-gap-2 ${isPinned ? 'jd-flex' : 'jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity'}`}>
-              <PinButton
-                isPinned={isPinned}
-                onClick={handleTogglePin}
-                className=""
-              />
+              {/* Delete Button */}
+              {showDeleteControls && onDeleteFolder && (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        onClick={handleDeleteFolder}
+                      >
+                        <Trash2 className="jd-h-4 jd-w-4 jd-text-red-500 hover:jd-text-red-600 hover:jd-bg-red-100 jd-dark:hover:jd-bg-red-900/30" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      <p>Delete folder</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              )}
             </div>
           )}
-          </div>
-        )}
-        <div className="jd-ml-2 jd-flex jd-items-center jd-gap-1">
-          {/* Pin Button */}
-          {showPinControls && onTogglePin && isPinned && (
-            <div className={`jd-ml-auto  jd-items-center jd-gap-1 jd-flex`}>
-              <PinButton
-                isPinned={isPinned}
-                onClick={handleTogglePin}
-              />
-            </div>
-          )}
-        </div>
       </div>
 
       {/* Folder Contents */}
@@ -386,8 +419,8 @@ export const FolderItem: React.FC<FolderItemProps> = ({
               onEditTemplate={onEditTemplate}
               onDeleteTemplate={onDeleteTemplate}
               onTogglePin={onTogglePin}
-              showEditControls={type === 'user'}
-              showDeleteControls={type === 'user'}
+              showEditControls={type === "user"}
+              showDeleteControls={type === "user"}
               showPinControls={showPinControls}
               organizations={organizations}
               parentFolderHasOrgImage={folderShowsOrgImage} // Pass context!
@@ -402,10 +435,13 @@ export const FolderItem: React.FC<FolderItemProps> = ({
         <div className="jd-space-y-1 jd-px-2 jd-max-h-96 jd-overflow-y-auto">
           {totalItems === 0 ? (
             <EmptyMessage>
-              {isAtRoot 
-                ? getMessage('noTemplates', undefined, 'No templates yet. Create your first template!')
-                : 'This folder is empty'
-              }
+              {isAtRoot
+                ? getMessage(
+                    "noTemplates",
+                    undefined,
+                    "No templates yet. Create your first template!",
+                  )
+                : "This folder is empty"}
             </EmptyMessage>
           ) : (
             <>
@@ -438,8 +474,8 @@ export const FolderItem: React.FC<FolderItemProps> = ({
                   onEditTemplate={onEditTemplate}
                   onDeleteTemplate={onDeleteTemplate}
                   onTogglePin={onTogglePin}
-                  showEditControls={type === 'user'}
-                  showDeleteControls={type === 'user'}
+                  showEditControls={type === "user"}
+                  showDeleteControls={type === "user"}
                   showPinControls={showPinControls}
                   organizations={organizations}
                   parentFolderHasOrgImage={folderShowsOrgImage} // Pass context!

--- a/src/components/prompts/templates/TemplateItem.tsx
+++ b/src/components/prompts/templates/TemplateItem.tsx
@@ -1,28 +1,37 @@
 // src/components/prompts/templates/TemplateItem.tsx - Enhanced with smart organization image logic
-import React, { useCallback, useMemo } from 'react';
-import { FileText, Edit, Trash2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { PinButton } from '@/components/prompts/common/PinButton';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { OrganizationImage } from '@/components/organizations';
-import { Template } from '@/types/prompts/templates';
-import { getMessage } from '@/core/utils/i18n';
-import { usePinnedTemplates } from '@/hooks/prompts';
+import React, { useCallback, useMemo } from "react";
+import { FileText, Edit, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { PinButton } from "@/components/prompts/common/PinButton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { OrganizationImage } from "@/components/organizations";
+import { Template } from "@/types/prompts/templates";
+import { getMessage } from "@/core/utils/i18n";
+import { usePinnedTemplates } from "@/hooks/prompts";
 
 const iconColorMap = {
-  user: 'jd-text-gray-600',
-  company: 'jd-text-red-500',
-  organization: 'jd-text-orange-500'
+  user: "jd-text-gray-600",
+  company: "jd-text-red-500",
+  organization: "jd-text-orange-500",
 } as const;
 
 interface TemplateItemProps {
   template: Template;
-  type: 'user' | 'company' | 'organization';
+  type: "user" | "company" | "organization";
   level?: number;
   onUseTemplate?: (template: Template) => void;
   onEditTemplate?: (template: Template) => void;
   onDeleteTemplate?: (templateId: number) => void;
-  onTogglePin?: (templateId: number, isPinned: boolean, type: 'user' | 'company' | 'organization') => void;
+  onTogglePin?: (
+    templateId: number,
+    isPinned: boolean,
+    type: "user" | "company" | "organization",
+  ) => void;
   showEditControls?: boolean;
   showDeleteControls?: boolean;
   showPinControls?: boolean;
@@ -49,91 +58,120 @@ export const TemplateItem: React.FC<TemplateItemProps> = ({
   showDeleteControls = true,
   showPinControls = false,
   isProcessing = false,
-  className = '',
+  className = "",
   organizations = [],
   parentFolderHasOrgImage = false,
-  isInGlobalSearch = false
+  isInGlobalSearch = false,
 }) => {
   // Ensure we have a display name
-  const displayName = template.title || 'Untitled Template';
+  const displayName = template.title || "Untitled Template";
 
   const { data: pinnedTemplateIds = [] } = usePinnedTemplates();
 
   const isPinned = useMemo(() => {
-    if (typeof (template as any).is_pinned === 'boolean') {
+    if (typeof (template as any).is_pinned === "boolean") {
       return (template as any).is_pinned;
     }
     return pinnedTemplateIds.includes(template.id);
   }, [pinnedTemplateIds, template.id, (template as any).is_pinned]);
-  
+
   // Get organization data
-  const templateOrganization = (template as any).organization || 
-    organizations.find(org => org.id === (template as any).organization_id);
-  
+  const templateOrganization =
+    (template as any).organization ||
+    organizations.find((org) => org.id === (template as any).organization_id);
+
   // Smart logic for showing organization image
   const shouldShowOrgImage = useMemo(() => {
     // Only show for organization templates
-    if (type !== 'organization') return false;
-    
+    if (type !== "organization") return false;
+
     // Don't show if template doesn't have organization data
     if (!templateOrganization?.image_url) return false;
-    
+
     // Always show in global search results (since context is unclear)
     if (isInGlobalSearch) return true;
-    
+
     // Don't show if parent folder already displays the organization image
     if (parentFolderHasOrgImage) return false;
-    
+
     // Show if this is a top-level template (level 0) or if we're not in a nested context
     return level === 0 || !parentFolderHasOrgImage;
-  }, [type, templateOrganization, isInGlobalSearch, parentFolderHasOrgImage, level]);
-  
+  }, [
+    type,
+    templateOrganization,
+    isInGlobalSearch,
+    parentFolderHasOrgImage,
+    level,
+  ]);
+
   // Handle template click to use it
   const handleTemplateClick = useCallback(() => {
     if (onUseTemplate && !isProcessing) {
       onUseTemplate(template);
     }
   }, [onUseTemplate, template, isProcessing]);
-  
+
   // Handle edit click
-  const handleEditClick = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (onEditTemplate) {
-      onEditTemplate(template);
-    }
-  }, [onEditTemplate, template]);
-  
+  const handleEditClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (onEditTemplate) {
+        onEditTemplate(template);
+      }
+    },
+    [onEditTemplate, template],
+  );
+
   // Handle delete click
-  const handleDeleteClick = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (onDeleteTemplate && template.id) {
-      onDeleteTemplate(template.id);
-    }
-  }, [onDeleteTemplate, template.id]);
+  const handleDeleteClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (onDeleteTemplate && template.id) {
+        onDeleteTemplate(template.id);
+      }
+    },
+    [onDeleteTemplate, template.id],
+  );
 
   // Handle pin toggle
-  const handleTogglePin = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (onTogglePin && template.id) {
-      onTogglePin(template.id, isPinned, type);
-    }
-  }, [onTogglePin, template.id, isPinned, type]);
+  const handleTogglePin = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (onTogglePin && template.id) {
+        onTogglePin(template.id, isPinned, type);
+      }
+    },
+    [onTogglePin, template.id, isPinned, type],
+  );
 
   // Show controls based on type and props
-  const shouldShowEditControls = showEditControls && type === 'user';
-  const shouldShowDeleteControls = showDeleteControls && type === 'user';
+  const shouldShowEditControls = showEditControls && type === "user";
+  const shouldShowDeleteControls = showDeleteControls && type === "user";
   const shouldShowPinControls = showPinControls && onTogglePin;
 
-
   return (
-    <div 
+    <div
       className={`jd-flex jd-items-center hover:jd-bg-accent/60 jd-rounded-sm jd-cursor-pointer jd-group jd-transition-colors ${
-      isProcessing ? 'jd-opacity-50 jd-cursor-not-allowed' : ''
+        isProcessing ? "jd-opacity-50 jd-cursor-not-allowed" : ""
       } ${className}`}
       onClick={handleTemplateClick}
       style={{ paddingLeft: `${level * 16 + 8}px` }}
-
     >
+      {shouldShowPinControls && (
+        <div className="jd-mr-2 jd-flex-shrink-0">
+          <PinButton
+            type="template"
+            isPinned={isPinned}
+            onClick={handleTogglePin}
+            className={
+              isPinned
+                ? ""
+                : "jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity"
+            }
+          />
+        </div>
+      )}
+
       {/* Template Icon or Organization Image */}
       {shouldShowOrgImage ? (
         <OrganizationImage
@@ -144,19 +182,18 @@ export const TemplateItem: React.FC<TemplateItemProps> = ({
           showFallback={false} // Don't show fallback icon, fall back to FileText instead
         />
       ) : (
-        <FileText className={`jd-h-4 jd-w-4 jd-mr-2 jd-flex-shrink-0 ${iconColorMap[type]}`} />
+        <FileText
+          className={`jd-h-4 jd-w-4 jd-mr-2 jd-flex-shrink-0 ${iconColorMap[type]}`}
+        />
       )}
-      
+
       {/* Template Content */}
       <div className="jd-flex-1 jd-min-w-0">
         {/* Template Title with optional description tooltip */}
         {template.description ? (
           <Tooltip>
             <TooltipTrigger asChild>
-              <div
-                className="jd-text-sm jd-truncate"
-                title={displayName}
-              >
+              <div className="jd-text-sm jd-truncate" title={displayName}>
                 {displayName}
               </div>
             </TooltipTrigger>
@@ -165,83 +202,70 @@ export const TemplateItem: React.FC<TemplateItemProps> = ({
             </TooltipContent>
           </Tooltip>
         ) : (
-          <div
-            className="jd-text-sm jd-truncate"
-            title={displayName}
-          >
+          <div className="jd-text-sm jd-truncate" title={displayName}>
             {displayName}
           </div>
         )}
       </div>
-  
 
-        {/* Edit and Delete Controls (for user templates) */}
-        {(shouldShowEditControls || shouldShowDeleteControls || shouldShowPinControls) && (
-          <div className="jd-flex jd-gap-2  jd-items-center jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity">
-            {/* Edit Button */}
-            {shouldShowEditControls && onEditTemplate && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button 
-                      variant="ghost" 
-                      size="xs" 
-                      onClick={handleEditClick}
-                      disabled={isProcessing}
-                    >
-                      <Edit className="jd-h-4 jd-w-4 jd-text-blue-600 hover:jd-text-blue-700 hover:jd-bg-blue-100 jd-dark:jd-text-blue-400 jd-dark:hover:jd-text-blue-300 jd-dark:hover:jd-bg-blue-900/30" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    <p>{getMessage('edit_template', undefined, 'Edit template')}</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-            
-            {/* Delete Button */}
-            {shouldShowDeleteControls && onDeleteTemplate && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button 
-                      variant="ghost" 
-                      size="xs"
-                      onClick={handleDeleteClick}
-                      disabled={isProcessing}
-                    >
-                      <Trash2 className="jd-h-4 jd-w-4 jd-text-red-500 hover:jd-text-red-600 hover:jd-bg-red-100 jd-dark:hover:jd-bg-red-900/30" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    <p>{getMessage('delete_template', undefined, 'Delete template')}</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
+      {/* Edit and Delete Controls (for user templates) */}
+      {(shouldShowEditControls ||
+        shouldShowDeleteControls ||
+        shouldShowPinControls) && (
+        <div className="jd-flex jd-gap-2  jd-items-center jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity">
+          {/* Edit Button */}
+          {shouldShowEditControls && onEditTemplate && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    onClick={handleEditClick}
+                    disabled={isProcessing}
+                  >
+                    <Edit className="jd-h-4 jd-w-4 jd-text-blue-600 hover:jd-text-blue-700 hover:jd-bg-blue-100 jd-dark:jd-text-blue-400 jd-dark:hover:jd-text-blue-300 jd-dark:hover:jd-bg-blue-900/30" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p>
+                    {getMessage("edit_template", undefined, "Edit template")}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
 
-
-             {shouldShowPinControls && !isPinned && (
-                <PinButton
-                  type="template"
-                  isPinned={isPinned}
-                  onClick={handleTogglePin}
-                />
-              )}
-          </div>
-        )}
-
-      <div className="jd-ml-2 jd-flex jd-items-center jd-gap-1">
-          {/* Pin Button */}
-          {showPinControls && onTogglePin && isPinned && (
-            <div className={`jd-ml-auto  jd-items-center jd-gap-1 jd-flex`}>
-              <PinButton
-                isPinned={isPinned}
-                onClick={handleTogglePin}
-              />
-            </div>
+          {/* Delete Button */}
+          {shouldShowDeleteControls && onDeleteTemplate && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    onClick={handleDeleteClick}
+                    disabled={isProcessing}
+                  >
+                    <Trash2 className="jd-h-4 jd-w-4 jd-text-red-500 hover:jd-text-red-600 hover:jd-bg-red-100 jd-dark:hover:jd-bg-red-900/30" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p>
+                    {getMessage(
+                      "delete_template",
+                      undefined,
+                      "Delete template",
+                    )}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
         </div>
+      )}
+
+      {/* Actions container end */}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- move pin button to the start of folder and template rows
- remove old right‑aligned pin button containers
- format updated files

## Testing
- `npm run lint` *(fails: 507 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685c294b6fd883259e06f18a66f0b61c