### PR TITLE
Fix AdvancedEditor block list

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
@@ -1,5 +1,5 @@
 // src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -69,6 +69,40 @@ export const CompactMetadataSection: React.FC<CompactMetadataProps> = ({
 
   // All metadata types combined
   const allMetadataTypes = [...PRIMARY_METADATA, ...SECONDARY_METADATA];
+
+  const blocksForType = useMemo(() => {
+    const result: Record<MetadataType, Block[]> = {} as Record<MetadataType, Block[]>;
+
+    (Object.keys(METADATA_CONFIGS) as MetadataType[]).forEach(type => {
+      const allBlocks = availableMetadataBlocks[type] || [];
+      const published = allBlocks.filter(b => (b as any).published);
+
+      const selectedIds: number[] = [];
+
+      if (isMultipleMetadataType(type)) {
+        const items = (metadata as any)[type as MultipleMetadataType] || [];
+        items.forEach((it: any) => {
+          if (it.blockId && !isNaN(it.blockId)) selectedIds.push(it.blockId);
+        });
+      } else {
+        const id = (metadata as any)[type as SingleMetadataType];
+        if (id && id !== 0) selectedIds.push(id);
+      }
+
+      const selectedBlocks = selectedIds
+        .map(id => allBlocks.find(b => b.id === id))
+        .filter(Boolean) as Block[];
+
+      const combined: Block[] = [...selectedBlocks];
+      published.forEach(b => {
+        if (!combined.some(sb => sb.id === b.id)) combined.push(b);
+      });
+
+      result[type] = combined;
+    });
+
+    return result;
+  }, [availableMetadataBlocks, metadata]);
 
   // Check if a metadata type has a value assigned
   const isAssigned = useCallback((type: MetadataType): boolean => {
@@ -232,7 +266,7 @@ export const CompactMetadataSection: React.FC<CompactMetadataProps> = ({
           const config = METADATA_CONFIGS[type];
           const Icon = METADATA_ICONS[type];
           const assigned = isAssigned(type);
-          const availableBlocks = availableMetadataBlocks[type] || [];
+          const availableBlocks = blocksForType[type] || [];
           const items = isMultipleMetadataType(type)
             ? ((metadata as any)[type as MultipleMetadataType] || [])
             : [];


### PR DESCRIPTION
## Summary
- filter available blocks in `CompactMetadataSection` to include only published blocks
- always include blocks referenced by current metadata when customizing

## Testing
- `npm run lint` *(fails: registry access blocked)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_686900c051b48325a0d23df9dc98de5f