### PR TITLE
Localize browse folders dialog text

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -604,6 +604,22 @@
     "message": "Refresh",
     "description": "Refresh button text"
   },
+  "browseFoldersTitle": {
+    "message": "Browse Folders",
+    "description": "Title for browse folders dialog"
+  },
+  "searchFoldersPlaceholder": {
+    "message": "Search folders...",
+    "description": "Placeholder text for folder search"
+  },
+  "loadingFoldersGeneric": {
+    "message": "Loading folders...",
+    "description": "Loading state text for folders"
+  },
+  "noFoldersOrTemplatesFound": {
+    "message": "No folders or templates found",
+    "description": "Empty state when no folders or templates match"
+  },
   "noPinnedOfficialTemplates": {
     "message": "No pinned organization templates. Click Browse More to add some.",
     "description": "Empty state message for organization templates section"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -513,6 +513,22 @@
     "message": "Actualiser",
     "description": "Button text to refresh templates"
   },
+  "browseFoldersTitle": {
+    "message": "Parcourir les Dossiers",
+    "description": "Titre de la fenêtre Parcourir les dossiers"
+  },
+  "searchFoldersPlaceholder": {
+    "message": "Rechercher des dossiers...",
+    "description": "Texte du champ de recherche des dossiers"
+  },
+  "loadingFoldersGeneric": {
+    "message": "Chargement des dossiers...",
+    "description": "Texte de chargement pour les dossiers"
+  },
+  "noFoldersOrTemplatesFound": {
+    "message": "Aucun dossier ou template trouvé",
+    "description": "Message lorsqu'aucun dossier ou template n'est trouvé"
+  },
   "noPinnedOfficialTemplates": {
     "message": "Aucun template d'organisation épinglé. Cliquez sur 'Voir Plus' pour en ajouter.",
     "description": "Empty state message for organization templates section"

--- a/src/components/dialogs/prompts/BrowseMoreFoldersDialog/index.tsx
+++ b/src/components/dialogs/prompts/BrowseMoreFoldersDialog/index.tsx
@@ -17,6 +17,7 @@ import { TemplateItem } from '@/components/prompts/templates/TemplateItem';
 import { Template } from '@/types/prompts/templates';
 import { Separator } from '@/components/ui/separator';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { getMessage } from '@/core/utils/i18n';
 import { useOrganizations } from '@/hooks/organizations';
 import { LoadingState } from '@/components/panels/TemplatesPanel/LoadingState';
 import { EmptyMessage } from '@/components/panels/TemplatesPanel/EmptyMessage';
@@ -118,22 +119,26 @@ export const BrowseMoreFoldersDialog: React.FC = () => {
     <BaseDialog
       open={isOpen}
       onOpenChange={dialogProps.onOpenChange}
-      title="Browse Folders"
+      title={getMessage('browseFoldersTitle', undefined, 'Browse Folders')}
       className="jd-max-w-lg"
     >
       <TooltipProvider>
         <FolderSearch
           searchQuery={searchQuery}
           onSearchChange={setSearchQuery}
-          placeholderText="Search folders..."
+          placeholderText={getMessage('searchFoldersPlaceholder', undefined, 'Search folders...')}
           onReset={clearSearch}
         />
         <Separator />
           <div className="jd-overflow-y-auto jd-max-h-[70vh]">
             {loading ? (
-              <LoadingState message="Loading folders..." />
+              <LoadingState
+                message={getMessage('loadingFoldersGeneric', undefined, 'Loading folders...')}
+              />
             ) : foldersWithPin.length === 0 && filteredTemplates.length === 0 ? (
-              <EmptyMessage>No folders or templates found</EmptyMessage>
+              <EmptyMessage>
+                {getMessage('noFoldersOrTemplatesFound', undefined, 'No folders or templates found')}
+              </EmptyMessage>
             ) : (
               <div className="jd-space-y-1 jd-px-2">
                 {foldersWithPin.map(folder => (


### PR DESCRIPTION
## Summary
- localize Browse More folders dialog strings
- add i18n keys for new folder dialog strings

## Testing
- `npm run lint` *(fails: no-unused-vars, etc.)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68614f3cf848832583fa105c7e0a405f