### PR TITLE
Allow empty templates

### DIFF
--- a/src/hooks/dialogs/useTemplateDialogBase.ts
+++ b/src/hooks/dialogs/useTemplateDialogBase.ts
@@ -252,10 +252,6 @@ export function useTemplateDialogBase(config: TemplateDialogConfig) {
       errors.name = getMessage('templateNameRequired', undefined, 'Template name is required');
     }
     
-    // Content is required
-    if (!state.content.trim()) {
-      errors.content = getMessage('templateContentRequired', undefined, 'Template content is required');
-    }
     
     // Only require metadata validation when creating or editing templates.
     // In customize mode we allow incomplete metadata so users can quickly

--- a/src/hooks/prompts/useTemplateCreation.ts
+++ b/src/hooks/prompts/useTemplateCreation.ts
@@ -116,9 +116,6 @@ export function useTemplateCreation() {
       errors.name = 'Template name is required';
     }
     
-    if (!data.content?.trim()) {
-      errors.content = 'Template content is required';
-    }
     
     setValidationErrors(errors);
     return Object.keys(errors).length === 0;

--- a/src/services/api/prompts/templates/createTemplate.ts
+++ b/src/services/api/prompts/templates/createTemplate.ts
@@ -7,10 +7,10 @@ import { apiClient } from "@/services/api/ApiClient";
 export async function createTemplate(templateData: any): Promise<any> {
     try {
       // Ensure required fields are present
-      if (!templateData.title || !templateData.content) {
+      if (!templateData.title) {
         return {
           success: false,
-          message: 'Title and content are required'
+          message: 'Title is required'
         };
       }
     

--- a/src/types/services/api.ts
+++ b/src/types/services/api.ts
@@ -70,7 +70,7 @@ export interface ApiResponse<T = unknown> {
   // Template API types
   export interface TemplateCreate {
     title: string;
-    content: string;
+    content: string | Record<string, string>;
     description?: string;
     folder_id?: number | null;
     locale?: string;
@@ -80,7 +80,7 @@ export interface ApiResponse<T = unknown> {
   
   export interface TemplateUpdate {
     title?: string;
-    content?: string;
+    content?: string | Record<string, string>;
     description?: string;
     folder_id?: number | null;
     metadata?: Record<string, number | number[]>;

--- a/src/utils/prompts/templateUtils.ts
+++ b/src/utils/prompts/templateUtils.ts
@@ -63,12 +63,7 @@ export const validateTemplateForm = (
 ) => {
   const errors: Record<string, string> = {};
   if (!name?.trim()) errors.name = 'templateNameRequired';
-  if (activeTab === 'basic' && !content?.trim()) errors.content = 'templateContentRequired';
-  if (activeTab === 'advanced') {
-    const hasContent = blocks.some(b => getBlockContent(b).trim()) ||
-      Object.values(metadata.values || {}).some(v => v?.trim());
-    if (!hasContent) errors.content = 'templateContentRequired';
-  }
+  // No content validation required
   setValidationErrors(errors);
   return Object.keys(errors).length === 0;
 };


### PR DESCRIPTION
## Summary
- permit creating templates with empty content
- relax validation for template content
- support localized empty content for TemplateCreate and TemplateUpdate types

## Testing
- `npm run type-check`
- `npm run lint` *(fails: 534 problems)*

------
https://chatgpt.com/codex/tasks/task_b_685d9f62d03883258d4d7bdde1dcc552