### PR TITLE
Fix mistral stream parsing

### DIFF
--- a/src/extension/content/networkInterceptor/streamProcessor.js
+++ b/src/extension/content/networkInterceptor/streamProcessor.js
@@ -211,6 +211,20 @@ export async function processMistralStreamingResponse(response, requestBody) {
           } catch (_) {
             content += dataStr;
           }
+        } else {
+          // Handle lines prefixed with a numeric id (e.g., "0: \"token\"")
+          const colonIndex = line.indexOf(':');
+          if (colonIndex !== -1) {
+            let token = line.slice(colonIndex + 1).trim();
+            if (token.startsWith('"') && token.endsWith('"')) {
+              try {
+                token = JSON.parse(token);
+              } catch (_) {
+                token = token.slice(1, -1);
+              }
+            }
+            content += token;
+          }
         }
       }
     }

--- a/src/platforms/adapters/mistral.adapter.ts
+++ b/src/platforms/adapters/mistral.adapter.ts
@@ -202,6 +202,19 @@ export class MistralAdapter extends BasePlatformAdapter {
             } catch (_) {
               content += dataStr;
             }
+          } else {
+            const colonIndex = line.indexOf(':');
+            if (colonIndex !== -1) {
+              let token = line.slice(colonIndex + 1).trim();
+              if (token.startsWith('"') && token.endsWith('"')) {
+                try {
+                  token = JSON.parse(token);
+                } catch (_) {
+                  token = token.slice(1, -1);
+                }
+              }
+              content += token;
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- handle Mistral stream chunks prefixed with a numeric id
- support numeric-prefixed chunks in adapter logic

## Testing
- `npm run lint` *(fails: 542 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68612cd06cf08325b9e51b29347a3375