### PR TITLE
Fix Mistral start message capture

### DIFF
--- a/src/platforms/adapters/mistral.adapter.ts
+++ b/src/platforms/adapters/mistral.adapter.ts
@@ -37,6 +37,16 @@ export class MistralAdapter extends BasePlatformAdapter {
         }
       }
 
+      // In "start" mode the request body contains the placeholder "start"
+      // instead of the actual user message. Retrieve the real text from the DOM
+      if (content === 'start') {
+        const firstSelected = document.querySelector('div.select-text span');
+        const domText = firstSelected?.textContent?.trim();
+        if (domText) {
+          content = domText;
+        }
+      }
+
       return {
         messageId,
         conversationId,


### PR DESCRIPTION
## Summary
- handle Mistral "start" mode user messages by reading text from the DOM

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68613c019d0883259ea8b90c23406bf6