### PR TITLE
Track placeholder replacements on template usage

### DIFF
--- a/src/hooks/dialogs/useCustomizeTemplateDialog.ts
+++ b/src/hooks/dialogs/useCustomizeTemplateDialog.ts
@@ -92,7 +92,11 @@ export function useCustomizeTemplateDialog() {
         data.onComplete(finalPrompt);
       }
 
-      // Track usage
+      // Track usage with placeholder info
+      const replacedPlaceholderKeys = Object.entries(placeholders)
+        .filter(([, value]) => value && value.trim())
+        .map(([key]) => key);
+
       trackEvent(EVENTS.TEMPLATE_USED, {
         template_id: data?.id,
         template_name: data?.title,
@@ -101,7 +105,9 @@ export function useCustomizeTemplateDialog() {
           Object.keys(metadata.values || {}).length +
           (metadata.constraint?.length || 0) +
           (metadata.example?.length || 0),
-        final_content_length: finalPrompt.length
+        final_content_length: finalPrompt.length,
+        replaced_placeholders: replacedPlaceholderKeys,
+        replaced_placeholders_count: replacedPlaceholderKeys.length
       });
       
       // Trigger cleanup events


### PR DESCRIPTION
## Summary
- log replaced placeholders when a template is used

## Testing
- `pnpm lint` *(fails: 540 errors)*
- `pnpm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6868fbf6ab0883259b86f348da12ff21