### PR TITLE
Handle Mistral chat requests

### DIFF
--- a/src/extension/content/networkInterceptor/constants.js
+++ b/src/extension/content/networkInterceptor/constants.js
@@ -21,7 +21,9 @@ export const ENDPOINTS = {
   'mistral': {
     USER_INFO: '/api/trpc/user.session',
     CONVERSATIONS_LIST: '/api/trpc/chat.list',
-    CHAT_COMPLETION: '/api/chat',
+    // First messages are sent via message.newChat while subsequent ones hit /chat
+    // Match both endpoints so we can capture all user prompts
+    CHAT_COMPLETION: /\/api\/trpc\/message\.newChat|\/chat(?:\?|$)/,
     SPECIFIC_CONVERSATION: /\/api\/chat/
   },
   'copilot': {

--- a/src/extension/content/networkInterceptor/fetchInterceptor.js
+++ b/src/extension/content/networkInterceptor/fetchInterceptor.js
@@ -48,10 +48,13 @@ export function initFetchInterceptor() {
       if (eventName === EVENTS.CHAT_COMPLETION) {
         // Dispatch chat completion event
         dispatchEvent(EVENTS.CHAT_COMPLETION, platform, { requestBody });
-        
-        
-        // Process streaming responses
-        if (isStreaming && requestBody?.messages?.[0]?.author?.role === "user") {
+
+        // Process streaming responses for user prompts
+        const isUserPrompt =
+          requestBody?.messages?.[0]?.author?.role === 'user' ||
+          requestBody?.messageInput;
+
+        if (isStreaming && isUserPrompt) {
           processStreamingResponse(response, requestBody);
         }
       } 

--- a/src/platforms/config/mistral.config.ts
+++ b/src/platforms/config/mistral.config.ts
@@ -2,11 +2,13 @@ import { PlatformConfig } from './base';
 
 export const mistralConfig: PlatformConfig = {
   name: 'mistral',
-  hostnames: ['chat.mistral.ai'],
+  // Include both main chat and admin hostnames used for requests
+  hostnames: ['chat.mistral.ai', 'admin.mistral.ai'],
   endpoints: {
     USER_INFO: '/api/trpc/user.session',
     CONVERSATIONS_LIST: '/api/trpc/chat.list',
-    CHAT_COMPLETION: '/api/chat',
+    // Match both the initial message.newChat call and subsequent /chat requests
+    CHAT_COMPLETION: /\/api\/trpc\/message\.newChat|\/chat(?:\?|$)/,
     SPECIFIC_CONVERSATION: /\/api\/chat/,
   },
   domSelectors: {


### PR DESCRIPTION
## Summary
- support new Mistral endpoints in network interceptor and config
- process streaming response for Mistral requests

## Testing
- `npm run lint` *(fails: 512 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_685ff23026f08325a5f787d986f42231