### PR TITLE
Fix tutorials dialog display

### DIFF
--- a/src/components/dialogs/DialogProvider.tsx
+++ b/src/components/dialogs/DialogProvider.tsx
@@ -13,6 +13,8 @@ import { SettingsDialog } from './settings/SettingsDialog';
 import { ConfirmationDialog } from './common/ConfirmationDialog';
 import { EnhancedStatsDialog } from './analytics/EnhancedStatsDialog';
 import { BrowseMoreFoldersDialog } from './prompts/BrowseMoreFoldersDialog';
+import { TutorialsDialog } from './tutorials/TutorialsDialog';
+import { TutorialVideoDialog } from './tutorials/TutorialVideoDialog';
 
 /**
  * Main dialog provider that includes all dialog components
@@ -65,6 +67,8 @@ export const DialogProvider: React.FC<{children: React.ReactNode}> = ({ children
       <ConfirmationDialog />
       <EnhancedStatsDialog />
       <BrowseMoreFoldersDialog />
+      <TutorialsDialog />
+      <TutorialVideoDialog />
       {/* Place the customize dialog last so it stacks above others */}
       <CustomizeTemplateDialog />
     </DialogManagerProvider>


### PR DESCRIPTION
## Summary
- register tutorial dialogs inside `DialogProvider`

## Testing
- `npm run lint` *(fails: 523 errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6867cd651aa883258b23cbaf29acf551