### PR TITLE
Localize quick block selector strings

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1751,5 +1751,11 @@
       }
     }
   },
-  "cannotRemoveLastBlock": { "message": "Cannot remove the last block. Templates must have at least one block.", "description": "Warning when trying to remove last block" }
+  "cannotRemoveLastBlock": { "message": "Cannot remove the last block. Templates must have at least one block.", "description": "Warning when trying to remove last block" },
+  "openBlockBuilder": { "message": "Open block builder", "description": "Tooltip for opening block builder" },
+  "searchBlocksPlaceholder": { "message": "Search blocks...", "description": "Placeholder text for block search" },
+  "newBlock": { "message": "New", "description": "Button label to create a new block" },
+  "loadingBlocks": { "message": "Loading blocks...", "description": "Text shown while blocks load" },
+  "noBlocksAvailable": { "message": "No blocks available", "description": "Message when no blocks can be displayed" },
+  "quickSelectorHints": { "message": "↑↓ Navigate • ←→ Filter • Enter Select", "description": "Footer instructions for quick block selector" }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1734,5 +1734,11 @@
       }
     }
   },
-  "cannotRemoveLastBlock": { "message": "Impossible de supprimer le dernier bloc. Le modèle doit comporter au moins un bloc.", "description": "Avertissement lors de la suppression du dernier bloc" }
+  "cannotRemoveLastBlock": { "message": "Impossible de supprimer le dernier bloc. Le modèle doit comporter au moins un bloc.", "description": "Avertissement lors de la suppression du dernier bloc" },
+  "openBlockBuilder": { "message": "Ouvrir l'outil de blocs", "description": "Info-bulle pour ouvrir l'éditeur de blocs" },
+  "searchBlocksPlaceholder": { "message": "Rechercher des blocs...", "description": "Texte du champ de recherche de blocs" },
+  "newBlock": { "message": "Nouveau", "description": "Bouton pour créer un nouveau bloc" },
+  "loadingBlocks": { "message": "Chargement des blocs...", "description": "Texte affiché pendant le chargement des blocs" },
+  "noBlocksAvailable": { "message": "Aucun bloc disponible", "description": "Message lorsqu'aucun bloc n'est disponible" },
+  "quickSelectorHints": { "message": "↑↓ Naviguer • ←→ Filtrer • Entrée Sélection", "description": "Instructions en bas du sélecteur rapide de blocs" }
 }

--- a/src/components/prompts/blocks/quick-selector/QuickBlockSelector.tsx
+++ b/src/components/prompts/blocks/quick-selector/QuickBlockSelector.tsx
@@ -14,6 +14,7 @@ import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
 import { Search, Maximize2, X, Plus } from 'lucide-react';
 import { cn } from '@/core/utils/classNames';
 import { useDialogActions } from '@/hooks/dialogs/useDialogActions';
+import { getMessage } from '@/core/utils/i18n';
 import {
   getBlockTypeIcon,
   getBlockIconColors,
@@ -209,7 +210,7 @@ export const QuickBlockSelector: React.FC<QuickBlockSelectorProps> = ({
             variant="ghost"
             onClick={openFullDialog}
             className="jd-h-7 jd-px-2 jd-text-xs"
-            title="Open block builder"
+            title={getMessage('openBlockBuilder', undefined, 'Open block builder')}
           >
             <Maximize2 className="jd-h-3 jd-w-3 jd-mr-1" />
             Builder
@@ -232,7 +233,7 @@ export const QuickBlockSelector: React.FC<QuickBlockSelectorProps> = ({
             ref={searchInputRef}
             value={search}
             onChange={e => setSearch(e.target.value)}
-            placeholder="Search blocks..."
+            placeholder={getMessage('searchBlocksPlaceholder', undefined, 'Search blocks...')}
             className="jd-pl-8 jd-h-8 jd-text-sm"
           />
         </div>
@@ -262,7 +263,7 @@ export const QuickBlockSelector: React.FC<QuickBlockSelectorProps> = ({
             className="jd-px-2 jd-py-1 jd-text-xs jd-rounded-md jd-transition-colors jd-flex jd-items-center jd-gap-1 jd-border jd-border-dashed jd-bg-muted hover:jd-bg-muted/80"
           >
             <Plus className="jd-h-3 jd-w-3" />
-            <span>New</span>
+            <span>{getMessage('newBlock', undefined, 'New')}</span>
           </button>
         </div>
       </div>
@@ -272,11 +273,11 @@ export const QuickBlockSelector: React.FC<QuickBlockSelectorProps> = ({
         <ScrollArea className="jd-h-full">
           {loading ? (
             <div className="jd-py-8">
-              <LoadingSpinner size="sm" message="Loading blocks..." />
+              <LoadingSpinner size="sm" message={getMessage('loadingBlocks', undefined, 'Loading blocks...')} />
             </div>
           ) : filteredBlocks.length === 0 ? (
             <div className="jd-py-8 jd-text-center jd-text-sm jd-text-muted-foreground">
-              {search ? `No blocks found for "${search}"` : 'No blocks available'}
+              {search ? `No blocks found for "${search}"` : getMessage('noBlocksAvailable', undefined, 'No blocks available')}
             </div>
           ) : (
             <div className="jd-space-y-1 jd-pr-2">
@@ -297,7 +298,7 @@ export const QuickBlockSelector: React.FC<QuickBlockSelectorProps> = ({
 
       {/* Footer hints */}
       <div className="jd-px-3 jd-py-2 jd-border-t jd-flex jd-items-center jd-justify-between jd-text-[10px] jd-text-muted-foreground jd-flex-shrink-0">
-        <span>↑↓ Navigate • ←→ Filter • Enter Select</span>
+        <span>{getMessage('quickSelectorHints', undefined, '↑↓ Navigate • ←→ Filter • Enter Select')}</span>
         <span>{filteredBlocks.length} blocks</span>
       </div>
     </div>,


### PR DESCRIPTION
## Summary
- add i18n strings for QuickBlockSelector
- use translation keys in QuickBlockSelector component

## Testing
- `pnpm lint` *(fails: 542 problems)*
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_b_68614f4433dc83258523d84f997b26bc