### PR TITLE
Track extension popup event

### DIFF
--- a/src/extension/popup/ExtensionPopup.tsx
+++ b/src/extension/popup/ExtensionPopup.tsx
@@ -12,11 +12,15 @@ import './popup.css';
 import { getMessage } from '@/core/utils/i18n';
 import { authService } from '@/services/auth/AuthService';
 import { AuthState } from '@/types';
+import { trackEvent, EVENTS } from '@/utils/amplitude';
 
 // Current extension version
 const EXTENSION_VERSION = "1.0.0";
 
 const ExtensionPopup: React.FC = () => {
+  useEffect(() => {
+    trackEvent(EVENTS.EXTENSION_OPENED);
+  }, []);
   // Auth state
   const [authState, setAuthState] = useState<AuthState>({
     user: null,


### PR DESCRIPTION
## Summary
- send Amplitude event when the popup opens

## Testing
- `npm run lint` *(fails: many eslint problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6861838ebe8083258e781c3095648357