### PR TITLE
Fix customize dialog title

### DIFF
--- a/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
+++ b/src/components/dialogs/prompts/CustomizeTemplateDialog/index.tsx
@@ -86,8 +86,8 @@ export const CustomizeTemplateDialog: React.FC = () => {
       customValues={hook.customValues}
       
       // Config
-      dialogTitle={getMessage('CustomizeTemplateDialog', undefined, 'Customize Template')}
-      dialogDescription={getMessage('CustomizeTemplateDialogDescription', undefined, 'Customize your prompt template')}
+      dialogTitle={getMessage('customizeTemplate', hook.data?.title || 'Template')}
+      dialogDescription={getMessage('customizeTemplateDesc', undefined, 'Customize the template by filling in the placeholders.')}
       mode="customize"
       infoForm={infoForm}
     />


### PR DESCRIPTION
## Summary
- show template name in Customize Template dialog

## Testing
- `npm run lint` *(fails: 507 errors, 27 warnings)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685df1a945848325872cc6de14684fba