### PR TITLE
Translate onboarding UI strings

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1751,5 +1751,19 @@
       }
     }
   },
-  "cannotRemoveLastBlock": { "message": "Cannot remove the last block. Templates must have at least one block.", "description": "Warning when trying to remove last block" }
+  "cannotRemoveLastBlock": { "message": "Cannot remove the last block. Templates must have at least one block.", "description": "Warning when trying to remove last block" },
+  "referralSourceSearch": { "message": "Search Engine (Google, Bing, etc.)", "description": "Referral source option" },
+  "referralSourceSocialMedia": { "message": "Social Media", "description": "Referral source option" },
+  "referralSourceFriend": { "message": "Friend or Colleague", "description": "Referral source option" },
+  "referralSourceBlog": { "message": "Blog or Article", "description": "Referral source option" },
+  "referralSourceYouTube": { "message": "YouTube", "description": "Referral source option" },
+  "referralSourcePodcast": { "message": "Podcast", "description": "Referral source option" },
+  "referralSourceAd": { "message": "Advertisement", "description": "Referral source option" },
+  "referralSourceStore": { "message": "Chrome Web Store", "description": "Referral source option" },
+  "referralSourceOther": { "message": "Other", "description": "Referral source option" },
+  "newLabel": { "message": "New", "description": "Label indicating a new item" },
+  "explanationRole": { "message": "Role", "description": "Tag label in onboarding completion" },
+  "explanationIndustry": { "message": "Industry", "description": "Tag label in onboarding completion" },
+  "explanationLevel": { "message": "Level", "description": "Tag label in onboarding completion" },
+  "explanationInterests": { "message": "Interests", "description": "Tag label in onboarding completion" }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1734,5 +1734,19 @@
       }
     }
   },
-  "cannotRemoveLastBlock": { "message": "Impossible de supprimer le dernier bloc. Le modèle doit comporter au moins un bloc.", "description": "Avertissement lors de la suppression du dernier bloc" }
+  "cannotRemoveLastBlock": { "message": "Impossible de supprimer le dernier bloc. Le modèle doit comporter au moins un bloc.", "description": "Avertissement lors de la suppression du dernier bloc" },
+  "referralSourceSearch": { "message": "Moteur de recherche (Google, Bing, etc.)", "description": "Option de source de recommandation" },
+  "referralSourceSocialMedia": { "message": "Réseaux sociaux", "description": "Option de source de recommandation" },
+  "referralSourceFriend": { "message": "Ami ou collègue", "description": "Option de source de recommandation" },
+  "referralSourceBlog": { "message": "Blog ou article", "description": "Option de source de recommandation" },
+  "referralSourceYouTube": { "message": "YouTube", "description": "Option de source de recommandation" },
+  "referralSourcePodcast": { "message": "Podcast", "description": "Option de source de recommandation" },
+  "referralSourceAd": { "message": "Publicité", "description": "Option de source de recommandation" },
+  "referralSourceStore": { "message": "Chrome Web Store", "description": "Option de source de recommandation" },
+  "referralSourceOther": { "message": "Autre", "description": "Option de source de recommandation" },
+  "newLabel": { "message": "Nouveau", "description": "Indique un nouvel élément" },
+  "explanationRole": { "message": "Rôle", "description": "Étiquette dans la vue de fin d'onboarding" },
+  "explanationIndustry": { "message": "Secteur", "description": "Étiquette dans la vue de fin d'onboarding" },
+  "explanationLevel": { "message": "Niveau", "description": "Étiquette dans la vue de fin d'onboarding" },
+  "explanationInterests": { "message": "Intérêts", "description": "Étiquette dans la vue de fin d'onboarding" }
 }

