### PR TITLE
Support free text segments in template metadata

### DIFF
--- a/src/hooks/dialogs/useCreateTemplateDialog.ts
+++ b/src/hooks/dialogs/useCreateTemplateDialog.ts
@@ -29,7 +29,10 @@ export function useCreateTemplateDialog() {
         content: content, // Use the base content directly
         description: baseHook.description?.trim(),
         folder_id: baseHook.selectedFolderId ? parseInt(baseHook.selectedFolderId, 10) : undefined,
-        metadata: metadataToBlockMapping(metadata)
+        metadata: {
+          ...metadataToBlockMapping(metadata),
+          ...(metadata.additional_text ? { additional_text: metadata.additional_text } : {})
+        }
       };
             
       const currentTemplate = data?.template;

--- a/src/types/prompts/metadata.ts
+++ b/src/types/prompts/metadata.ts
@@ -27,9 +27,16 @@ export interface PromptMetadata {
   // Multiple value metadata (arrays)
   constraint?: MetadataItem[];
   example?: MetadataItem[];
-  
+
   // Custom values for single metadata types
   values?: Record<SingleMetadataType, string>;
+
+  /**
+   * Additional free text to insert after specific metadata blocks.
+   * Keys correspond to metadata types (e.g. "context", "constraint") or
+   * special positions like "intro" or "outro".
+   */
+  additional_text?: Record<string, string>;
 }
 
 // Configuration for each metadata type
@@ -115,7 +122,8 @@ export const ALL_METADATA_TYPES: MetadataType[] = [...PRIMARY_METADATA, ...SECON
 export const DEFAULT_METADATA: PromptMetadata = {
   constraint: [],
   example: [],
-  values: {} as Record<SingleMetadataType, string>
+  values: {} as Record<SingleMetadataType, string>,
+  additional_text: {}
 };
 
 // Helper functions

--- a/src/types/prompts/templates.ts
+++ b/src/types/prompts/templates.ts
@@ -9,6 +9,7 @@ export interface TemplateMetadata {
   audience?: number;
   example?: number[];
   constraint?: number[];
+  additional_text?: Record<string, string>;
 }
 
 export interface Template {

--- a/src/utils/prompts/metadataUtils.ts
+++ b/src/utils/prompts/metadataUtils.ts
@@ -31,6 +31,7 @@ export function createMetadata(initial?: Partial<PromptMetadata>): PromptMetadat
   return {
     ...DEFAULT_METADATA,
     values: {},
+    additional_text: {},
     ...initial
   };
 }
@@ -43,7 +44,10 @@ export function cloneMetadata(metadata: PromptMetadata): PromptMetadata {
     ...metadata,
     values: { ...metadata.values },
     constraint: metadata.constraint?.map(item => ({ ...item })),
-    example: metadata.example?.map(item => ({ ...item }))
+    example: metadata.example?.map(item => ({ ...item })),
+    additional_text: metadata.additional_text
+      ? { ...metadata.additional_text }
+      : {}
   };
 }
 
@@ -569,6 +573,11 @@ export function parseTemplateMetadata(rawMetadata: any): PromptMetadata {
     parsed.values = { ...parsed.values, ...rawMetadata.values };
   }
 
-  
+  // Handle additional text
+  if (rawMetadata.additional_text && typeof rawMetadata.additional_text === 'object') {
+    parsed.additional_text = { ...rawMetadata.additional_text };
+  }
+
+
   return parsed;
 }

--- a/src/utils/templates/enhancedPreviewUtils.ts
+++ b/src/utils/templates/enhancedPreviewUtils.ts
@@ -21,6 +21,17 @@ export function convertMetadataToVirtualBlocks(
   blockContentCache: Record<number, string> = {}
 ): VirtualBlock[] {
   const virtualBlocks: VirtualBlock[] = [];
+  const additional = metadata.additional_text || {};
+
+  // Intro text before any metadata
+  if (additional.intro) {
+    virtualBlocks.push({
+      id: 'additional_intro',
+      type: 'custom',
+      content: additional.intro.trim(),
+      isFromMetadata: false
+    });
+  }
 
   // Convert single metadata types (role, context, goal, etc.)
   const singleTypes: SingleMetadataType[] = [
@@ -49,6 +60,17 @@ export function convertMetadataToVirtualBlocks(
         originalBlockId: blockId && blockId !== 0 ? blockId : undefined,
         metadataType: type
       });
+
+      // Add additional text immediately after this block if present
+      const extra = additional[type];
+      if (extra) {
+        virtualBlocks.push({
+          id: `additional_${type}_${index}`,
+          type: 'custom',
+          content: extra.trim(),
+          isFromMetadata: false
+        });
+      }
     }
   });
 
@@ -74,6 +96,15 @@ export function convertMetadataToVirtualBlocks(
         });
       }
     });
+
+    if (additional.constraint) {
+      virtualBlocks.push({
+        id: 'additional_constraint',
+        type: 'custom',
+        content: additional.constraint.trim(),
+        isFromMetadata: false
+      });
+    }
   }
 
   if (metadata.example) {
@@ -96,6 +127,25 @@ export function convertMetadataToVirtualBlocks(
           itemId: example.id
         });
       }
+    });
+
+    if (additional.example) {
+      virtualBlocks.push({
+        id: 'additional_example',
+        type: 'custom',
+        content: additional.example.trim(),
+        isFromMetadata: false
+      });
+    }
+  }
+
+  // Outro text after all metadata
+  if (additional.outro) {
+    virtualBlocks.push({
+      id: 'additional_outro',
+      type: 'custom',
+      content: additional.outro.trim(),
+      isFromMetadata: false
     });
   }
 


### PR DESCRIPTION
## Summary
- allow storing `additional_text` in template metadata
- clone and parse `additional_text`
- inject free text blocks during preview rendering
- include `additional_text` when saving templates

## Testing
- `npm run lint` *(fails: unexpected any, etc.)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6867e58a73908325bf3c489288141be9