### PR TITLE
Fix loading of metadata blocks when template dialog opens

### DIFF
--- a/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
@@ -108,7 +108,7 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
     availableMetadataBlocks,
     blockContentCache,
     addNewBlock
-  } = useBlockManager({ metadata, content });
+  } = useBlockManager({ metadata, content, enabled: isOpen });
 
   const contextValue = React.useMemo(
     () => ({

--- a/src/hooks/prompts/editors/useBlockManager.ts
+++ b/src/hooks/prompts/editors/useBlockManager.ts
@@ -28,9 +28,16 @@ interface UseBlockManagerReturn {
 interface UseBlockManagerProps {
   metadata?: PromptMetadata;
   content?: string;
+  /**
+   * When false, block loading is skipped. This allows dialogs to
+   * postpone fetching data until they are actually opened.
+   */
+  enabled?: boolean;
 }
 
 export function useBlockManager(props?: UseBlockManagerProps): UseBlockManagerReturn {
+  const { enabled = true } = props || {};
+
   const [isLoading, setIsLoading] = useState(true);
   const [availableMetadataBlocks, setAvailableMetadataBlocks] = useState<Record<MetadataType, Block[]>>({} as Record<MetadataType, Block[]>);
   const [availableBlocksByType, setAvailableBlocksByType] = useState<Record<BlockType, Block[]>>({} as Record<BlockType, Block[]>);
@@ -82,10 +89,11 @@ export function useBlockManager(props?: UseBlockManagerProps): UseBlockManagerRe
     }
   }, []);
 
-  // Initial fetch
+  // Initial fetch and re-fetch when enabled becomes true
   useEffect(() => {
+    if (!enabled) return;
     fetchBlocks();
-  }, [fetchBlocks]);
+  }, [fetchBlocks, enabled]);
 
   // Add a new block to the cache
   const addNewBlock = useCallback((block: Block) => {


### PR DESCRIPTION
## Summary
- add optional `enabled` flag to the `useBlockManager` hook
- trigger block loading only when the dialog is open
- update `TemplateEditorDialog` to pass `isOpen` to `useBlockManager`

## Testing
- `npx eslint .` *(fails: could not reach registry)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_b_6862ac6ac5d88325913cb88e473e6195