### PR TITLE
Add drag handle i18n label

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1751,5 +1751,6 @@
       }
     }
   },
+  "dragToMove": { "message": "Drag to move", "description": "Tooltip for dragging the main button" },
   "cannotRemoveLastBlock": { "message": "Cannot remove the last block. Templates must have at least one block.", "description": "Warning when trying to remove last block" }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1734,5 +1734,6 @@
       }
     }
   },
+  "dragToMove": { "message": "Glissez pour déplacer", "description": "Infobulle pour déplacer le bouton principal" },
   "cannotRemoveLastBlock": { "message": "Impossible de supprimer le dernier bloc. Le modèle doit comporter au moins un bloc.", "description": "Avertissement lors de la suppression du dernier bloc" }
 }

--- a/src/components/MainButton.tsx
+++ b/src/components/MainButton.tsx
@@ -157,7 +157,7 @@ const MainButton = () => {
                   'hover:jd-bg-white hover:jd-shadow-lg hover:jd-scale-110',
                   isDragging && 'jd-cursor-grabbing jd-scale-110 jd-shadow-xl jd-bg-white jd-opacity-100 jd-pointer-events-auto'
                 )}
-                title="Drag to move"
+                title={getMessage('dragToMove', undefined, 'Drag to move')}
               >
                 <Move className={cn(
                   'jd-w-3 jd-h-3 jd-text-gray-500',


### PR DESCRIPTION
## Summary
- add `dragToMove` string in locales
- use `getMessage` for the drag handle tooltip

## Testing
- `npm run lint` *(fails: 542 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68614f3942c4832584b5b8a3768735fe