### PR TITLE
Localize AddBlockButton labels

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1751,5 +1751,35 @@
       }
     }
   },
+  "createNewBlock": { "message": "Create New Block", "description": "Label for creating a new block" },
+  "createNewSpecificBlock": {
+    "message": "Create new $TYPE$ block",
+    "description": "Option to create a new block of a given type",
+    "placeholders": {
+      "type": {
+        "content": "$1",
+        "example": "context"
+      }
+    }
+  },
+  "addExistingBlock": { "message": "Add Existing Block", "description": "Label for adding an existing block" },
+  "browseAllBlocks": { "message": "Browse all blocks...", "description": "Button text to browse all blocks" },
+  "blockTypeLabel": { "message": "Type", "description": "Label for block type field" },
+  "blockTitleLabel": { "message": "Title", "description": "Label for block title field" },
+  "blockTitlePlaceholder": {
+    "message": "$TYPE$ Block",
+    "description": "Placeholder for block title",
+    "placeholders": {
+      "type": { "content": "$1", "example": "custom" }
+    }
+  },
+  "blockContentPlaceholder": {
+    "message": "Enter $TYPE$ content...",
+    "description": "Placeholder for block content input",
+    "placeholders": {
+      "type": { "content": "$1", "example": "custom" }
+    }
+  },
+  "createBlock": { "message": "Create Block", "description": "Button text to create a block" },
   "cannotRemoveLastBlock": { "message": "Cannot remove the last block. Templates must have at least one block.", "description": "Warning when trying to remove last block" }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1734,5 +1734,35 @@
       }
     }
   },
+  "createNewBlock": { "message": "Créer un bloc", "description": "Libellé pour la création d'un nouveau bloc" },
+  "createNewSpecificBlock": {
+    "message": "Créer un bloc $TYPE$",
+    "description": "Option pour créer un bloc d'un type spécifique",
+    "placeholders": {
+      "type": {
+        "content": "$1",
+        "example": "contexte"
+      }
+    }
+  },
+  "addExistingBlock": { "message": "Ajouter un bloc existant", "description": "Libellé pour ajouter un bloc existant" },
+  "browseAllBlocks": { "message": "Parcourir tous les blocs...", "description": "Bouton pour parcourir tous les blocs" },
+  "blockTypeLabel": { "message": "Type", "description": "Libellé du type de bloc" },
+  "blockTitleLabel": { "message": "Titre", "description": "Libellé du titre du bloc" },
+  "blockTitlePlaceholder": {
+    "message": "Bloc $TYPE$",
+    "description": "Placeholder pour le titre du bloc",
+    "placeholders": {
+      "type": { "content": "$1", "example": "personnalisé" }
+    }
+  },
+  "blockContentPlaceholder": {
+    "message": "Saisir le contenu $TYPE$...",
+    "description": "Placeholder pour le contenu du bloc",
+    "placeholders": {
+      "type": { "content": "$1", "example": "personnalisé" }
+    }
+  },
+  "createBlock": { "message": "Créer un bloc", "description": "Bouton pour créer un bloc" },
   "cannotRemoveLastBlock": { "message": "Impossible de supprimer le dernier bloc. Le modèle doit comporter au moins un bloc.", "description": "Avertissement lors de la suppression du dernier bloc" }
 }

