### PR TITLE
Fix block publish filter

### DIFF
--- a/src/components/common/AddBlockButton.tsx
+++ b/src/components/common/AddBlockButton.tsx
@@ -122,7 +122,7 @@ export const AddBlockButton: React.FC<AddBlockButtonProps> = ({
         })}
         
         {/* Existing Blocks Section */}
-        {Object.entries(availableBlocks).some(([_, blocks]) => blocks.length > 0) && (
+        {Object.entries(availableBlocks).some(([_type, blocks]) => blocks.length > 0) && (
           <>
             <DropdownMenuSeparator />
             <DropdownMenuLabel className="jd-text-xs jd-text-muted-foreground">

--- a/src/components/dialogs/BaseDialog.tsx
+++ b/src/components/dialogs/BaseDialog.tsx
@@ -1,6 +1,5 @@
 // src/components/dialogs/BaseDialog.tsx
 import React, { useRef, useEffect, useState } from 'react';
-import { useDialogFocusGuard } from '@/core/utils/shadowDomFocusManager';
 import { getMessage } from '@/core/utils/i18n';
 import { cn } from "@/core/utils/classNames";
 import { X } from "lucide-react";
@@ -39,8 +38,6 @@ export const BaseDialog: React.FC<BaseDialogProps> = ({
   // All hooks must be called unconditionally at the top
   const dialogRef = useRef<HTMLDivElement>(null);
   const [mounted, setMounted] = useState(false);
-  // Keep focus trapped inside the dialog when open
-  //useDialogFocusGuard(dialogRef.current, open);
   
   // Setup effect for mounting state
   useEffect(() => {

--- a/src/components/dialogs/DialogRegistry.ts
+++ b/src/components/dialogs/DialogRegistry.ts
@@ -1,4 +1,5 @@
 // src/components/dialogs/DialogRegistry.ts
+/* eslint-disable @typescript-eslint/no-explicit-any */
 // Define dialog types
 export const DIALOG_TYPES = {
   // Existing dialog types

--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -264,7 +264,7 @@ export const InsertBlockDialog: React.FC = () => {
       blocksApi.getBlocks().then(res => {
         if (res.success) {
           const published = res.data.filter(
-            b => (b as any).published === true || (b as any).is_published === true
+            b => (b as any).published || (b as any).is_published
           );
           setBlocks(published);
         } else {
@@ -353,7 +353,7 @@ const filteredBlocks = blocks.filter(b => {
   const term = search.toLowerCase();
   const matchesSearch = title.toLowerCase().includes(term) || content.toLowerCase().includes(term);
   const matchesType = selectedTypeFilter === 'all' || b.type === selectedTypeFilter;
-  const isPublished = (b as any).published === true || (b as any).is_published === true;
+  const isPublished = (b as any).published || (b as any).is_published;
   return matchesSearch && matchesType && isPublished;
 });
 

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/MetadataSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/MetadataSection.tsx
@@ -91,7 +91,7 @@ export const MetadataSection: React.FC<MetadataSectionProps> = ({
     (Object.keys(METADATA_CONFIGS) as MetadataType[]).forEach(type => {
       const allBlocks = availableMetadataBlocks[type] || [];
       const published = allBlocks.filter(
-        b => (b as any).published === true || (b as any).is_published === true
+        b => (b as any).published || (b as any).is_published
       );
 
       const selectedIds: number[] = [];

--- a/src/components/prompts/blocks/quick-selector/useBlocks.ts
+++ b/src/components/prompts/blocks/quick-selector/useBlocks.ts
@@ -10,7 +10,7 @@ export function useBlocks() {
     blocksApi.getBlocks().then(res => {
       if (res.success) {
         const published = res.data.filter(
-          b => (b as any).published === true || (b as any).is_published === true
+          b => (b as any).published || (b as any).is_published
         );
         setBlocks(published);
       }


### PR DESCRIPTION
## Summary
- show published blocks that use `is_published` or `published` flags
- suppress `no-explicit-any` linter rule in dialog registry
- remove unused import in `BaseDialog`
- fix unused variable warning in `AddBlockButton`

## Testing
- `npm run lint` *(fails: 534 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_686285720694832590acb9883417cc44