### PR TITLE
Fix metadata card expansion in customize dialog

### DIFF
--- a/src/hooks/dialogs/useTemplateDialogBase.ts
+++ b/src/hooks/dialogs/useTemplateDialogBase.ts
@@ -352,15 +352,15 @@ export function useTemplateDialogBase(config: TemplateDialogConfig) {
         } else if (dialogType === 'customize') {
           const meta = initialData.metadata || createMetadata();
           const content = getLocalizedContent(initialData.content || '');
-          
+
           setState(prev => ({
             ...prev,
             content,
             metadata: meta,
-            expandedMetadata: new Set([
-              ...PRIMARY_METADATA,
-              ...Array.from(getFilledMetadataTypes(meta))
-            ]),
+            // In customize mode we want all metadata cards collapsed by default
+            // so the user immediately sees the selected block titles.
+            // Therefore we only expand the primary metadata types.
+            expandedMetadata: new Set(PRIMARY_METADATA),
             isProcessing: false
           }));
         }


### PR DESCRIPTION
## Summary
- don't auto-expand filled metadata cards when customizing templates

## Testing
- `npm run lint` *(fails: 536 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685fc3250fd0832593759dd1ca7b8198