### PR TITLE
Add template search and folder analytics

### DIFF
--- a/src/components/panels/BrowseTemplatesPanel/index.tsx
+++ b/src/components/panels/BrowseTemplatesPanel/index.tsx
@@ -20,6 +20,7 @@ import { FolderItem } from '@/components/prompts/folders/FolderItem';
 import { TemplateItem } from '@/components/prompts/templates/TemplateItem';
 import { useFolderSearch } from '@/hooks/prompts/utils/useFolderSearch';
 import { Template, TemplateFolder } from '@/types/prompts/templates';
+import { trackEvent, EVENTS } from '@/utils/amplitude';
 
 interface BrowseTemplatesPanelProps {
   folderType: 'organization' | 'company';
@@ -68,6 +69,10 @@ const BrowseTemplatesPanel: React.FC<BrowseTemplatesPanelProps> = ({
     filteredFolders,
     clearSearch
   } = useFolderSearch(folders);
+
+  useEffect(() => {
+    trackEvent(EVENTS.TEMPLATE_SEARCH, { query: searchQuery });
+  }, [searchQuery]);
   
   // Get folder mutations
   const { toggleFolderPin } = useFolderMutations();

--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -34,6 +34,7 @@ import EmptyState from './EmptyState';
 import { TemplateFolder, Template } from '@/types/prompts/templates';
 import { getLocalizedContent } from '@/utils/prompts/blockUtils';
 import { getFolderTitle } from '@/utils/prompts/folderUtils';
+import { trackEvent, EVENTS } from '@/utils/amplitude';
 
 // Import the new global search hook
 import { useGlobalTemplateSearch } from '@/hooks/prompts/utils/useGlobalTemplateSearch';
@@ -100,6 +101,10 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
   useEffect(() => {
     setGlobalSearchQuery(searchQuery);
   }, [searchQuery, setGlobalSearchQuery]);
+
+  useEffect(() => {
+    trackEvent(EVENTS.TEMPLATE_SEARCH, { query: searchQuery });
+  }, [searchQuery]);
 
   // Navigation hook for combined user + organization folders
   const navigation = useBreadcrumbNavigation({

--- a/src/components/prompts/folders/FolderItem.tsx
+++ b/src/components/prompts/folders/FolderItem.tsx
@@ -10,6 +10,7 @@ import { Organization } from '@/types/organizations';
 import { TemplateItem } from '@/components/prompts/templates/TemplateItem';
 import { EmptyMessage } from '@/components/panels/TemplatesPanel/EmptyMessage';
 import { getMessage } from '@/core/utils/i18n';
+import { trackEvent, EVENTS } from '@/utils/amplitude';
 
 const folderIconColors = {
   user: 'jd-text-gray-600',
@@ -115,6 +116,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
 
   // Handle folder click
   const handleFolderClick = useCallback(() => {
+    trackEvent(EVENTS.TEMPLATE_FOLDER_OPENED, { folder_id: folder.id, type });
     if (enableNavigation && onNavigateToFolder) {
       onNavigateToFolder(folder);
     } else if (onToggleExpand) {
@@ -122,7 +124,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
     } else {
       setLocalExpanded(!localExpanded);
     }
-  }, [enableNavigation, onNavigateToFolder, onToggleExpand, folder.id, localExpanded]);
+  }, [enableNavigation, onNavigateToFolder, onToggleExpand, folder.id, localExpanded, type]);
 
   // Handle pin toggle with proper state
   const handleTogglePin = useCallback((e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- send `TEMPLATE_SEARCH` events from template panels
- log `TEMPLATE_FOLDER_OPENED` when clicking a folder

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6861839017d88325a5707a849652c389