### PR TITLE
Refactor compact metadata card

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataCard.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataCard.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select';
+import { Plus, ChevronDown, ChevronUp, X } from 'lucide-react';
+import {
+  MetadataType,
+  MultipleMetadataType,
+  SingleMetadataType,
+  METADATA_CONFIGS,
+  isMultipleMetadataType,
+  MetadataItem
+} from '@/types/prompts/metadata';
+import { Block } from '@/types/prompts/blocks';
+import { cn } from '@/core/utils/classNames';
+import {
+  getLocalizedContent,
+  getBlockTypeColors,
+  getBlockIconColors,
+  getBlockTextColors,
+  getBlockTypeIcon
+} from '@/utils/prompts/blockUtils';
+import { getMessage } from '@/core/utils/i18n';
+import CompactMetadataItem from './CompactMetadataItem';
+
+interface CompactMetadataCardProps {
+  type: MetadataType;
+  assigned: boolean;
+  items: MetadataItem[];
+  availableBlocks: Block[];
+  expanded: boolean;
+  isDarkMode: boolean;
+  onToggleExpand: () => void;
+  onSelect: (val: string) => void;
+  onItemSelect: (id: string, val: string) => void;
+  onAddItem: (val: string) => void;
+  onRemoveItem: (id: string) => void;
+  onRemove: () => void;
+}
+
+export const CompactMetadataCard: React.FC<CompactMetadataCardProps> = ({
+  type,
+  assigned,
+  items,
+  availableBlocks,
+  expanded,
+  isDarkMode,
+  onToggleExpand,
+  onSelect,
+  onItemSelect,
+  onAddItem,
+  onRemoveItem,
+  onRemove
+}) => {
+  const config = METADATA_CONFIGS[type];
+  const Icon = getBlockTypeIcon(config.blockType);
+  const cardColors = getBlockTypeColors(config.blockType, isDarkMode);
+  const iconColors = getBlockIconColors(config.blockType, isDarkMode);
+  const dotColor = getBlockTextColors(config.blockType, isDarkMode).replace('jd-text', 'jd-bg');
+
+  return (
+    <div className="jd-relative jd-group">
+      <div
+        className={cn(
+          'jd-flex jd-flex-col jd-items-center jd-p-2 jd-rounded jd-border jd-transition-all jd-duration-200',
+          'jd-hover:jd-shadow-sm jd-cursor-pointer jd-relative',
+          assigned
+            ? cardColors
+            : isDarkMode
+              ? 'jd-border-gray-600 jd-bg-gray-800/50 jd-text-gray-300'
+              : 'jd-border-gray-300 jd-bg-gray-100 jd-text-gray-600'
+        )}
+      >
+        <div
+          className={cn(
+            'jd-absolute jd-top-1 jd-right-1 jd-w-2 jd-h-2 jd-rounded-full',
+            assigned ? dotColor : isDarkMode ? 'jd-bg-gray-500' : 'jd-bg-gray-400'
+          )}
+        />
+        <div
+          className={cn(
+            'jd-p-1 jd-rounded jd-mb-1',
+            assigned
+              ? iconColors
+              : isDarkMode
+                ? 'jd-bg-gray-700 jd-text-gray-300'
+                : 'jd-bg-gray-200 jd-text-gray-600'
+          )}
+        >
+          <Icon className="jd-h-3 jd-w-3" />
+        </div>
+        <span className="jd-text-[10px] jd-font-medium jd-text-center jd-leading-tight jd-truncate jd-w-full">
+          {config.label}
+        </span>
+        {assigned && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove();
+            }}
+            className="jd-absolute jd-top-0 jd-left-0 jd-h-4 jd-w-4 jd-p-0 jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity jd-bg-red-500 jd-text-white jd-rounded-full"
+          >
+            <X className="jd-h-2 jd-w-2" />
+          </Button>
+        )}
+      </div>
+
+      <div className="jd-mt-1 jd-space-y-1">
+        {isMultipleMetadataType(type) ? (
+          <>
+            {items.length > 0 && !expanded ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onToggleExpand}
+                className="jd-w-full jd-h-6 jd-text-[10px] jd-px-2 jd-flex jd-items-center jd-justify-between"
+              >
+                <span>{items.length}</span>
+                <ChevronDown className="jd-h-3 jd-w-3" />
+              </Button>
+            ) : (
+              <>
+                {items.length > 0 && (
+                  <div className="jd-flex jd-justify-end">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={onToggleExpand}
+                      className="jd-h-4 jd-w-4 jd-p-0"
+                    >
+                      <ChevronUp className="jd-h-3 jd-w-3" />
+                    </Button>
+                  </div>
+                )}
+                {items.map(item => (
+                  <CompactMetadataItem
+                    key={item.id}
+                    type={type as MultipleMetadataType}
+                    item={item}
+                    availableBlocks={availableBlocks}
+                    onSelect={val => onItemSelect(item.id, val)}
+                    onRemove={() => onRemoveItem(item.id)}
+                  />
+                ))}
+                <Select onValueChange={onAddItem}>
+                  <SelectTrigger className="jd-w-full jd-h-6 jd-text-[10px] jd-px-2 jd-border-dashed">
+                    <SelectValue placeholder="+" />
+                  </SelectTrigger>
+                  <SelectContent className="jd-z-[10010]">
+                    {availableBlocks.map(block => (
+                      <SelectItem key={block.id} value={String(block.id)}>
+                        <span className="jd-text-xs">
+                          {getLocalizedContent(block.title) || `${config.label} block`}
+                        </span>
+                      </SelectItem>
+                    ))}
+                    <SelectItem value="create">
+                      <div className="jd-flex jd-items-center jd-gap-2">
+                        <Plus className="jd-h-3 jd-w-3" />
+                        <span className="jd-text-xs">
+                          {getMessage(
+                            'createTypeBlock',
+                            [config.label.toLowerCase()],
+                            `Create ${config.label.toLowerCase()} block`
+                          )}
+                        </span>
+                      </div>
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </>
+            )}
+          </>
+        ) : (
+          <Select onValueChange={onSelect}>
+            <SelectTrigger className="jd-w-full jd-h-6 jd-text-[10px] jd-px-2">
+              <SelectValue placeholder={assigned ? '•' : '+'} />
+            </SelectTrigger>
+            <SelectContent className="jd-z-[10010]">
+              {availableBlocks.map(block => (
+                <SelectItem key={block.id} value={String(block.id)}>
+                  <span className="jd-text-xs">
+                    {getLocalizedContent(block.title) || `${config.label} block`}
+                  </span>
+                </SelectItem>
+              ))}
+              <SelectItem value="create">
+                <div className="jd-flex jd-items-center jd-gap-2">
+                  <Plus className="jd-h-3 jd-w-3" />
+                  <span className="jd-text-xs">
+                    {getMessage(
+                      'createTypeBlock',
+                      [config.label.toLowerCase()],
+                      `Create ${config.label.toLowerCase()} block`
+                    )}
+                  </span>
+                </div>
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CompactMetadataCard;

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataItem.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataItem.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select';
+import { Plus, X } from 'lucide-react';
+import {
+  MultipleMetadataType,
+  MetadataItem,
+  METADATA_CONFIGS
+} from '@/types/prompts/metadata';
+import { Block } from '@/types/prompts/blocks';
+import { getLocalizedContent } from '@/utils/prompts/blockUtils';
+import { getMessage } from '@/core/utils/i18n';
+
+interface CompactMetadataItemProps {
+  type: MultipleMetadataType;
+  item: MetadataItem;
+  availableBlocks: Block[];
+  onSelect: (val: string) => void;
+  onRemove: () => void;
+}
+
+export const CompactMetadataItem: React.FC<CompactMetadataItemProps> = ({
+  type,
+  item,
+  availableBlocks,
+  onSelect,
+  onRemove
+}) => {
+  const config = METADATA_CONFIGS[type];
+
+  return (
+    <div className="jd-flex jd-items-center jd-gap-1">
+      <Select value={item.blockId ? String(item.blockId) : '0'} onValueChange={onSelect}>
+        <SelectTrigger className="jd-w-full jd-h-6 jd-text-[10px] jd-px-2">
+          <SelectValue placeholder={getMessage('select', undefined, 'Select')} />
+        </SelectTrigger>
+        <SelectContent className="jd-z-[10010]">
+          <SelectItem value="0">{getMessage('none', undefined, 'None')}</SelectItem>
+          {availableBlocks.map(block => (
+            <SelectItem key={block.id} value={String(block.id)}>
+              <span className="jd-text-xs">
+                {getLocalizedContent(block.title) || `${config.label} block`}
+              </span>
+            </SelectItem>
+          ))}
+          <SelectItem value="create">
+            <div className="jd-flex jd-items-center jd-gap-2">
+              <Plus className="jd-h-3 jd-w-3" />
+              <span className="jd-text-xs">
+                {getMessage(
+                  'createTypeBlock',
+                  [config.label.toLowerCase()],
+                  `Create ${config.label.toLowerCase()} block`
+                )}
+              </span>
+            </div>
+          </SelectItem>
+        </SelectContent>
+      </Select>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onRemove}
+        className="jd-h-4 jd-w-4 jd-p-0"
+      >
+        <X className="jd-h-2 jd-w-2" />
+      </Button>
+    </div>
+  );
+};
+
+export default CompactMetadataItem;

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
@@ -1,15 +1,7 @@
 // src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
 import React, { useCallback, useState } from 'react';
