### PR TITLE
Update ErrorBoundary copy to use localization

### DIFF
--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { errorReporter } from '@/core/errors/ErrorReporter';
 import { AppError, ErrorCode } from '@/core/errors/AppError';
+import { getMessage } from '@/core/utils/i18n';
 
 interface Props {
   children: ReactNode;
@@ -70,17 +71,22 @@ export class ErrorBoundary extends Component<Props, State> {
         <div className="jd-p-4 jd-bg-red-900/20 jd-border jd-border-red-700/30 jd-rounded-md jd-text-center">
           <AlertTriangle className="jd-h-10 jd-w-10 jd-text-red-500 jd-mx-auto jd-mb-2" />
           <h3 className="jd-text-lg jd-font-medium jd-text-red-200 jd-mb-2">
-            Something went wrong
+            {getMessage('somethingWentWrong', undefined, 'Something went wrong')}
           </h3>
           <p className="jd-text-sm jd-text-red-300 jd-mb-4">
-            {this.state.error?.message || 'An unexpected error occurred'}
+            {this.state.error?.message ||
+              getMessage(
+                'unexpectedError',
+                undefined,
+                'An unexpected error occurred'
+              )}
           </p>
-          <Button 
-            variant="outline" 
+          <Button
+            variant="outline"
             className="jd-border-red-700 jd-text-red-200 hover:jd-bg-red-900/30"
             onClick={this.resetErrorBoundary}
           >
-            Try Again
+            {getMessage('tryAgain', undefined, 'Try Again')}
           </Button>
         </div>
       );


### PR DESCRIPTION
## Summary
- import `getMessage` into `ErrorBoundary`
- localize fallback texts in the default UI

## Testing
- `npm run lint` *(fails: 542 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68614f3b4b70832583ff04c816d6f0e6