### PR TITLE
Fix placeholder panel

### DIFF
--- a/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
@@ -168,6 +168,13 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
     originalBlockCacheRef.current = blockContentCache;
   }, [blockContentCache]);
 
+  React.useEffect(() => {
+    if (isOpen && mode === 'customize') {
+      originalContentRef.current = content;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, mode]);
+
   const getPlaceholderKeys = React.useCallback((): string[] => {
     const base = mode === 'customize' ? originalContentRef.current : content;
     const fromContent = (base.match(/\[([^\]]+)\]/g) || []).map(m => m.slice(1, -1));
@@ -198,7 +205,6 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
           return { key: k, value: existing?.value || '' };
         })
       );
-      originalContentRef.current = content;
     }
   }, [content, mode, getPlaceholderKeys]);
 


### PR DESCRIPTION
## Summary
- maintain original content when replacing placeholders in customize mode
- reinitialize original content on dialog open

## Testing
- `npm run lint` *(fails: 565 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6867da79d0908325be61ec0bcce62728