### PR TITLE
Add drag hint for main button

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1751,5 +1751,6 @@
       }
     }
   },
-  "cannotRemoveLastBlock": { "message": "Cannot remove the last block. Templates must have at least one block.", "description": "Warning when trying to remove last block" }
+  "cannotRemoveLastBlock": { "message": "Cannot remove the last block. Templates must have at least one block.", "description": "Warning when trying to remove last block" },
+  "dragButtonHint": { "message": "Drag me to change my position", "description": "Hint text displayed near the draggable main button" }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1734,5 +1734,6 @@
       }
     }
   },
-  "cannotRemoveLastBlock": { "message": "Impossible de supprimer le dernier bloc. Le modèle doit comporter au moins un bloc.", "description": "Avertissement lors de la suppression du dernier bloc" }
+  "cannotRemoveLastBlock": { "message": "Impossible de supprimer le dernier bloc. Le modèle doit comporter au moins un bloc.", "description": "Avertissement lors de la suppression du dernier bloc" },
+  "dragButtonHint": { "message": "Faites glisser pour changer ma position", "description": "Texte d'aide affiché près du bouton principal pour indiquer qu'il peut être déplacé" }
 }

--- a/src/components/MainButton.tsx
+++ b/src/components/MainButton.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { Toaster } from "sonner";
 import { Button } from '@/components/ui/button';
-import { X } from "lucide-react";
+import { X, MoreVertical } from "lucide-react";
 import PanelManager from '@/components/panels/PanelManager';
 import ErrorBoundary from '@/components/common/ErrorBoundary';
 import { useMainButtonState } from '@/hooks/ui/useMainButtonState';
@@ -103,6 +103,14 @@ const MainButton = () => {
             notificationCount={notificationCount}
             activePanelType={panelType}
           />
+
+          {/* Drag hint */}
+          <div
+            className="jd-absolute jd-bottom-full jd-mb-2 jd-left-1/2 jd--translate-x-1/2 jd-flex jd-items-center jd-gap-1 jd-text-xs jd-text-muted-foreground jd-bg-background jd-border jd-border-muted jd-rounded jd-px-2 jd-py-1 jd-pointer-events-none"
+          >
+            <MoreVertical className="jd-w-3 jd-h-3" />
+            <span>{getMessage('dragButtonHint', undefined, 'Drag me to change my position')}</span>
+          </div>
 
           {/* Main Button with logo */}
           <div className="jd-relative jd-w-20 jd-h-20">


### PR DESCRIPTION
## Summary
- enhance MainButton with a drag hint overlay
- localize drag hint text in EN and FR locales

## Testing
- `npm run lint` *(fails: Unexpected any, no-useless-escape etc.)*

------
https://chatgpt.com/codex/tasks/task_b_685fe550ceac8325b533520fd91f0937