### PR TITLE
Fix action buttons only on hovered item

### DIFF
--- a/src/components/prompts/folders/FolderItem.tsx
+++ b/src/components/prompts/folders/FolderItem.tsx
@@ -235,7 +235,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
 
       {/* Folder Header */}
       <div 
-        className="jd-group jd-flex jd-items-center hover:jd-bg-accent/60 jd-cursor-pointer jd-rounded-sm jd-transition-colors"
+        className="jd-group/folder jd-flex jd-items-center hover:jd-bg-accent/60 jd-cursor-pointer jd-rounded-sm jd-transition-colors"
         onClick={handleFolderClick}
         style={{ paddingLeft: `${level * 16 + 8}px` }}
       >
@@ -284,7 +284,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
 
         {/* Action Buttons */}
         {((showEditControls && type === 'user') || (showDeleteControls && type === 'user')) && (
-          <div className="jd-flex jd-gap-1 jd-items-center jd-gap-2 jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity jd-duration-200">
+          <div className="jd-flex jd-gap-1 jd-items-center jd-gap-2 jd-opacity-0 group-hover/folder:jd-opacity-100 jd-transition-opacity jd-duration-200">
             {/* Edit Button */}
             {showEditControls && onEditFolder && (
               <TooltipProvider>
@@ -331,7 +331,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
           {showPinControls && onTogglePin && (
             <div
               className={`jd-ml-auto jd-items-center jd-gap-1 jd-flex ${
-                isPinned ? '' : 'jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity'
+                isPinned ? '' : 'jd-opacity-0 group-hover/folder:jd-opacity-100 jd-transition-opacity'
               }`}
             >
               <PinButton isPinned={isPinned} onClick={handleTogglePin} className="" />

--- a/src/components/prompts/templates/TemplateItem.tsx
+++ b/src/components/prompts/templates/TemplateItem.tsx
@@ -126,8 +126,8 @@ export const TemplateItem: React.FC<TemplateItemProps> = ({
 
 
   return (
-    <div 
-      className={`jd-flex jd-items-center hover:jd-bg-accent/60 jd-rounded-sm jd-cursor-pointer jd-group jd-transition-colors ${
+    <div
+      className={`jd-flex jd-items-center hover:jd-bg-accent/60 jd-rounded-sm jd-cursor-pointer jd-group/template jd-transition-colors ${
       isProcessing ? 'jd-opacity-50 jd-cursor-not-allowed' : ''
       } ${className}`}
       onClick={handleTemplateClick}
@@ -177,7 +177,7 @@ export const TemplateItem: React.FC<TemplateItemProps> = ({
 
         {/* Edit and Delete Controls (for user templates) */}
         {(shouldShowEditControls || shouldShowDeleteControls) && (
-          <div className="jd-flex jd-gap-2  jd-items-center jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity">
+          <div className="jd-flex jd-gap-2  jd-items-center jd-opacity-0 group-hover/template:jd-opacity-100 jd-transition-opacity">
             {/* Edit Button */}
             {shouldShowEditControls && onEditTemplate && (
               <TooltipProvider>
@@ -229,7 +229,7 @@ export const TemplateItem: React.FC<TemplateItemProps> = ({
           {showPinControls && onTogglePin && (
             <div
               className={`jd-ml-auto jd-items-center jd-gap-1 jd-flex ${
-                isPinned ? '' : 'jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity'
+                isPinned ? '' : 'jd-opacity-0 group-hover/template:jd-opacity-100 jd-transition-opacity'
               }`}
             >
               <PinButton


### PR DESCRIPTION
## Summary
- use unique group names so hovering one template or folder only shows its own actions

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_686106dc6d348325b34b298a203136c0