### PR TITLE
Track enterprise CTA taps

### DIFF
--- a/src/components/prompts/folders/FolderSection.tsx
+++ b/src/components/prompts/folders/FolderSection.tsx
@@ -55,6 +55,7 @@ export function FolderSection({
 
   const handleContactSales = () => {
     trackEvent(EVENTS.ENTERPRISE_LIBRARY_ACCESSED, { action: 'contact_sales' });
+    trackEvent(EVENTS.ENTERPRISE_CTA_CLICKED, { source: 'folder_section' });
     window.open('https://www.jayd.ai/#Contact', '_blank');
   };
 

--- a/src/utils/amplitude/index.ts
+++ b/src/utils/amplitude/index.ts
@@ -109,6 +109,7 @@ export const EVENTS = {
   TEMPLATE_BROWSE_OFFICIAL: 'Template Browse Official',
   TEMPLATE_BROWSE_ORGANIZATION: 'Template Browse Organization',
   ENTERPRISE_LIBRARY_ACCESSED: 'Enterprise Library Accessed',
+  ENTERPRISE_CTA_CLICKED: 'Enterprise CTA Clicked',
   TEMPLATE_REFRESH: 'Template Refresh',
   TEMPLATE_FOLDER_CREATED: 'Template Folder Created',
   TEMPLATE_EDIT_DIALOG_OPENED: 'Template Edit Dialog Opened',


### PR DESCRIPTION
## Summary
- add `ENTERPRISE_CTA_CLICKED` event constant
- send amplitude event when enterprise CTA is tapped in folder section

## Testing
- `pnpm lint` *(fails: 569 problems)*
- `pnpm type-check`

------
https://chatgpt.com/codex/tasks/task_b_6868fc11e9688325a752dc6938c3305e