### PR TITLE
Internationalize folder UI messages

### DIFF
--- a/src/components/prompts/folders/FolderHeader.tsx
+++ b/src/components/prompts/folders/FolderHeader.tsx
@@ -3,6 +3,7 @@ import { Folder } from "lucide-react";
 import { OrganizationImage } from '@/components/organizations';
 import { Organization } from '@/types/organizations';
 import { useOrganizationById } from '@/hooks/organizations';
+import { getMessage } from '@/core/utils/i18n';
 
 const folderIconColors = {
   user: 'jd-text-blue-500',
@@ -52,7 +53,10 @@ export function FolderHeader({
         
         {folder.templates?.length > 0 && (
           <span className="jd-text-xs jd-text-muted-foreground jd-mr-2">
-            {folder.templates.length} {folder.templates.length === 1 ? 'template' : 'templates'}
+            {folder.templates.length}{' '}
+            {folder.templates.length === 1
+              ? getMessage('template', undefined, 'template')
+              : getMessage('templates', undefined, 'templates')}
           </span>
         )}
         

--- a/src/components/prompts/folders/FolderItem.tsx
+++ b/src/components/prompts/folders/FolderItem.tsx
@@ -157,7 +157,9 @@ export const FolderItem: React.FC<FolderItemProps> = ({
           <div className="jd-flex jd-items-center jd-justify-between jd-text-sm jd-font-medium jd-text-muted-foreground jd-mb-2">
             <div className="jd-flex jd-items-center">
               <FolderOpen className="jd-mr-2 jd-h-4 jd-w-4" />
-              {isAtRoot ? 'My Templates' : folder.title}
+              {isAtRoot
+                ? getMessage('myTemplates', undefined, 'My Templates')
+                : folder.title}
             </div>
             <div className="jd-flex jd-items-center jd-gap-1">
               {onCreateTemplate && (
@@ -192,7 +194,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
                   size="sm" 
                   onClick={onNavigateToRoot} 
                   className="jd-h-6 jd-px-2 jd-text-muted-foreground hover:jd-text-foreground"
-                  title="Go to root"
+                  title={getMessage('goToRoot', undefined, 'Go to root')}
                 >
                   <Home className="jd-h-4 jd-w-4" />
                 </Button>
@@ -223,7 +225,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
                   size="sm" 
                   onClick={onNavigateBack} 
                   className="jd-h-6 jd-px-2 jd-text-muted-foreground hover:jd-text-foreground jd-flex-shrink-0"
-                  title="Go back"
+                  title={getMessage('goBack', undefined, 'Go back')}
                 >
                   <ArrowLeft className="jd-h-4 jd-w-4" />
                 </Button>
@@ -299,7 +301,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
                       </Button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">
-                    <p>Edit folder</p>
+                    <p>{getMessage('editFolder', undefined, 'Edit folder')}</p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
@@ -319,7 +321,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">
-                    <p>Delete folder</p>
+                    <p>{getMessage('deleteFolder', undefined, 'Delete folder')}</p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
@@ -396,7 +398,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
             <EmptyMessage>
               {isAtRoot 
                 ? getMessage('noTemplates', undefined, 'No templates yet. Create your first template!')
-                : 'This folder is empty'
+                : getMessage('folderEmpty', undefined, 'This folder is empty')
               }
             </EmptyMessage>
           ) : (

--- a/src/components/prompts/folders/FolderList.tsx
+++ b/src/components/prompts/folders/FolderList.tsx
@@ -4,6 +4,7 @@ import { Template, TemplateFolder } from '@/types/prompts/templates';
 import { Organization } from '@/types/organizations';
 import { FolderItem } from './FolderItem';
 import { EmptyMessage } from '@/components/panels/TemplatesPanel/EmptyMessage';
+import { getMessage } from '@/core/utils/i18n';
 
 interface FolderListProps {
   folders: TemplateFolder[];
@@ -56,7 +57,8 @@ const FolderList: React.FC<FolderListProps> = ({
   if (validFolders.length === 0) {
     return (
       <EmptyMessage>
-        {emptyMessage || `No ${type} folders available.`}
+        {emptyMessage ||
+          getMessage('noFolders', [type], `No ${type} folders available.`)}
       </EmptyMessage>
     );
   }

--- a/src/components/prompts/folders/FolderPicker.tsx
+++ b/src/components/prompts/folders/FolderPicker.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useMemo } from 'react';
 import { FolderOpen, ChevronRight } from 'lucide-react';
 import { FolderNavigation } from './FolderNavigation';
 import { TemplateFolder } from '@/types/prompts/templates';
+import { getMessage } from '@/core/utils/i18n';
 
 interface FolderPickerProps {
   folders: TemplateFolder[];
@@ -90,7 +91,9 @@ export const FolderPicker: React.FC<FolderPickerProps> = ({ folders, onSelect, c
           </div>
         ))}
         {currentFolders.length === 0 && (
-          <div className="jd-text-xs jd-text-muted-foreground jd-p-2">No subfolders</div>
+          <div className="jd-text-xs jd-text-muted-foreground jd-p-2">
+            {getMessage('noSubfolders', undefined, 'No subfolders')}
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- use i18n `getMessage` for folder headers and lists
- localize empty folder and navigation messages

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68614f4036b88325a643498f6a261d2c