### PR TITLE
Enhance compact metadata styling

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
@@ -37,7 +37,9 @@ import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
 import {
   getLocalizedContent,
   getBlockTypeIcon,
-  getBlockIconColors
+  getBlockIconColors,
+  getBlockTypeColors,
+  getBlockTextColors
 } from '@/utils/prompts/blockUtils';
 
 const METADATA_ICONS: Record<MetadataType, React.ComponentType<any>> = {
@@ -237,29 +239,43 @@ export const CompactMetadataSection: React.FC<CompactMetadataProps> = ({
             ? ((metadata as any)[type as MultipleMetadataType] || [])
             : [];
 
+          const cardColors = getBlockTypeColors(config.blockType, isDarkMode);
+          const iconColors = getBlockIconColors(config.blockType, isDarkMode);
+          const dotColor = getBlockTextColors(config.blockType, isDarkMode).replace('jd-text', 'jd-bg');
+
           return (
             <div key={type} className="jd-relative jd-group">
               {/* Ultra-compact metadata card */}
-              <div className={cn(
-                'jd-flex jd-flex-col jd-items-center jd-p-2 jd-rounded jd-border jd-transition-all jd-duration-200',
-                'jd-hover:jd-shadow-sm jd-cursor-pointer jd-relative',
-                assigned
-                  ? 'jd-border-green-400 jd-bg-green-100 jd-dark:jd-border-green-500 jd-dark:jd-bg-green-900/30'
-                  : 'jd-border-gray-300 jd-bg-gray-100 jd-dark:jd-border-gray-600 jd-dark:jd-bg-gray-800/50 jd-hover:jd-border-primary/50'
-              )}>
+              <div
+                className={cn(
+                  'jd-flex jd-flex-col jd-items-center jd-p-2 jd-rounded jd-border jd-transition-all jd-duration-200',
+                  'jd-hover:jd-shadow-sm jd-cursor-pointer jd-relative',
+                  assigned
+                    ? cardColors
+                    : isDarkMode
+                      ? 'jd-border-gray-600 jd-bg-gray-800/50 jd-text-gray-300'
+                      : 'jd-border-gray-300 jd-bg-gray-100 jd-text-gray-600'
+                )}
+              >
                 {/* Status dot */}
-                <div className={cn(
-                  'jd-absolute jd-top-1 jd-right-1 jd-w-2 jd-h-2 jd-rounded-full',
-                  assigned ? 'jd-bg-green-500' : 'jd-bg-gray-400'
-                )} />
+                <div
+                  className={cn(
+                    'jd-absolute jd-top-1 jd-right-1 jd-w-2 jd-h-2 jd-rounded-full',
+                    assigned ? dotColor : isDarkMode ? 'jd-bg-gray-500' : 'jd-bg-gray-400'
+                  )}
+                />
 
                 {/* Icon */}
-                <div className={cn(
-                  'jd-p-1 jd-rounded jd-mb-1',
-                  assigned 
-                    ? 'jd-bg-green-200 jd-text-green-800 jd-dark:jd-bg-green-800 jd-dark:jd-text-green-200' 
-                    : 'jd-bg-gray-200 jd-text-gray-600 jd-dark:jd-bg-gray-700 jd-dark:jd-text-gray-300'
-                )}>
+                <div
+                  className={cn(
+                    'jd-p-1 jd-rounded jd-mb-1',
+                    assigned
+                      ? iconColors
+                      : isDarkMode
+                        ? 'jd-bg-gray-700 jd-text-gray-300'
+                        : 'jd-bg-gray-200 jd-text-gray-600'
+                  )}
+                >
                   <Icon className="jd-h-3 jd-w-3" />
                 </div>
 


### PR DESCRIPTION
## Summary
- improve dark mode handling for compact metadata section
- use block-specific colors when metadata is filled

## Testing
- `npm run lint` *(fails: 521 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_6868ffdbf33c83259e004d7b4585f321