### PR TITLE
Track chat session lifecycle

### DIFF
--- a/src/extension/content/applicationInitializer.ts
+++ b/src/extension/content/applicationInitializer.ts
@@ -8,6 +8,7 @@ import { eventManager } from '@/core/events/EventManager';
 import { errorReporter } from '@/core/errors/ErrorReporter';
 import { AppError, ErrorCode } from '@/core/errors/AppError';
 import Main from '@/components/Main';
+import { trackEvent, EVENTS } from '@/utils/amplitude';
 
 /**
  * Main application initializer
@@ -61,9 +62,10 @@ export class AppInitializer {
       if (!servicesInitialized) {
         throw new Error('Failed to initialize services');
       }
-      
+
       
       this.isInitialized = true;
+      trackEvent(EVENTS.CHAT_SESSION_STARTED);
       console.log('✅ Archimind application initialized successfully');
       return true;
     } catch (error) {
@@ -119,9 +121,11 @@ export class AppInitializer {
    */
   public cleanup(): void {
     if (!this.isInitialized) return;
-    
+
     console.log('🧹 Cleaning up Archimind application...');
-    
+
+    trackEvent(EVENTS.CHAT_SESSION_ENDED);
+
     // Remove UI components
     componentInjector.removeAll();
     

--- a/src/utils/amplitude/index.ts
+++ b/src/utils/amplitude/index.ts
@@ -113,6 +113,10 @@ export const EVENTS = {
   USAGE_STATISTICS_VIEWED: 'Usage Statistics Viewed',
   CONVERSATION_CAPTURED: 'Conversation Captured',
   CONVERSATION_ANALYZED: 'Conversation Analyzed',
+
+  // Chat session events
+  CHAT_SESSION_STARTED: 'Chat Session Started',
+  CHAT_SESSION_ENDED: 'Chat Session Ended',
 };
 
 /**


### PR DESCRIPTION
## Summary
- define constants to track chat sessions
- send `CHAT_SESSION_STARTED` after initialization
- send `CHAT_SESSION_ENDED` when cleaning up

## Testing
- `npm run lint` *(fails: 538 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68618394a2688325b4d5429e3659a580