### PR TITLE
Localize folder manager dialog

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -484,6 +484,18 @@
     "message": "Create a new template to use with AI conversations.",
     "description": "Description for create template dialog"
   },
+  "editFolder": {
+    "message": "Edit Folder",
+    "description": "Title for edit folder dialog"
+  },
+  "editFolderDescription": {
+    "message": "Update folder information",
+    "description": "Description for edit folder dialog"
+  },
+  "parentFolder": {
+    "message": "Parent Folder",
+    "description": "Label for parent folder field"
+  },
   "enterTemplateName": {
     "message": "Enter template name",
     "description": "Placeholder for template name input"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1283,6 +1283,18 @@
     "message": "Créez un nouveau template à utiliser avec les conversations IA.",
     "description": "Description pour la boîte de dialogue de création de template"
   },
+  "editFolder": {
+    "message": "Modifier le dossier",
+    "description": "Titre de la boîte de dialogue de modification de dossier"
+  },
+  "editFolderDescription": {
+    "message": "Mettre à jour les informations du dossier",
+    "description": "Description de la boîte de dialogue de modification de dossier"
+  },
+  "parentFolder": {
+    "message": "Dossier parent",
+    "description": "Étiquette pour le champ dossier parent"
+  },
   "TemplateName": {
     "message": "Nom du template",
     "description": "Étiquette pour le champ de nom du template"

--- a/src/components/dialogs/prompts/FolderManagerDialog/index.tsx
+++ b/src/components/dialogs/prompts/FolderManagerDialog/index.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { getLocalizedContent } from '@/utils/prompts/blockUtils';
+import { getMessage } from '@/core/utils/i18n';
 import { useDialog } from '@/components/dialogs/DialogContext';
 import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
 import { BaseDialog } from '@/components/dialogs/BaseDialog';
@@ -72,13 +73,13 @@ export const FolderManagerDialog: React.FC = () => {
     <BaseDialog
       open={isOpen}
       onOpenChange={dialogProps.onOpenChange}
-      title="Edit Folder"
-      description="Update folder information"
+      title={getMessage('editFolder', undefined, 'Edit Folder')}
+      description={getMessage('editFolderDescription', undefined, 'Update folder information')}
       className="jd-max-w-xl"
     >
       <form onSubmit={handleSave} className="jd-space-y-4 jd-mt-4">
         <div>
-          <label className="jd-text-sm jd-font-medium">Name</label>
+          <label className="jd-text-sm jd-font-medium">{getMessage('name', undefined, 'Name')}</label>
           <Input
             value={title}
             placeholder="Folder name"
@@ -97,7 +98,7 @@ export const FolderManagerDialog: React.FC = () => {
           />
         </div>
         <div>
-          <label className="jd-text-sm jd-font-medium">Parent Folder</label>
+          <label className="jd-text-sm jd-font-medium">{getMessage('parentFolder', undefined, 'Parent Folder')}</label>
           <Select
             value={parentId !== null ? String(parentId) : 'root'}
             onValueChange={(val) =>
@@ -120,14 +121,14 @@ export const FolderManagerDialog: React.FC = () => {
         </div>
         <div className="jd-flex jd-justify-end jd-gap-2 jd-pt-4">
           <Button type="button" variant="outline" onClick={() => dialogProps.onOpenChange(false)} disabled={isSubmitting}>
-            Cancel
+            {getMessage('cancel')}
           </Button>
           <Button type="submit" disabled={isSubmitting || !title.trim()}
             className="jd-flex jd-items-center jd-gap-1">
             {isSubmitting && (
               <div className="jd-h-4 jd-w-4 jd-border-2 jd-border-current jd-border-t-transparent jd-animate-spin jd-rounded-full"></div>
             )}
-            <span>Save</span>
+            <span>{getMessage('save')}</span>
           </Button>
         </div>
       </form>


### PR DESCRIPTION
## Summary
- localize strings in folder manager dialog
- add locale entries for folder manager

## Testing
- `pnpm run lint` *(fails: many existing lint errors)*
- `pnpm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68614f3f69cc8325a9043a6f64de58c4