### PR TITLE
Support additional text segments in template editor

### DIFF
--- a/src/hooks/dialogs/useCreateTemplateDialog.ts
+++ b/src/hooks/dialogs/useCreateTemplateDialog.ts
@@ -7,7 +7,7 @@ import { useTemplateCreation } from '@/hooks/prompts/useTemplateCreation';
 import { toast } from 'sonner';
 import { getMessage } from '@/core/utils/i18n';
 import { PromptMetadata } from '@/types/prompts/metadata';
-import { metadataToBlockMapping } from '@/utils/prompts/metadataUtils';
+import { metadataToAdvancedMapping } from '@/utils/prompts/metadataUtils';
 
 export function useCreateTemplateDialog() {
   const createDialog = useDialog(DIALOG_TYPES.CREATE_TEMPLATE);
@@ -29,7 +29,7 @@ export function useCreateTemplateDialog() {
         content: content, // Use the base content directly
         description: baseHook.description?.trim(),
         folder_id: baseHook.selectedFolderId ? parseInt(baseHook.selectedFolderId, 10) : undefined,
-        metadata: metadataToBlockMapping(metadata)
+        metadata: metadataToAdvancedMapping(metadata)
       };
             
       const currentTemplate = data?.template;

--- a/src/types/prompts/metadata.ts
+++ b/src/types/prompts/metadata.ts
@@ -27,9 +27,16 @@ export interface PromptMetadata {
   // Multiple value metadata (arrays)
   constraint?: MetadataItem[];
   example?: MetadataItem[];
-  
+
   // Custom values for single metadata types
   values?: Record<SingleMetadataType, string>;
+
+  /**
+   * Additional text entered in the preview editor that does not belong to a
+   * specific block. Keys are metadata types (or "intro" for text before any
+   * block) and values are the freeform text associated with that section.
+   */
+  additional_text?: Record<string, string>;
 }
 
 // Configuration for each metadata type
@@ -115,7 +122,8 @@ export const ALL_METADATA_TYPES: MetadataType[] = [...PRIMARY_METADATA, ...SECON
 export const DEFAULT_METADATA: PromptMetadata = {
   constraint: [],
   example: [],
-  values: {} as Record<SingleMetadataType, string>
+  values: {} as Record<SingleMetadataType, string>,
+  additional_text: {}
 };
 
 // Helper functions

--- a/src/utils/prompts/metadataUtils.ts
+++ b/src/utils/prompts/metadataUtils.ts
@@ -31,6 +31,7 @@ export function createMetadata(initial?: Partial<PromptMetadata>): PromptMetadat
   return {
     ...DEFAULT_METADATA,
     values: {},
+    additional_text: {},
     ...initial
   };
 }
@@ -43,7 +44,8 @@ export function cloneMetadata(metadata: PromptMetadata): PromptMetadata {
     ...metadata,
     values: { ...metadata.values },
     constraint: metadata.constraint?.map(item => ({ ...item })),
-    example: metadata.example?.map(item => ({ ...item }))
+    example: metadata.example?.map(item => ({ ...item })),
+    additional_text: { ...(metadata.additional_text || {}) }
   };
 }
 
@@ -434,8 +436,22 @@ export function metadataToBlockMapping(metadata: PromptMetadata): Record<string,
       mapping.example = exampleBlockIds;
     }
   }
-  
+
   return mapping;
+}
+
+/**
+ * Convert metadata to block mapping including additional text sections.
+ */
+export function metadataToAdvancedMapping(
+  metadata: PromptMetadata
+): Record<string, any> {
+  const base = metadataToBlockMapping(metadata);
+  const advanced: Record<string, any> = { ...base };
+  if (metadata.additional_text && Object.keys(metadata.additional_text).length > 0) {
+    advanced.additional_text = { ...metadata.additional_text };
+  }
+  return advanced;
 }
 
 /**
@@ -569,6 +585,10 @@ export function parseTemplateMetadata(rawMetadata: any): PromptMetadata {
     parsed.values = { ...parsed.values, ...rawMetadata.values };
   }
 
-  
+  if (rawMetadata.additional_text && typeof rawMetadata.additional_text === 'object') {
+    parsed.additional_text = { ...rawMetadata.additional_text };
+  }
+
+
   return parsed;
 }


### PR DESCRIPTION
## Summary
- track text ranges for each block in the TemplateEditorDialog
- compute `additional_text` from edited preview content
- include `additional_text` when saving templates via a new `metadataToAdvancedMapping`
- extend metadata types to store `additional_text`

## Testing
- `npm run lint` *(fails: 568 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6867fc3851e48325a16ae01db280d296