### PR TITLE
Localize usage indicator strings

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -784,6 +784,26 @@
       }
     }
   },
+  "used_time": {
+    "message": "Used {{count}} time",
+    "description": "Message showing how many times a template has been used (singular)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "popular_used_times": {
+    "message": "Popular \u2022 Used {{count}} times",
+    "description": "Label showing a template is popular with usage count",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "5"
+      }
+    }
+  },
   "last_used": {
     "message": "Last used {{date}}",
     "description": "Message showing when a template was last used",

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -693,6 +693,26 @@
       }
     }
   },
+  "used_time": {
+    "message": "Utilisé {{count}} fois",
+    "description": "Message indiquant combien de fois un template a été utilisé (singulier)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "popular_used_times": {
+    "message": "Populaire \u2022 Utilisé {{count}} fois",
+    "description": "Indique qu'un template est populaire avec le nombre d'utilisations",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "5"
+      }
+    }
+  },
   "last_used": {
     "message": "Dernière utilisation {{date}}",
     "description": "Message indiquant quand un template a été utilisé pour la dernière fois",

--- a/src/components/prompts/templates/UsageIndicator.tsx
+++ b/src/components/prompts/templates/UsageIndicator.tsx
@@ -41,7 +41,7 @@ const UsageIndicator: React.FC<UsageIndicatorProps> = ({ template }) => {
               <Badge variant="secondary" className="jd-px-1 jd-py-0 jd-h-4 jd-mr-1">
                 <Sparkles className="jd-h-3 jd-w-3 jd-text-yellow-500" />
               </Badge>
-              Popular • Used {usageCount} times
+              {getMessage('popular_used_times', {count: usageCount.toString()}, `Popular • Used ${usageCount} times`)}
             </div>
           </TooltipTrigger>
           <TooltipContent>
@@ -57,7 +57,7 @@ const UsageIndicator: React.FC<UsageIndicatorProps> = ({ template }) => {
     return (
       <div className="flex items-center text-xs text-muted-foreground">
         <Clock className="h-3 w-3 mr-1 flex-shrink-0" />
-        <span>Last used {lastUsed}</span>
+        <span>{getMessage('last_used', {date: lastUsed || ''}, `Last used ${lastUsed}`)}</span>
       </div>
     );
   }
@@ -65,7 +65,11 @@ const UsageIndicator: React.FC<UsageIndicatorProps> = ({ template }) => {
   // Default case: just show the usage count
   return (
     <div className="text-xs text-muted-foreground">
-      Used {usageCount} {usageCount === 1 ? 'time' : 'times'}
+      {getMessage(
+        usageCount === 1 ? 'used_time' : 'used_times',
+        {count: usageCount.toString()},
+        `Used ${usageCount} ${usageCount === 1 ? 'time' : 'times'}`
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- localize template usage indicator strings
- add i18n entries for singular, plural, and popular usage indicator texts in English and French

## Testing
- `npm run lint` *(fails: 542 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68614f4130388325a0df8f2e5a17fbf6