### PR TITLE
Add i18n for block actions

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1752,4 +1752,28 @@
     }
   },
   "cannotRemoveLastBlock": { "message": "Cannot remove the last block. Templates must have at least one block.", "description": "Warning when trying to remove last block" }
+  ,
+  "saveAsNewBlock": {
+    "message": "Save as new block",
+    "description": "Tooltip for saving a block as new"
+  },
+  "deleteBlock": {
+    "message": "Delete block",
+    "description": "Tooltip for deleting a block"
+  },
+  "selectBlockType": {
+    "message": "Select type",
+    "description": "Placeholder for block type selection"
+  },
+  "createTypeBlock": {
+    "message": "Create $TYPE$ block",
+    "description": "Menu entry to create a block of specified type",
+    "placeholders": {
+      "type": { "content": "$1", "example": "goal" }
+    }
+  },
+  "createCustom": {
+    "message": "Create custom",
+    "description": "Menu entry to create a custom block"
+  }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1735,4 +1735,26 @@
     }
   },
   "cannotRemoveLastBlock": { "message": "Impossible de supprimer le dernier bloc. Le modèle doit comporter au moins un bloc.", "description": "Avertissement lors de la suppression du dernier bloc" }
+  ,
+  "saveAsNewBlock": {
+    "message": "Enregistrer comme nouveau bloc",
+    "description": "Infobulle pour enregistrer un nouveau bloc"
+  },
+  "deleteBlock": {
+    "message": "Supprimer le bloc",
+    "description": "Infobulle pour supprimer un bloc"
+  },
+  "selectBlockType": {
+    "message": "Sélectionner le type",
+    "description": "Espace réservé pour la sélection du type de bloc"
+  },
+  "createTypeBlock": {
+    "message": "Créer un bloc $TYPE$",
+    "description": "Entrée de menu pour créer un bloc du type indiqué",
+    "placeholders": { "type": { "content": "$1", "example": "goal" } }
+  },
+  "createCustom": {
+    "message": "Créer personnalisé",
+    "description": "Entrée de menu pour créer un bloc personnalisé"
+  }
 }

--- a/src/components/prompts/blocks/BlockCard.tsx
+++ b/src/components/prompts/blocks/BlockCard.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
 import { Trash2, GripVertical, Plus, Save } from 'lucide-react';
+import { getMessage } from '@/core/utils/i18n';
 import { Input } from '@/components/ui/input';
 import { getCurrentLanguage } from '@/core/utils/i18n';
 import { useDialogManager } from '@/components/dialogs/DialogContext';
@@ -184,7 +185,9 @@ export const BlockCard: React.FC<BlockCardProps> = ({
                     onValueChange={(value) => handleTypeChange(value as BlockType)}
                   >
                     <SelectTrigger className="jd-w-32 jd-text-xs jd-h-7">
-                      <SelectValue placeholder="Select type" />
+                      <SelectValue
+                        placeholder={getMessage('selectBlockType', undefined, 'Select type')}
+                      />
                     </SelectTrigger>
                     <SelectContent className="jd-z-[10010]">
                       {AVAILABLE_BLOCK_TYPES.map((t) => (
@@ -207,7 +210,8 @@ export const BlockCard: React.FC<BlockCardProps> = ({
                         ))}
                         <SelectItem value="custom">
                           <div className="jd-flex jd-items-center jd-gap-1">
-                            <Plus className="jd-h-3 jd-w-3" /> Create custom
+                            <Plus className="jd-h-3 jd-w-3" />
+                            {getMessage('createCustom', undefined, 'Create custom')}
                           </div>
                         </SelectItem>
                       </SelectContent>
@@ -228,7 +232,7 @@ export const BlockCard: React.FC<BlockCardProps> = ({
                 variant="ghost"
                 onClick={handleSaveClick}
                 className="jd-h-8 jd-px-3 jd-text-blue-600 jd-hover:jd-text-blue-700 jd-hover:jd-bg-blue-50 jd-transition-colors"
-                title="Save as new block"
+                title={getMessage('saveAsNewBlock', undefined, 'Save as new block')}
               >
                 <Save className="jd-h-3 jd-w-3 jd-mr-1" />
                 Save
@@ -240,7 +244,7 @@ export const BlockCard: React.FC<BlockCardProps> = ({
               variant="ghost"
               onClick={() => onRemove(block.id)}
               className="jd-h-8 jd-w-8 jd-p-0 jd-text-muted-foreground jd-hover:jd-text-destructive jd-transition-colors"
-              title="Delete block"
+              title={getMessage('deleteBlock', undefined, 'Delete block')}
             >
               <Trash2 className="jd-h-4 jd-w-4" />
             </Button>

--- a/src/components/prompts/blocks/MetadataCard.tsx
+++ b/src/components/prompts/blocks/MetadataCard.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue
 } from '@/components/ui/select';
 import { Trash2, ChevronUp, ChevronDown, Plus } from 'lucide-react';
+import { getMessage } from '@/core/utils/i18n';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -253,7 +254,11 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
                   <SelectItem value="create">
                     <div className="jd-flex jd-items-center jd-gap-2">
                       <Plus className="jd-h-3 jd-w-3" />
-                      Create {config.label.toLowerCase()} block
+                      {getMessage(
+                        'createTypeBlock',
+                        [config.label.toLowerCase()],
+                        `Create ${config.label.toLowerCase()} block`
+                      )}
                     </div>
                   </SelectItem>
                 </SelectContent>
@@ -280,7 +285,11 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
                         <SelectItem value="create">
                           <div className="jd-flex jd-items-center jd-gap-2">
                             <Plus className="jd-h-3 jd-w-3" />
-                            Create {config.label.toLowerCase()} block
+                            {getMessage(
+                              'createTypeBlock',
+                              [config.label.toLowerCase()],
+                              `Create ${config.label.toLowerCase()} block`
+                            )}
                           </div>
                         </SelectItem>
                       </SelectContent>
@@ -310,7 +319,11 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
                     <DropdownMenuItem onClick={() => handleAddSelect('create')}>
                       <div className="jd-flex jd-items-center jd-gap-2">
                         <Plus className="jd-h-3 jd-w-3" />
-                        Create {config.label.toLowerCase()} block
+                        {getMessage(
+                          'createTypeBlock',
+                          [config.label.toLowerCase()],
+                          `Create ${config.label.toLowerCase()} block`
+                        )}
                       </div>
                     </DropdownMenuItem>
                   </DropdownMenuContent>


### PR DESCRIPTION
## Summary
- internationalize block card actions and placeholders
- add translations for block-related UI text

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68614f434f308325b75e9bf3fef3b350