### PR TITLE
Use i18n strings for pagination tooltips

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1751,5 +1751,13 @@
       }
     }
   },
+  "previousPage": {
+    "message": "Previous page",
+    "description": "Tooltip for pagination previous button"
+  },
+  "nextPage": {
+    "message": "Next page",
+    "description": "Tooltip for pagination next button"
+  },
   "cannotRemoveLastBlock": { "message": "Cannot remove the last block. Templates must have at least one block.", "description": "Warning when trying to remove last block" }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1734,5 +1734,13 @@
       }
     }
   },
+  "previousPage": {
+    "message": "Page précédente",
+    "description": "Info-bulle pour le bouton de page précédente"
+  },
+  "nextPage": {
+    "message": "Page suivante",
+    "description": "Info-bulle pour le bouton de page suivante"
+  },
   "cannotRemoveLastBlock": { "message": "Impossible de supprimer le dernier bloc. Le modèle doit comporter au moins un bloc.", "description": "Avertissement lors de la suppression du dernier bloc" }
 }

--- a/src/components/prompts/common/Pagination.tsx
+++ b/src/components/prompts/common/Pagination.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { getMessage } from '@/core/utils/i18n';
 
 interface PaginationProps {
   currentPage: number;
@@ -36,7 +37,7 @@ export function Pagination({
           onClick={() => onPageChange(Math.max(0, currentPage - 1))}
           disabled={!hasPrev}
           className="jd-h-6 jd-w-6"
-          title="Previous page"
+          title={getMessage('previousPage', undefined, 'Previous page')}
         >
           <ChevronLeft className="jd-h-4 jd-w-4" />
         </Button>
@@ -53,7 +54,7 @@ export function Pagination({
           onClick={() => onPageChange(Math.min(totalPages - 1, currentPage + 1))}
           disabled={!hasNext}
           className="jd-h-6 jd-w-6"
-          title="Next page"
+          title={getMessage('nextPage', undefined, 'Next page')}
         >
           <ChevronRight className="jd-h-4 jd-w-4" />
         </Button>


### PR DESCRIPTION
## Summary
- use `getMessage` in `Pagination` component
- add `previousPage` and `nextPage` translations in English and French locales

## Testing
- `npm run lint` *(fails: 542 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68614f3ec0f88325b4e4d6b92494c390