### PR TITLE
Add missing i18n strings for TemplatesPanel

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1966,5 +1966,32 @@
   "shortcutTipSuffix": { "message": "in the prompt area to open this block selector instantly.", "description": "Shortcut help suffix" },
   "titleOptional": { "message": "Title (optional)", "description": "Label for optional title field" },
   "usingShortcut": { "message": "Using //j Shortcut", "description": "Title for shortcut instructions dialog" },
-  "type": { "message": "Type", "description": "Label for block type field" }
+  "type": { "message": "Type", "description": "Label for block type field" },
+
+  "searchTemplatesAndFolders": {
+    "message": "Search templates and folders...",
+    "description": "Placeholder for template and folder search"
+  },
+  "searchResults": {
+    "message": "Search Results",
+    "description": "Header for search results section"
+  },
+  "clear": { "message": "Clear", "description": "Button text to clear search" },
+  "pinnedTemplates": {
+    "message": "Pinned Templates",
+    "description": "Pinned templates section title"
+  },
+  "noPinnedTemplates": {
+    "message": "No pinned templates. Pin your favorites for quick access.",
+    "description": "Empty state message when no pinned templates"
+  },
+  "folderEmpty": {
+    "message": "This folder is empty",
+    "description": "Message shown when folder has no items"
+  },
+  "noResultsForQuery": {
+    "message": "No results found for \"$QUERY$\"",
+    "description": "Message when search yields no results",
+    "placeholders": { "query": { "content": "$1", "example": "sales" } }
+  }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1948,5 +1948,32 @@
   "shortcutTipSuffix": { "message": "dans la zone de saisie pour ouvrir ce sélecteur de blocs instantanément.", "description": "Suffixe de l'aide sur le raccourci" },
   "titleOptional": { "message": "Titre (optionnel)", "description": "Libellé pour le champ de titre optionnel" },
   "usingShortcut": { "message": "Utiliser le raccourci //j", "description": "Titre de la boîte de dialogue d'aide sur le raccourci" },
-  "type": { "message": "Type", "description": "Libellé du type de bloc" }
+  "type": { "message": "Type", "description": "Libellé du type de bloc" },
+
+  "searchTemplatesAndFolders": {
+    "message": "Rechercher des templates et des dossiers...",
+    "description": "Placeholder pour la recherche de templates et dossiers"
+  },
+  "searchResults": {
+    "message": "Résultats de recherche",
+    "description": "En-tête pour la section des résultats de recherche"
+  },
+  "clear": { "message": "Effacer", "description": "Texte du bouton pour effacer la recherche" },
+  "pinnedTemplates": {
+    "message": "Templates épinglés",
+    "description": "Titre de section Templates épinglés"
+  },
+  "noPinnedTemplates": {
+    "message": "Aucun template épinglé. Épinglez vos favoris pour y accéder rapidement.",
+    "description": "Message affiché lorsqu'aucun template n'est épinglé"
+  },
+  "folderEmpty": {
+    "message": "Ce dossier est vide",
+    "description": "Message affiché lorsqu'un dossier est vide"
+  },
+  "noResultsForQuery": {
+    "message": "Aucun résultat trouvé pour \"$QUERY$\"",
+    "description": "Message affiché lorsqu'aucun résultat n'est trouvé",
+    "placeholders": { "query": { "content": "$1", "example": "vente" } }
+  }
 }

--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -314,7 +314,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
           return { success: true, folder: result };
         } catch (error) {
           console.error('Error creating folder:', error);
-          return { success: false, error: 'Failed to create folder' };
+          return { success: false, error: getMessage('failedToCreateFolder', undefined, 'Failed to create folder') };
         }
       },
       onFolderCreated: async (folder: TemplateFolder) => {
@@ -422,10 +422,14 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
               {displayItems.items.length === 0 ? (
                 <EmptyMessage>
                   {searchQuery.trim()
-                    ? `No results found for "${searchQuery}"`
+                    ? getMessage(
+                        'noResultsForQuery',
+                        [searchQuery],
+                        `No results found for "${searchQuery}"`
+                      )
                     : navigation.isAtRoot
                       ? getMessage('noTemplates', undefined, 'No templates yet. Create your first template!')
-                      : 'This folder is empty'
+                      : getMessage('folderEmpty', undefined, 'This folder is empty')
                   }
                 </EmptyMessage>
               ) : (


### PR DESCRIPTION
## Summary
- add missing TemplatePanel strings to English and French locale files
- replace hard-coded strings in TemplatesPanel with i18n lookups

## Testing
- `npm run lint` *(fails: 552 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6862a5a8cd488325b9e48c97fab0cda2