### PR TITLE
Update useCustomizeTemplateDialog to resolve blocks

### DIFF
--- a/src/hooks/dialogs/useCustomizeTemplateDialog.ts
+++ b/src/hooks/dialogs/useCustomizeTemplateDialog.ts
@@ -1,4 +1,5 @@
 // src/hooks/dialogs/useCustomizeTemplateDialog.ts - Simplified Version
+import { useState, useEffect, useRef } from 'react';
 import { useDialog } from '@/components/dialogs/DialogContext';
 import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
 import { useTemplateDialogBase } from './useTemplateDialogBase';
@@ -6,40 +7,99 @@ import { trackEvent, EVENTS } from '@/utils/amplitude';
 import { toast } from 'sonner';
 import { getMessage } from '@/core/utils/i18n';
 import { PromptMetadata } from '@/types/prompts/metadata';
-import { replaceBlockIdsInContent } from '@/utils/templates/promptPreviewUtils';
+import {
+  replaceBlockIdsInContent,
+  buildCompletePreviewWithBlocks
+} from '@/utils/templates/promptPreviewUtils';
+import { replacePlaceholders } from '@/utils/templates/placeholderHelpers';
+import { blocksApi } from '@/services/api/BlocksApi';
+import { getLocalizedContent } from '@/utils/prompts/blockUtils';
+import { Block } from '@/types/prompts/blocks';
+
+// Helper to build a cache of block ID -> translated content
+const buildBlockCache = (blocks: Block[]): Record<number, string> => {
+  const cache: Record<number, string> = {};
+  blocks.forEach(b => {
+    cache[b.id] = getLocalizedContent(b.content);
+  });
+  return cache;
+};
 
 export function useCustomizeTemplateDialog() {
   const { isOpen, data, dialogProps } = useDialog(DIALOG_TYPES.PLACEHOLDER_EDITOR);
+
+  const [blockContentCache, setBlockContentCache] = useState<Record<number, string>>({});
+  const placeholderValuesRef = useRef<Record<string, string>>({});
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<Record<string, string>>).detail || {};
+      placeholderValuesRef.current = detail;
+    };
+    document.addEventListener('jaydai:placeholder-values', handler as EventListener);
+    return () => document.removeEventListener('jaydai:placeholder-values', handler as EventListener);
+  }, []);
+
+  // Fetch blocks when dialog opens
+  useEffect(() => {
+    if (!isOpen) return;
+    const loadBlocks = async () => {
+      try {
+        const res = await blocksApi.getBlocks();
+        if (res.success && Array.isArray(res.data)) {
+          setBlockContentCache(buildBlockCache(res.data));
+        }
+      } catch (err) {
+        console.error('Failed to load blocks for customize dialog', err);
+      }
+    };
+    loadBlocks();
+  }, [isOpen]);
   
   const handleComplete = async (
-    content: string, 
+    content: string,
     metadata: PromptMetadata
   ): Promise<boolean> => {
     try {
-      const blockContentCache = data?.blockContentCache || {};
+      const initialCache = data?.blockContentCache || {};
+      const allBlocks = { ...initialCache, ...blockContentCache };
 
-      // Replace block IDs in the content if a cache is provided
-      let finalContent = content.trim();
-      if (Object.keys(blockContentCache).length > 0) {
-        finalContent = replaceBlockIdsInContent(finalContent, blockContentCache);
+      // Resolve placeholders in content and blocks
+      const placeholders = placeholderValuesRef.current;
+
+      let replacedContent = replacePlaceholders(content.trim(), placeholders);
+
+      const resolvedBlocks: Record<number, string> = {};
+      Object.entries(allBlocks).forEach(([id, text]) => {
+        resolvedBlocks[parseInt(id, 10)] = replacePlaceholders(text, placeholders);
+      });
+
+      // Replace block IDs in the content
+      if (Object.keys(resolvedBlocks).length > 0) {
+        replacedContent = replaceBlockIdsInContent(replacedContent, resolvedBlocks);
       }
 
-      // NOTE: We intentionally avoid injecting metadata lines here. The caller
-      // will handle any metadata formatting if needed.
-      
+      // Build final prompt using metadata + content
+      const finalPrompt = buildCompletePreviewWithBlocks(
+        metadata,
+        replacedContent,
+        resolvedBlocks
+      );
+
       if (data && data.onComplete) {
-        data.onComplete(finalContent);
+        data.onComplete(finalPrompt);
       }
-      
+
       // Track usage
       trackEvent(EVENTS.TEMPLATE_USED, {
         template_id: data?.id,
         template_name: data?.title,
         template_type: data?.type,
-        metadata_items_count: Object.keys(metadata.values || {}).length + 
-                              (metadata.constraint?.length || 0) + 
-                              (metadata.example?.length || 0),
-        final_content_length: finalContent.length
+        metadata_items_count:
+          Object.keys(metadata.values || {}).length +
+          (metadata.constraint?.length || 0) +
+          (metadata.example?.length || 0),
+        final_content_length: finalPrompt.length
       });
       
       // Trigger cleanup events


### PR DESCRIPTION
## Summary
- fetch blocks inside `useCustomizeTemplateDialog`
- build block cache from fetched blocks
- resolve metadata block references when generating final prompt
- propagate placeholder values from `BasicEditor` so block content can be updated

## Testing
- `pnpm lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_685d0b6b3b288325a13564cecded3bbf