### PR TITLE
Fix Customize dialog content handling

### DIFF
--- a/src/utils/templates/promptPreviewUtils.ts
+++ b/src/utils/templates/promptPreviewUtils.ts
@@ -242,3 +242,19 @@ export function buildCompletePreviewHtmlWithBlocks(
   return buildCompletePreviewHtml(resolved, content, isDark);
 }
 
+/**
+ * Replace numeric block ID placeholders like `[123]` in the provided content
+ * with their corresponding block text from the cache.
+ */
+export function replaceBlockIdsInContent(
+  content: string,
+  blockMap: Record<number, string>
+): string {
+  if (!content) return '';
+
+  return content.replace(/\[(\d+)\]/g, (match, id) => {
+    const text = blockMap[parseInt(id, 10)];
+    return text !== undefined ? text : match;
+  });
+}
+


### PR DESCRIPTION
## Summary
- ensure CustomizeTemplateDialog only uses template content
- add helper to replace block ID placeholders with block text

## Testing
- `npm run lint` *(fails: 506 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685c723913808325816808e48e307ec0