### PR TITLE
Update AdvancedEditor layout

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/MetadataSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/MetadataSection.tsx
@@ -2,7 +2,6 @@
 import React, { useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import {
-  Plus,
   ChevronDown,
   ChevronUp,
   User,
@@ -30,7 +29,6 @@ import {
 } from '@/types/prompts/metadata';
 import { Block } from '@/types/prompts/blocks';
 import { useTemplateEditor } from '../../TemplateEditorDialog/TemplateEditorContext';
-import { addSecondaryMetadata, removeSecondaryMetadata } from '@/utils/prompts/metadataUtils';
 
 const METADATA_ICONS: Record<MetadataType, React.ComponentType<any>> = {
   role: User,
@@ -59,29 +57,11 @@ export const MetadataSection: React.FC<MetadataSectionProps> = ({
     setMetadata,
     expandedMetadata,
     toggleExpandedMetadata,
-    activeSecondaryMetadata,
     metadataCollapsed,
     setMetadataCollapsed,
     secondaryMetadataCollapsed,
     setSecondaryMetadataCollapsed
   } = useTemplateEditor();
-
-
-  const handleAddSecondaryMetadata = useCallback(
-    (type: MetadataType) => {
-      setMetadata(prev => addSecondaryMetadata(prev, type));
-      if (!expandedMetadata.has(type)) toggleExpandedMetadata(type);
-    },
-    [setMetadata, expandedMetadata, toggleExpandedMetadata]
-  );
-
-  const handleRemoveSecondaryMetadata = useCallback(
-    (type: MetadataType) => {
-      setMetadata(prev => removeSecondaryMetadata(prev, type));
-      if (expandedMetadata.has(type)) toggleExpandedMetadata(type);
-    },
-    [setMetadata, expandedMetadata, toggleExpandedMetadata]
-  );
   
   const isDarkMode = useThemeDetector();
 
@@ -124,8 +104,7 @@ export const MetadataSection: React.FC<MetadataSectionProps> = ({
 
   const renderCards = (
     types: MetadataType[],
-    isPrimary: boolean,
-    onRemove?: (t: MetadataType) => void
+    isPrimary: boolean
   ) => (
     <div
       className={cn(
@@ -143,37 +122,9 @@ export const MetadataSection: React.FC<MetadataSectionProps> = ({
             expanded={expandedMetadata.has(type)}
             isPrimary={isPrimary}
             onToggle={() => toggleExpandedMetadata(type)}
-            onRemove={onRemove ? () => onRemove(type) : undefined}
           />
         </div>
       ))}
-    </div>
-  );
-
-  const renderAddButtons = () => (
-    <div className="jd-flex jd-flex-wrap jd-gap-2">
-      {SECONDARY_METADATA.filter(t => !activeSecondaryMetadata.has(t)).map(type => {
-        const Icon = METADATA_ICONS[type];
-        const config = METADATA_CONFIGS[type];
-        return (
-          <Button
-            key={type}
-            variant="outline"
-            size="sm"
-            onClick={() => handleAddSecondaryMetadata(type)}
-            className={cn(
-              'jd-flex jd-items-center jd-gap-1 jd-text-xs',
-              'jd-transition-all jd-duration-300',
-              'hover:jd-scale-105 hover:jd-shadow-md',
-              isDarkMode ? 'jd-bg-gray-800/50 hover:jd-bg-gray-700/50' : 'jd-bg-white/70 hover:jd-bg-white/90'
-            )}
-          >
-            <Plus className="jd-h-3 jd-w-3" />
-            <Icon className="jd-h-3 jd-w-3" />
-            {config.label}
-          </Button>
-        );
-      })}
     </div>
   );
 
@@ -213,13 +164,7 @@ export const MetadataSection: React.FC<MetadataSectionProps> = ({
             </Button>
           </div>
 
-          {!secondaryMetadataCollapsed && (
-            <>
-              {activeSecondaryMetadata.size > 0 &&
-                renderCards(Array.from(activeSecondaryMetadata), false, handleRemoveSecondaryMetadata)}
-              {renderAddButtons()}
-            </>
-          )}
+          {!secondaryMetadataCollapsed && renderCards(SECONDARY_METADATA, false)}
         </div>
       )}
     </>

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
@@ -1,15 +1,30 @@
 // src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx - Fixed Version
-import React from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { cn } from '@/core/utils/classNames';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
 import { MetadataSection } from './MetadataSection';
 import { useTemplateEditor } from '../../TemplateEditorDialog/TemplateEditorContext';
 import TemplatePreview from '@/components/prompts/TemplatePreview';
 import { getMessage } from '@/core/utils/i18n';
+import {
+  convertMetadataToVirtualBlocks,
+  extractPlaceholdersFromBlocks
+} from '@/utils/templates/enhancedPreviewUtils';
+import {
+  ResizablePanelGroup,
+  ResizablePanel,
+  ResizableHandle
+} from '@/components/ui/resizable';
+import { PlaceholderPanel } from '../BasicEditor/PlaceholderPanel';
 
 interface AdvancedEditorProps {
   mode?: 'create' | 'customize';
   isProcessing?: boolean;
+}
+
+interface Placeholder {
+  key: string;
+  value: string;
 }
 
 export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
@@ -19,11 +34,97 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   const {
     metadata,
     content,
+    setContent,
     availableMetadataBlocks,
     blockContentCache
   } = useTemplateEditor();
-  
+
   const isDarkMode = useThemeDetector();
+
+  // ----- Placeholder logic (only used in customize mode) -----
+  const originalContentRef = useRef(content);
+  const originalBlockCacheRef = useRef(blockContentCache);
+
+  useEffect(() => {
+    originalBlockCacheRef.current = blockContentCache;
+  }, [blockContentCache]);
+
+  const getPlaceholderKeys = useCallback((): string[] => {
+    const base = mode === 'customize' ? originalContentRef.current : content;
+    const fromContent = (base.match(/\[([^\]]+)\]/g) || []).map(m => m.slice(1, -1));
+
+    const virtualBlocks = convertMetadataToVirtualBlocks(metadata, blockContentCache);
+    const fromBlocks = extractPlaceholdersFromBlocks(virtualBlocks);
+
+    const keys = new Set<string>();
+    fromContent.forEach(key => keys.add(key));
+    fromBlocks.forEach(({ key }) => keys.add(key));
+
+    return Array.from(keys);
+  }, [metadata, blockContentCache, mode, content]);
+
+  const [placeholders, setPlaceholders] = useState<Placeholder[]>(() => {
+    if (mode === 'customize') {
+      const keys = getPlaceholderKeys();
+      return keys.map(key => ({ key, value: '' }));
+    }
+    return [];
+  });
+
+  useEffect(() => {
+    if (mode === 'customize') {
+      const keys = getPlaceholderKeys();
+      setPlaceholders(prev =>
+        keys.map(k => {
+          const existing = prev.find(p => p.key === k);
+          return { key: k, value: existing?.value || '' };
+        })
+      );
+    }
+  }, [getPlaceholderKeys, mode]);
+
+  const computeContent = useCallback(
+    (list: Placeholder[]) => {
+      let result = originalContentRef.current;
+      const updatedCache: Record<number, string> = { ...originalBlockCacheRef.current };
+
+      list.forEach(({ key, value }) => {
+        if (!value.trim()) return;
+        const regex = new RegExp(`\\[${key.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}\\]`, 'g');
+        result = result.replace(regex, value);
+
+        Object.keys(updatedCache).forEach(id => {
+          updatedCache[parseInt(id, 10)] = updatedCache[parseInt(id, 10)].replace(regex, value);
+        });
+      });
+
+      return { content: result, cache: updatedCache };
+    },
+    []
+  );
+
+  const computed = React.useMemo(() => computeContent(placeholders), [computeContent, placeholders]);
+  const previewContent = computed.content;
+  const previewCache = computed.cache;
+
+  useEffect(() => {
+    if (mode === 'customize') {
+      // keep content synced so dialog completion uses replaced version
+      setContent(previewContent);
+    }
+  }, [previewContent, mode, setContent]);
+
+  const updatePlaceholder = useCallback((index: number, value: string) => {
+    setPlaceholders(prev => {
+      const updated = [...prev];
+      updated[index] = { ...updated[index], value };
+      return updated;
+    });
+  }, []);
+
+  const resetPlaceholders = useCallback(() => {
+    setPlaceholders(prev => prev.map(p => ({ ...p, value: '' })));
+  }, []);
 
   if (isProcessing) {
     return (
@@ -55,25 +156,51 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
           />
         </div>
 
-        {/* 2. PREVIEW SECTION - Read Only */}
+        {/* 2. PREVIEW SECTION - Read Only or with placeholders */}
         <div className="jd-flex-shrink-0 jd-mb-6">
           <div className="jd-space-y-3">
             <h3 className="jd-text-lg jd-font-semibold jd-flex jd-items-center jd-gap-2">
               <span className="jd-w-2 jd-h-6 jd-bg-gradient-to-b jd-from-blue-500 jd-to-purple-600 jd-rounded-full"></span>
               {getMessage('completePreview', undefined, 'Complete Preview')}
             </h3>
-            
-            <div className="jd-border jd-rounded-lg jd-p-1 jd-bg-gradient-to-r jd-from-blue-500/10 jd-to-purple-500/10 jd-border-blue-200 jd-dark:jd-border-blue-700">
-              <div className="jd-max-h-[400px] jd-overflow-y-auto">
-                <TemplatePreview
-                  metadata={metadata}
-                  content={content}
-                  blockContentCache={blockContentCache}
-                  isDarkMode={isDarkMode}
-                  className="jd-min-h-0"
-                />
+
+            {mode === 'customize' ? (
+              <ResizablePanelGroup direction="horizontal" className="jd-h-[400px] jd-w-full">
+                <ResizablePanel defaultSize={30} minSize={20} maxSize={50}>
+                  <PlaceholderPanel
+                    placeholders={placeholders}
+                    onUpdatePlaceholder={updatePlaceholder}
+                    onResetPlaceholders={resetPlaceholders}
+                  />
+                </ResizablePanel>
+                <ResizableHandle withHandle />
+                <ResizablePanel defaultSize={70} minSize={40}>
+                  <div className="jd-h-full jd-border jd-rounded-md jd-p-1 jd-bg-gradient-to-r jd-from-blue-500/10 jd-to-purple-500/10 jd-border-blue-200 jd-dark:jd-border-blue-700 jd-flex jd-flex-col jd-min-h-0 jd-overflow-hidden">
+                    <div className="jd-max-h-full jd-overflow-y-auto jd-flex-1 jd-min-h-0">
+                      <TemplatePreview
+                        metadata={metadata}
+                        content={previewContent}
+                        blockContentCache={previewCache}
+                        isDarkMode={isDarkMode}
+                        className="jd-min-h-0"
+                      />
+                    </div>
+                  </div>
+                </ResizablePanel>
+              </ResizablePanelGroup>
+            ) : (
+              <div className="jd-border jd-rounded-lg jd-p-1 jd-bg-gradient-to-r jd-from-blue-500/10 jd-to-purple-500/10 jd-border-blue-200 jd-dark:jd-border-blue-700">
+                <div className="jd-max-h-[400px] jd-overflow-y-auto">
+                  <TemplatePreview
+                    metadata={metadata}
+                    content={content}
+                    blockContentCache={blockContentCache}
+                    isDarkMode={isDarkMode}
+                    className="jd-min-h-0"
+                  />
+                </div>
               </div>
-            </div>
+            )}
           </div>
         </div>
 

--- a/src/components/prompts/blocks/MetadataCard.tsx
+++ b/src/components/prompts/blocks/MetadataCard.tsx
@@ -17,7 +17,7 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select';
-import { Trash2, ChevronUp, ChevronDown, Plus } from 'lucide-react';
+import { Trash2, ChevronUp, ChevronDown, Plus, Check } from 'lucide-react';
 import { getMessage } from '@/core/utils/i18n';
 import {
   DropdownMenu,
@@ -82,6 +82,15 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
     }
     return [];
   }, [metadata, type]);
+
+  const assigned = React.useMemo(() => {
+    if (!isMultipleMetadataType(type)) {
+      const val = metadata.values?.[type as SingleMetadataType];
+      const blockId = metadata[type as SingleMetadataType];
+      return (!!blockId && blockId !== 0) || !!val?.trim();
+    }
+    return items.length > 0;
+  }, [metadata, items, type]);
 
   const [addMenuOpen, setAddMenuOpen] = React.useState(false);
 
@@ -207,10 +216,12 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
             <div className={cn('jd-p-1.5 jd-rounded-md', iconColors)}>
               <Icon className="jd-h-4 jd-w-4" />
             </div>
-            <span className={cn('jd-font-black', getBlockTextColors(config.blockType, isDarkMode))}>
-              {config.label}
-              {isMultipleMetadataType(type) && items.length > 0 ? ` (${items.length})` : ''}
-            </span>
+            {expanded && (
+              <span className={cn('jd-font-black', getBlockTextColors(config.blockType, isDarkMode))}>
+                {config.label}
+                {isMultipleMetadataType(type) && items.length > 0 ? ` (${items.length})` : ''}
+              </span>
+            )}
           </div>
           <div className="jd-flex jd-items-center jd-gap-1" onClick={stopPropagation}>
             {!isPrimary && onRemove && (


### PR DESCRIPTION
## Summary
- add placeholder panel support to AdvancedEditor
- show all metadata cards in AdvancedEditor sections
- tweak metadata card collapsed state

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68668776a7d0832590b3ef905fd0d14e