-import { Button } from '@/components/ui/button';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from '@/components/ui/select';
-import { Plus, Check, X, ChevronDown, ChevronUp } from 'lucide-react';
 import { cn } from '@/core/utils/classNames';
+import CompactMetadataCard from './CompactMetadataCard';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
 import { getMessage } from '@/core/utils/i18n';
 
@@ -28,30 +20,12 @@ import {
   updateSingleMetadata,
   addMetadataItem,
   removeMetadataItem,
-  updateMetadataItem,
-  addSecondaryMetadata,
-  removeSecondaryMetadata
+  updateMetadataItem
 } from '@/utils/prompts/metadataUtils';
 import { useDialogManager } from '@/components/dialogs/DialogContext';
 import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
-import {
-  getLocalizedContent,
-  getBlockTypeIcon,
-  getBlockIconColors,
-  getBlockTypeColors,
-  getBlockTextColors
-} from '@/utils/prompts/blockUtils';
+import { getLocalizedContent } from '@/utils/prompts/blockUtils';
 
-const METADATA_ICONS: Record<MetadataType, React.ComponentType<any>> = {
-  role: getBlockTypeIcon('role'),
-  context: getBlockTypeIcon('context'),
-  goal: getBlockTypeIcon('goal'),
-  audience: getBlockTypeIcon('audience'),
-  output_format: getBlockTypeIcon('output_format'),
-  example: getBlockTypeIcon('example'),
-  tone_style: getBlockTypeIcon('tone_style'),
-  constraint: getBlockTypeIcon('constraint')
-};
 
 interface CompactMetadataProps {
   availableMetadataBlocks: Record<MetadataType, Block[]>;
@@ -239,207 +213,33 @@ export const CompactMetadataSection: React.FC<CompactMetadataProps> = ({
       {/* Ultra-compact metadata grid */}
       <div className="jd-grid jd-grid-cols-8 jd-gap-2">
         {allMetadataTypes.map(type => {
-          const config = METADATA_CONFIGS[type];
-          const Icon = METADATA_ICONS[type];
           const assigned = isAssigned(type);
           const availableBlocks = availableMetadataBlocks[type] || [];
           const items = isMultipleMetadataType(type)
             ? ((metadata as any)[type as MultipleMetadataType] || [])
             : [];
 
-          const cardColors = getBlockTypeColors(config.blockType, isDarkMode);
-          const iconColors = getBlockIconColors(config.blockType, isDarkMode);
-          const dotColor = getBlockTextColors(config.blockType, isDarkMode).replace('jd-text', 'jd-bg');
-
           return (
-            <div key={type} className="jd-relative jd-group">
-              {/* Ultra-compact metadata card */}
-              <div
-                className={cn(
-                  'jd-flex jd-flex-col jd-items-center jd-p-2 jd-rounded jd-border jd-transition-all jd-duration-200',
-                  'jd-hover:jd-shadow-sm jd-cursor-pointer jd-relative',
-                  assigned
-                    ? cardColors
-                    : isDarkMode
-                      ? 'jd-border-gray-600 jd-bg-gray-800/50 jd-text-gray-300'
-                      : 'jd-border-gray-300 jd-bg-gray-100 jd-text-gray-600'
-                )}
-              >
-                {/* Status dot */}
-                <div
-                  className={cn(
-                    'jd-absolute jd-top-1 jd-right-1 jd-w-2 jd-h-2 jd-rounded-full',
-                    assigned ? dotColor : isDarkMode ? 'jd-bg-gray-500' : 'jd-bg-gray-400'
-                  )}
-                />
-
-                {/* Icon */}
-                <div
-                  className={cn(
-                    'jd-p-1 jd-rounded jd-mb-1',
-                    assigned
-                      ? iconColors
-                      : isDarkMode
-                        ? 'jd-bg-gray-700 jd-text-gray-300'
-                        : 'jd-bg-gray-200 jd-text-gray-600'
-                  )}
-                >
-                  <Icon className="jd-h-3 jd-w-3" />
-                </div>
-
-                {/* Label */}
-                <span className="jd-text-[10px] jd-font-medium jd-text-center jd-leading-tight jd-truncate jd-w-full">
-                  {config.label}
-                </span>
-
-                {/* Remove button (only when assigned) */}
-                {assigned && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleRemove(type);
-                    }}
-                    className="jd-absolute jd-top-0 jd-left-0 jd-h-4 jd-w-4 jd-p-0 jd-opacity-0 group-hover:jd-opacity-100 jd-transition-opacity jd-bg-red-500 jd-text-white jd-rounded-full"
-                  >
-                    <X className="jd-h-2 jd-w-2" />
-                  </Button>
-                )}
-              </div>
-
-              {/* Ultra-compact select dropdown */}
-              <div className="jd-mt-1 jd-space-y-1">
-                {isMultipleMetadataType(type) ? (
-                  <>
-                    {items.length > 0 && !expandedTypes[type as MultipleMetadataType] ? (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => toggleExpanded(type as MultipleMetadataType)}
-                        className="jd-w-full jd-h-6 jd-text-[10px] jd-px-2 jd-flex jd-items-center jd-justify-between"
-                      >
-                        <span>{items.length}</span>
-                        <ChevronDown className="jd-h-3 jd-w-3" />
-                      </Button>
-                    ) : (
-                      <>
-                        {items.length > 0 && (
-                          <div className="jd-flex jd-justify-end">
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => toggleExpanded(type as MultipleMetadataType)}
-                              className="jd-h-4 jd-w-4 jd-p-0"
-                            >
-                              <ChevronUp className="jd-h-3 jd-w-3" />
-                            </Button>
-                          </div>
-                        )}
-                        {items.map(item => (
-                          <div key={item.id} className="jd-flex jd-items-center jd-gap-1">
-                            <Select
-                              value={item.blockId ? String(item.blockId) : '0'}
-                              onValueChange={val => handleItemSelect(type as MultipleMetadataType, item.id, val)}
-                            >
-                              <SelectTrigger className="jd-w-full jd-h-6 jd-text-[10px] jd-px-2">
-                                <SelectValue placeholder={getMessage('select', undefined, 'Select')} />
-                              </SelectTrigger>
-                              <SelectContent className="jd-z-[10010]">
-                                <SelectItem value="0">{getMessage('none', undefined, 'None')}</SelectItem>
-                                {availableBlocks.map(block => (
-                                  <SelectItem key={block.id} value={String(block.id)}>
-                                    <span className="jd-text-xs">
-                                      {getLocalizedContent(block.title) || `${config.label} block`}
-                                    </span>
-                                  </SelectItem>
-                                ))}
-                                <SelectItem value="create">
-                                  <div className="jd-flex jd-items-center jd-gap-2">
-                                    <Plus className="jd-h-3 jd-w-3" />
-                                    <span className="jd-text-xs">
-                                      {getMessage(
-                                        'createTypeBlock',
-                                        [config.label.toLowerCase()],
-                                        `Create ${config.label.toLowerCase()} block`
-                                      )}
-                                    </span>
-                                  </div>
-                                </SelectItem>
-                              </SelectContent>
-                            </Select>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => handleRemoveItem(type as MultipleMetadataType, item.id)}
-                              className="jd-h-4 jd-w-4 jd-p-0"
-                            >
-                              <X className="jd-h-2 jd-w-2" />
-                            </Button>
-                          </div>
-                        ))}
-                        <Select onValueChange={val => handleAddItem(type as MultipleMetadataType, val)}>
-                          <SelectTrigger className="jd-w-full jd-h-6 jd-text-[10px] jd-px-2 jd-border-dashed">
-                            <SelectValue placeholder="+" />
-                          </SelectTrigger>
-                          <SelectContent className="jd-z-[10010]">
-                            {availableBlocks.map(block => (
-                              <SelectItem key={block.id} value={String(block.id)}>
-                                <span className="jd-text-xs">
-                                  {getLocalizedContent(block.title) || `${config.label} block`}
-                                </span>
-                              </SelectItem>
-                            ))}
-                            <SelectItem value="create">
-                              <div className="jd-flex jd-items-center jd-gap-2">
-                                <Plus className="jd-h-3 jd-w-3" />
-                                <span className="jd-text-xs">
-                                  {getMessage(
-                                    'createTypeBlock',
-                                    [config.label.toLowerCase()],
-                                    `Create ${config.label.toLowerCase()} block`
-                                  )}
-                                </span>
-                              </div>
-                            </SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </>
-                    )}
-                  </>
-                ) : (
-                  <Select onValueChange={val => handleSelect(type, val)}>
-                    <SelectTrigger className="jd-w-full jd-h-6 jd-text-[10px] jd-px-2">
-                      <SelectValue placeholder={assigned ? '•' : '+'} />
-                    </SelectTrigger>
-                    <SelectContent className="jd-z-[10010]">
-                      {availableBlocks.map(block => (
-                        <SelectItem key={block.id} value={String(block.id)}>
-                          <span className="jd-text-xs">
-                            {getLocalizedContent(block.title) || `${config.label} block`}
-                          </span>
-                        </SelectItem>
-                      ))}
-                      <SelectItem value="create">
-                        <div className="jd-flex jd-items-center jd-gap-2">
-                          <Plus className="jd-h-3 jd-w-3" />
-                          <span className="jd-text-xs">
-                            {getMessage(
-                              'createTypeBlock',
-                              [config.label.toLowerCase()],
-                              `Create ${config.label.toLowerCase()} block`
-                            )}
-                          </span>
-                        </div>
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                )}
-              </div>
-            </div>
+            <CompactMetadataCard
+              key={type}
+              type={type}
+              assigned={assigned}
+              items={items}
+              availableBlocks={availableBlocks}
+              expanded={!!expandedTypes[type as MultipleMetadataType]}
+              isDarkMode={isDarkMode}
+              onToggleExpand={() => toggleExpanded(type as MultipleMetadataType)}
+              onSelect={val => handleSelect(type, val)}
+              onItemSelect={(id, val) => handleItemSelect(type as MultipleMetadataType, id, val)}
+              onAddItem={val => handleAddItem(type as MultipleMetadataType, val)}
+              onRemoveItem={id => handleRemoveItem(type as MultipleMetadataType, id)}
+              onRemove={() => handleRemove(type)}
+            />
           );
         })}
       </div>
     </div>
   );
+}
 };
+


### PR DESCRIPTION
## Summary
- extract CompactMetadataCard and CompactMetadataItem components
- simplify CompactMetadataSection to use new components

## Testing
- `npm run type-check`
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68694ae5243483258ce6175c93afb454