### PR TITLE
Add organization website link

### DIFF
--- a/src/components/organizations/OrganizationBanner.tsx
+++ b/src/components/organizations/OrganizationBanner.tsx
@@ -1,7 +1,7 @@
 
 // src/components/organizations/OrganizationBanner.tsx - simplified banner
 import React from 'react';
-import { Building2 } from 'lucide-react';
+import { Building2, ExternalLink } from 'lucide-react';
 import { cn } from '@/core/utils/classNames';
 import { OrganizationImage } from '@/components/organizations';
 import { Organization } from '@/types/organizations';
@@ -17,7 +17,6 @@ export const OrganizationBanner: React.FC<OrganizationBannerProps> = ({
   className = '',
   variant = 'default'
 }) => {
-    console.log("organization--->", organization);
   const isCompact = variant === 'compact';
   const bannerStyle = organization.banner_url
     ? {
@@ -77,6 +76,20 @@ export const OrganizationBanner: React.FC<OrganizationBannerProps> = ({
           >
             Created by {organization.name}
           </p>
+          {organization.website_url && (
+            <a
+              href={organization.website_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn(
+                'jd-flex jd-items-center jd-text-xs jd-font-medium hover:jd-underline',
+                organization.banner_url ? 'jd-text-white' : 'jd-text-blue-600 jd-dark:jd-text-blue-400'
+              )}
+            >
+              Visit website
+              <ExternalLink className="jd-h-3 jd-w-3 jd-ml-1" />
+            </a>
+          )}
         </div>
       </div>
     </div>

--- a/src/services/api/OrganizationsApi.ts
+++ b/src/services/api/OrganizationsApi.ts
@@ -6,6 +6,7 @@ export interface Organization {
   name: string;
   image_url?: string;
   banner_url?: string;
+  website_url?: string;
   description?: string;
   created_at?: string;
 }

--- a/src/types/organizations.ts
+++ b/src/types/organizations.ts
@@ -8,6 +8,7 @@ export interface Organization {
     name: string;
     image_url?: string;
     banner_url?: string;
+    website_url?: string;
     description?: string;
     created_at?: string;
     updated_at?: string;


### PR DESCRIPTION
## Summary
- support `website_url` on organization type and API models
- show organization website link in `OrganizationBanner`

## Testing
- `npm run lint` *(fails: 542 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68615cc2ba0483258d98d0e4164255fd