### PR TITLE
Add quick action for block creation

### DIFF
--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -249,7 +249,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
   const { toggleFolderPin, deleteFolder, createFolder } = useFolderMutations();
   const { deleteTemplate, toggleTemplatePin } = useTemplateMutations();
   const { useTemplate, createTemplate, editTemplate } = useTemplateActions();
-  const { openConfirmation, openFolderManager, openCreateFolder, openBrowseMoreFolders } = useDialogActions();
+  const { openConfirmation, openFolderManager, openCreateFolder, openBrowseMoreFolders, openCreateBlock } = useDialogActions();
 
   // Enhanced pin handler that works with the navigation system
   const handleTogglePin = useCallback(
@@ -317,6 +317,10 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
       },
     });
   }, [openCreateFolder, createFolder, refetchUser]);
+
+  const handleCreateBlock = useCallback(() => {
+    openCreateBlock();
+  }, [openCreateBlock]);
 
   // Template handlers
   const handleDeleteTemplate = useCallback((templateId: number) => {
@@ -401,8 +405,10 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
                 onNavigateToPathIndex={navigation.navigateToPathIndex}
                 onCreateTemplate={createTemplate}
                 onCreateFolder={handleCreateFolder}
+                onCreateBlock={handleCreateBlock}
                 showCreateTemplate={true}
                 showCreateFolder={true}
+                showCreateBlock={true}
               />
             )}
 

--- a/src/components/prompts/navigation/UnifiedNavigation.tsx
+++ b/src/components/prompts/navigation/UnifiedNavigation.tsx
@@ -1,6 +1,6 @@
 // src/components/prompts/navigation/UnifiedNavigation.tsx
 import React from 'react';
-import { FolderOpen, FilePlus, FolderPlus, ArrowLeft, Home, ChevronRight } from 'lucide-react';
+import { FolderOpen, FilePlus, FolderPlus, PlusSquare, ArrowLeft, Home, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { getMessage } from '@/core/utils/i18n';
 
@@ -23,10 +23,12 @@ interface UnifiedNavigationProps {
   // Action handlers
   onCreateTemplate?: () => void;
   onCreateFolder?: () => void;
+  onCreateBlock?: () => void;
   
   // Display options
   showCreateTemplate?: boolean;
   showCreateFolder?: boolean;
+  showCreateBlock?: boolean;
   className?: string;
 }
 
@@ -43,8 +45,10 @@ export const UnifiedNavigation: React.FC<UnifiedNavigationProps> = ({
   onNavigateToPathIndex,
   onCreateTemplate,
   onCreateFolder,
+  onCreateBlock,
   showCreateTemplate = false,
   showCreateFolder = false,
+  showCreateBlock = false,
   className = ''
 }) => {
   return (
@@ -74,6 +78,16 @@ export const UnifiedNavigation: React.FC<UnifiedNavigationProps> = ({
               title={getMessage('newFolder', undefined, 'New Folder')}
             >
               <FolderPlus className="jd-h-4 jd-w-4 jd-text-muted-foreground" />
+            </Button>
+          )}
+          {showCreateBlock && onCreateBlock && (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={onCreateBlock}
+              title="Create Block"
+            >
+              <PlusSquare className="jd-h-4 jd-w-4" />
             </Button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- support a new quick button in `UnifiedNavigation` for creating blocks
- expose the new create block action from `TemplatesPanel`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685fb9930afc8325a01b7865299320b1