### PR TITLE
Sort templates alphabetically

### DIFF
--- a/src/utils/prompts/folderUtils.ts
+++ b/src/utils/prompts/folderUtils.ts
@@ -1,6 +1,7 @@
 // src/components/panels/TemplatesPanel/utils/folderUtils.ts
 
 import { TemplateFolder } from '@/types/prompts/templates';
+import { getLocalizedContent } from '@/utils/prompts/blockUtils';
 
 /**
  * Count all templates in a folder including its subfolders
@@ -67,7 +68,13 @@ export function getFolderDepth(folderPath: string): number {
  * Compare folders by name for sorting
  */
 export function compareFoldersByName(a: TemplateFolder, b: TemplateFolder): number {
-  return (a.name || '').localeCompare(b.name || '');
+  const aName = getLocalizedContent(a.title ?? a.name) || '';
+  const bName = getLocalizedContent(b.title ?? b.name) || '';
+  return aName.localeCompare(bName, undefined, { sensitivity: 'base' });
+}
+
+export function getFolderTitle(folder: TemplateFolder): string {
+  return getLocalizedContent(folder.title ?? folder.name) || '';
 }
 
 /**

--- a/src/utils/prompts/templateUtils.ts
+++ b/src/utils/prompts/templateUtils.ts
@@ -1,4 +1,4 @@
-import { getBlockContent } from '@/utils/prompts/blockUtils';
+import { getBlockContent, getLocalizedContent } from '@/utils/prompts/blockUtils';
 import { formatBlockForPrompt, formatMetadataForPrompt } from '@/utils/prompts/promptUtils';
 import { ALL_METADATA_TYPES, PromptMetadata } from '@/types/prompts/metadata';
 import { Block } from '@/types/prompts/blocks';
@@ -159,6 +159,12 @@ export function isTemplatePopular(template: Template): boolean {
  */
 export function getTemplateTitle(template: Template): string {
   return template.title || 'Untitled Template';
+}
+
+export function compareTemplatesByTitle(a: Template, b: Template): number {
+  const aTitle = getLocalizedContent(a.title) || '';
+  const bTitle = getLocalizedContent(b.title) || '';
+  return aTitle.localeCompare(bTitle, undefined, { sensitivity: 'base' });
 }
 
 /**


### PR DESCRIPTION
## Summary
- add helper to compare folder names using localized titles
- add helper to compare template titles
- sort items in breadcrumb navigation hook
- order user section alphabetically
- show pinned items in alphabetical order

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685c2f10bb4c8325b7177269be8e6ee0