### PR TITLE
Localize Template Preview text

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1751,5 +1751,17 @@
       }
     }
   },
+  "templatePreview.title": {
+    "message": "Template Preview",
+    "description": "Default title for template preview section"
+  },
+  "constraintLabel": {
+    "message": "Contrainte:",
+    "description": "Label for constraint items in template preview"
+  },
+  "exampleLabel": {
+    "message": "Exemple:",
+    "description": "Label for example items in template preview"
+  },
   "cannotRemoveLastBlock": { "message": "Cannot remove the last block. Templates must have at least one block.", "description": "Warning when trying to remove last block" }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1734,5 +1734,17 @@
       }
     }
   },
+  "templatePreview.title": {
+    "message": "Aperçu du template",
+    "description": "Titre par défaut pour l'aperçu du template"
+  },
+  "constraintLabel": {
+    "message": "Contrainte:",
+    "description": "Étiquette pour les contraintes dans l'aperçu"
+  },
+  "exampleLabel": {
+    "message": "Exemple:",
+    "description": "Étiquette pour les exemples dans l'aperçu"
+  },
   "cannotRemoveLastBlock": { "message": "Impossible de supprimer le dernier bloc. Le modèle doit comporter au moins un bloc.", "description": "Avertissement lors de la suppression du dernier bloc" }
 }

--- a/src/components/prompts/TemplatePreview.tsx
+++ b/src/components/prompts/TemplatePreview.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { cn } from '@/core/utils/classNames';
 import { PromptMetadata } from '@/types/prompts/metadata';
 import { buildCompletePreviewWithBlocks, buildCompletePreviewHtmlWithBlocks } from '@/utils/templates/promptPreviewUtils';
+import { getMessage } from '@/core/utils/i18n';
 
 interface TemplatePreviewProps {
   metadata: PromptMetadata;
@@ -19,7 +20,7 @@ export const TemplatePreview: React.FC<TemplatePreviewProps> = ({
   blockContentCache = {},
   isDarkMode,
   className,
-  title = "Template Preview"
+  title = getMessage('templatePreview.title', undefined, 'Template Preview')
 }) => {
   // Build the complete preview HTML
   const previewHtml = React.useMemo(() => {
@@ -43,15 +44,15 @@ export const TemplatePreview: React.FC<TemplatePreviewProps> = ({
     if (metadata.constraint) {
       metadata.constraint.forEach(item => {
         if (item.value.trim()) {
-          parts.push(`Contrainte: ${item.value}`);
+          parts.push(`${getMessage('constraintLabel', undefined, 'Contrainte:')} ${item.value}`);
         }
       });
     }
-    
+
     if (metadata.example) {
       metadata.example.forEach(item => {
         if (item.value.trim()) {
-          parts.push(`Exemple: ${item.value}`);
+          parts.push(`${getMessage('exampleLabel', undefined, 'Exemple:')} ${item.value}`);
         }
       });
     }


### PR DESCRIPTION
## Summary
- localize TemplatePreview title and labels
- add English/French translations for template preview text

## Testing
- `npm run lint` *(fails: eslint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68614f4264c483258c57b42eaa29ecb2