--- a/src/components/welcome/onboarding/steps/CompletionStep.tsx
+++ b/src/components/welcome/onboarding/steps/CompletionStep.tsx
@@ -196,7 +196,7 @@ export const CompletionStep: React.FC<CompletionStepProps> = ({
                       </div>
                       {folderRecommendations.new_folders.includes(folder.id) && (
                         <span className="jd-bg-green-500/20 jd-text-green-300 jd-px-1.5 jd-py-0.5 jd-rounded jd-text-xs jd-font-medium jd-flex-shrink-0 jd-animate-pulse">
-                          New
+                          {getMessage('newLabel', undefined, 'New')}
                         </span>
                       )}
                     </div>
@@ -218,22 +218,22 @@ export const CompletionStep: React.FC<CompletionStepProps> = ({
                 <div className="jd-flex jd-flex-wrap jd-gap-1">
                   {folderRecommendations.explanation.professional_role.length > 0 && (
                     <span className="jd-bg-blue-600/20 jd-text-blue-300 jd-px-1.5 jd-py-0.5 jd-rounded jd-text-xs">
-                      Role
+                      {getMessage('explanationRole', undefined, 'Role')}
                     </span>
                   )}
                   {folderRecommendations.explanation.industry.length > 0 && (
                     <span className="jd-bg-purple-600/20 jd-text-purple-300 jd-px-1.5 jd-py-0.5 jd-rounded jd-text-xs">
-                      Industry
+                      {getMessage('explanationIndustry', undefined, 'Industry')}
                     </span>
                   )}
                   {folderRecommendations.explanation.seniority.length > 0 && (
                     <span className="jd-bg-green-600/20 jd-text-green-300 jd-px-1.5 jd-py-0.5 jd-rounded jd-text-xs">
-                      Level
+                      {getMessage('explanationLevel', undefined, 'Level')}
                     </span>
                   )}
                   {folderRecommendations.explanation.interests.length > 0 && (
                     <span className="jd-bg-orange-600/20 jd-text-orange-300 jd-px-1.5 jd-py-0.5 jd-rounded jd-text-xs">
-                      Interests
+                      {getMessage('explanationInterests', undefined, 'Interests')}
                     </span>
                   )}
                 </div>

--- a/src/components/welcome/onboarding/steps/ReferralStep.tsx
+++ b/src/components/welcome/onboarding/steps/ReferralStep.tsx
@@ -14,15 +14,43 @@ import { OtherOptionInput } from '@/components/welcome/onboarding/OtherOptionInp
 
 // Referral sources
 const REFERRAL_SOURCES = [
-  { value: 'search', label: 'Search Engine (Google, Bing, etc.)' },
-  { value: 'social_media', label: 'Social Media' },
-  { value: 'friend', label: 'Friend or Colleague' },
-  { value: 'blog', label: 'Blog or Article' },
-  { value: 'youtube', label: 'YouTube' },
-  { value: 'podcast', label: 'Podcast' },
-  { value: 'ad', label: 'Advertisement' },
-  { value: 'store', label: 'Chrome Web Store' },
-  { value: 'other', label: 'Other' }
+  {
+    value: 'search',
+    label: getMessage(
+      'referralSourceSearch',
+      undefined,
+      'Search Engine (Google, Bing, etc.)'
+    )
+  },
+  {
+    value: 'social_media',
+    label: getMessage('referralSourceSocialMedia', undefined, 'Social Media')
+  },
+  {
+    value: 'friend',
+    label: getMessage('referralSourceFriend', undefined, 'Friend or Colleague')
+  },
+  {
+    value: 'blog',
+    label: getMessage('referralSourceBlog', undefined, 'Blog or Article')
+  },
+  {
+    value: 'youtube',
+    label: getMessage('referralSourceYouTube', undefined, 'YouTube')
+  },
+  {
+    value: 'podcast',
+    label: getMessage('referralSourcePodcast', undefined, 'Podcast')
+  },
+  {
+    value: 'ad',
+    label: getMessage('referralSourceAd', undefined, 'Advertisement')
+  },
+  {
+    value: 'store',
+    label: getMessage('referralSourceStore', undefined, 'Chrome Web Store')
+  },
+  { value: 'other', label: getMessage('referralSourceOther', undefined, 'Other') }
 ];
 
 interface ReferralStepProps {


### PR DESCRIPTION
## Summary
- localize referral options and completion tags
- load new translation texts via `getMessage`

## Testing
- `npm run lint` *(fails: Unexpected any, no-useless-escape)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68614f456c7c83258916403b57173469