--- a/src/components/common/AddBlockButton.tsx
+++ b/src/components/common/AddBlockButton.tsx
@@ -20,6 +20,7 @@ import {
 import { useThemeDetector } from '@/hooks/useThemeDetector';
 import { useDialogActions } from '@/hooks/dialogs/useDialogActions';
 import { cn } from '@/core/utils/classNames';
+import { getMessage } from '@/core/utils/i18n';
 
 interface AddBlockButtonProps {
   availableBlocks: Record<BlockType, Block[]>;
@@ -72,7 +73,7 @@ export const AddBlockButton: React.FC<AddBlockButtonProps> = ({
           )}
         >
           <Plus className="jd-h-4 jd-w-4" />
-          Add Block
+          {getMessage('addBlock', undefined, 'Add Block')}
         </Button>
       </DropdownMenuTrigger>
       
@@ -83,13 +84,13 @@ export const AddBlockButton: React.FC<AddBlockButtonProps> = ({
       >
         <DropdownMenuLabel className="jd-flex jd-items-center jd-gap-2">
           <Sparkles className="jd-h-4 jd-w-4" />
-          Add Block
+          {getMessage('addBlock', undefined, 'Add Block')}
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         
         {/* Create New Blocks Section */}
         <DropdownMenuLabel className="jd-text-xs jd-text-muted-foreground">
-          Create New Block
+          {getMessage('createNewBlock', undefined, 'Create New Block')}
         </DropdownMenuLabel>
         {addableBlockTypes.map(blockType => {
           const Icon = getBlockTypeIcon(blockType);
@@ -109,7 +110,11 @@ export const AddBlockButton: React.FC<AddBlockButtonProps> = ({
                   {BLOCK_TYPE_LABELS[blockType]}
                 </span>
                 <span className="jd-text-xs jd-text-muted-foreground">
-                  Create new {blockType} block
+                  {getMessage(
+                    'createNewSpecificBlock',
+                    [blockType],
+                    `Create new ${blockType} block`
+                  )}
                 </span>
               </div>
             </DropdownMenuItem>
@@ -121,7 +126,7 @@ export const AddBlockButton: React.FC<AddBlockButtonProps> = ({
           <>
             <DropdownMenuSeparator />
             <DropdownMenuLabel className="jd-text-xs jd-text-muted-foreground">
-              Add Existing Block
+              {getMessage('addExistingBlock', undefined, 'Add Existing Block')}
             </DropdownMenuLabel>
             
             {Object.entries(availableBlocks).map(([blockType, blocks]) => {
@@ -170,7 +175,9 @@ export const AddBlockButton: React.FC<AddBlockButtonProps> = ({
                 className="jd-flex jd-items-center jd-gap-2 jd-py-2 jd-cursor-pointer jd-text-primary"
               >
                 <Plus className="jd-h-4 jd-w-4" />
-                <span className="jd-text-sm">Browse all blocks...</span>
+                <span className="jd-text-sm">
+                  {getMessage('browseAllBlocks', undefined, 'Browse all blocks...')}
+                </span>
               </DropdownMenuItem>
             )}
           </>
@@ -196,7 +203,13 @@ export const InlineBlockForm: React.FC<{
     if (content.trim()) {
       onSave({
         type,
-        title: title.trim() || `${BLOCK_TYPE_LABELS[type]} Block`,
+        title:
+          title.trim() ||
+          getMessage(
+            'blockTitlePlaceholder',
+            [BLOCK_TYPE_LABELS[type]],
+            `${BLOCK_TYPE_LABELS[type]} Block`
+          ),
         content: content.trim()
       });
     }
@@ -211,12 +224,16 @@ export const InlineBlockForm: React.FC<{
         <div className={cn('jd-p-1.5 jd-rounded-md', iconBg)}>
           <Icon className="jd-h-4 jd-w-4" />
         </div>
-        <h3 className="jd-font-medium jd-text-sm">Create New Block</h3>
+        <h3 className="jd-font-medium jd-text-sm">
+          {getMessage('createNewBlock', undefined, 'Create New Block')}
+        </h3>
       </div>
 
       <div className="jd-grid jd-grid-cols-2 jd-gap-3">
         <div>
-          <label className="jd-text-xs jd-font-medium jd-mb-1 jd-block">Type</label>
+          <label className="jd-text-xs jd-font-medium jd-mb-1 jd-block">
+            {getMessage('blockTypeLabel', undefined, 'Type')}
+          </label>
           <select
             value={type}
             onChange={(e) => setType(e.target.value as BlockType)}
@@ -231,23 +248,35 @@ export const InlineBlockForm: React.FC<{
         </div>
 
         <div>
-          <label className="jd-text-xs jd-font-medium jd-mb-1 jd-block">Title</label>
+          <label className="jd-text-xs jd-font-medium jd-mb-1 jd-block">
+            {getMessage('blockTitleLabel', undefined, 'Title')}
+          </label>
           <input
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            placeholder={`${BLOCK_TYPE_LABELS[type]} Block`}
+            placeholder={getMessage(
+              'blockTitlePlaceholder',
+              [BLOCK_TYPE_LABELS[type]],
+              `${BLOCK_TYPE_LABELS[type]} Block`
+            )}
             className="jd-w-full jd-h-8 jd-px-2 jd-text-xs jd-border jd-rounded"
           />
         </div>
       </div>
 
       <div>
-        <label className="jd-text-xs jd-font-medium jd-mb-1 jd-block">Content</label>
+        <label className="jd-text-xs jd-font-medium jd-mb-1 jd-block">
+          {getMessage('content', undefined, 'Content')}
+        </label>
         <textarea
           value={content}
           onChange={(e) => setContent(e.target.value)}
-          placeholder={`Enter ${type} content...`}
+          placeholder={getMessage(
+            'blockContentPlaceholder',
+            [type],
+            `Enter ${type} content...`
+          )}
           className="jd-w-full jd-h-20 jd-p-2 jd-text-xs jd-border jd-rounded jd-resize-none"
           required
         />
@@ -261,7 +290,7 @@ export const InlineBlockForm: React.FC<{
           onClick={onCancel}
           className="jd-flex-1 jd-h-8 jd-text-xs"
         >
-          Cancel
+          {getMessage('cancel', undefined, 'Cancel')}
         </Button>
         <Button
           type="submit"
@@ -269,7 +298,7 @@ export const InlineBlockForm: React.FC<{
           disabled={!content.trim()}
           className="jd-flex-1 jd-h-8 jd-text-xs"
         >
-          Create Block
+          {getMessage('createBlock', undefined, 'Create Block')}
         </Button>
       </div>
     </form>


### PR DESCRIPTION
## Summary
- internationalize AddBlockButton UI text
- add translations for new block labels in English and French

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68614f3a46688325a8ec4c760af16f72