### PR TITLE
Add block update/delete options in InsertBlockDialog

### DIFF
--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -23,6 +23,7 @@ import {
 import EditablePromptPreview from '@/components/prompts/EditablePromptPreview';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
 import { useDialogActions } from '@/hooks/dialogs/useDialogActions';
+import { useBlockActions } from '@/hooks/prompts/actions/useBlockActions';
 import { insertIntoPromptArea } from '@/utils/templates/placeholderUtils';
 import { 
   DndContext, 
@@ -241,6 +242,27 @@ export const InsertBlockDialog: React.FC = () => {
   const [blockContents, setBlockContents] = useState<Record<number, string>>({});
   const isDark = useThemeDetector();
   const { openCreateBlock } = useDialogActions();
+  const { editBlock, deleteBlock } = useBlockActions({
+    onBlockUpdated: (updated) => {
+      setBlocks(prev => prev.map(b => (b.id === updated.id ? updated : b)));
+      setSelectedBlocks(prev => prev.map(b => (b.id === updated.id ? updated : b)));
+      setBlockContents(prev => {
+        if (prev.hasOwnProperty(updated.id)) {
+          const content = typeof updated.content === 'string' ? updated.content : updated.content?.en || '';
+          return { ...prev, [updated.id]: content };
+        }
+        return prev;
+      });
+    },
+    onBlockDeleted: (id) => {
+      setBlocks(prev => prev.filter(b => b.id !== id));
+      setSelectedBlocks(prev => prev.filter(b => b.id !== id));
+      setBlockContents(prev => {
+        const { [id]: _removed, ...rest } = prev;
+        return rest;
+      });
+    }
+  });
 
   // Drag & Drop sensors
   const sensors = useSensors(
@@ -345,6 +367,14 @@ export const InsertBlockDialog: React.FC = () => {
     setBlocks(prev => [newBlock, ...prev]);
     addBlock(newBlock);
     setShowInlineCreator(false);
+  };
+
+  const handleEditBlock = (block: Block) => {
+    editBlock(block);
+  };
+
+  const handleDeleteBlock = (block: Block) => {
+    deleteBlock(block);
   };
 
 // Filter blocks based on search, type, and published status
@@ -529,6 +559,8 @@ const filteredBlocks = blocks.filter(b => {
                     block={block}
                     isDark={isDark}
                     onAdd={addBlock}
+                    onEdit={handleEditBlock}
+                    onDelete={handleDeleteBlock}
                     isSelected={!!selectedBlocks.find(b => b.id === block.id)}
                     onRemove={removeBlock}
                   />


### PR DESCRIPTION
## Summary
- allow editing or deleting blocks from InsertBlockDialog
- hook into `useBlockActions` to update dialog state
- forward edit/delete callbacks to `AvailableBlockCard`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6866591ed9d48325aa159efdee5b0ca0