### PR TITLE
Fix line breaks in create block dialog

### DIFF
--- a/src/components/dialogs/prompts/CreateBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateBlockDialog/index.tsx
@@ -177,6 +177,15 @@ export const CreateBlockDialog: React.FC = () => {
             placeholder={getMessage('enterBlockName', undefined, 'Enter block name')}
             className={cn("jd-w-full", validationErrors.name && "jd-border-red-500")}
             autoFocus
+            onKeyDown={(e) => {
+              e.stopPropagation();
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                return;
+              }
+            }}
+            onKeyPress={(e) => e.stopPropagation()}
+            onKeyUp={(e) => e.stopPropagation()}
           />
           {validationErrors.name ? (
             <p className="jd-text-xs jd-text-red-500 jd-mt-1">{validationErrors.name}</p>
@@ -190,8 +199,8 @@ export const CreateBlockDialog: React.FC = () => {
         {/* Block Content */}
         <div>
           <label className="jd-text-sm jd-font-medium jd-mb-2 jd-block">{getMessage('blockContent', undefined, 'Block Content')}</label>
-          <Textarea 
-            value={content} 
+          <Textarea
+            value={content}
             onChange={(e) => {
               setContent(e.target.value);
               if (validationErrors.content) {
@@ -201,6 +210,15 @@ export const CreateBlockDialog: React.FC = () => {
             placeholder={getMessage('enterBlockContent', undefined, 'Enter block content...')}
             className={cn("jd-w-full jd-min-h-[120px] jd-resize-none", validationErrors.content && "jd-border-red-500")}
             rows={6}
+            onKeyDown={(e) => {
+              e.stopPropagation();
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                return;
+              }
+            }}
+            onKeyPress={(e) => e.stopPropagation()}
+            onKeyUp={(e) => e.stopPropagation()}
           />
           {validationErrors.content && (
             <p className="jd-text-xs jd-text-red-500 jd-mt-1">{validationErrors.content}</p>
@@ -224,12 +242,21 @@ export const CreateBlockDialog: React.FC = () => {
           <label className="jd-text-sm jd-font-medium jd-mb-2 jd-block">
             {getMessage('templateDescription', undefined, 'Description (optional)')}
           </label>
-          <Textarea 
-            value={description} 
+          <Textarea
+            value={description}
             onChange={(e) => setDescription(e.target.value)}
             placeholder={getMessage('blockDescriptionPlaceholder', undefined, 'Enter block description...')}
             className="jd-w-full jd-resize-none"
             rows={3}
+            onKeyDown={(e) => {
+              e.stopPropagation();
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                return;
+              }
+            }}
+            onKeyPress={(e) => e.stopPropagation()}
+            onKeyUp={(e) => e.stopPropagation()}
           />
         </div>
         


### PR DESCRIPTION
## Summary
- stop Enter events from propagating up the page in `CreateBlockDialog`
- allow textarea and input fields to accept line breaks without host page interference

## Testing
- `npm run lint` *(fails: 552 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6862a64b8fcc8325aaadcdb939d2fc06