### PR TITLE
Introduce BlockEditablePreview

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/core/utils/classNames';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
 import { CompactMetadataSection } from './CompactMetadataSection';
 import { useTemplateEditor } from '../../TemplateEditorDialog/TemplateEditorContext';
-import TemplatePreview from '@/components/prompts/TemplatePreview';
+import BlockEditablePreview from '@/components/prompts/BlockEditablePreview';
 import { getMessage } from '@/core/utils/i18n';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { Input } from '@/components/ui/input';
@@ -188,12 +188,13 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
               <div className="jd-flex-1 jd-min-h-0">
                 <div className="jd-space-y-3 jd-h-full jd-flex jd-flex-col">
                   <div className="jd-rounded-lg jd-p-1 jd-bg-gradient-to-r jd-from-blue-500/10 jd-to-purple-500/10 jd-border-blue-200 jd-dark:jd-border-blue-700 jd-flex-1 jd-min-h-0">
-                    <TemplatePreview
+                    <BlockEditablePreview
                       metadata={metadata}
-                      content={previewContent}
-                      blockContentCache={previewCache}
+                      content={content}
+                      blockContentCache={blockContentCache}
                       isDarkMode={isDarkMode}
                       className="jd-h-full"
+                      onContentChange={setContent}
                     />
                   </div>
                 </div>
@@ -231,12 +232,13 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
           </h3>
           
           <div className="jd-border jd-rounded-lg jd-p-1 jd-bg-gradient-to-r jd-from-blue-500/10 jd-to-purple-500/10 jd-border-blue-200 jd-dark:jd-border-blue-700 jd-flex-1 jd-min-h-0">
-            <TemplatePreview
+            <BlockEditablePreview
               metadata={metadata}
               content={content}
               blockContentCache={blockContentCache}
               isDarkMode={isDarkMode}
               className="jd-h-full"
+              onContentChange={setContent}
             />
           </div>
         </div>

--- a/src/components/prompts/BlockEditablePreview.tsx
+++ b/src/components/prompts/BlockEditablePreview.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { cn } from '@/core/utils/classNames';
+import EditablePromptPreview from './EditablePromptPreview';
+import { PromptMetadata, MetadataType } from '@/types/prompts/metadata';
+import { convertMetadataToVirtualBlocks } from '@/utils/templates/enhancedPreviewUtils';
+import { buildPromptPartHtml, getBlockTextColors, getBlockTypeLabel } from '@/utils/prompts/blockUtils';
+
+interface BlockEditablePreviewProps {
+  metadata: PromptMetadata;
+  content: string;
+  blockContentCache?: Record<number, string>;
+  isDarkMode: boolean;
+  className?: string;
+  onContentChange?: (value: string) => void;
+}
+
+const ORDER: MetadataType[] = [
+  'role',
+  'context',
+  'goal',
+  'audience',
+  'tone_style',
+  'output_format',
+  'constraint',
+  'example'
+];
+
+export const BlockEditablePreview: React.FC<BlockEditablePreviewProps> = ({
+  metadata,
+  content,
+  blockContentCache = {},
+  isDarkMode,
+  className,
+  onContentChange
+}) => {
+  const virtualBlocks = React.useMemo(
+    () => convertMetadataToVirtualBlocks(metadata, blockContentCache),
+    [metadata, blockContentCache]
+  );
+
+  const ordered = React.useMemo(
+    () =>
+      [...virtualBlocks].sort(
+        (a, b) => ORDER.indexOf(a.type as MetadataType) - ORDER.indexOf(b.type as MetadataType)
+      ),
+    [virtualBlocks]
+  );
+
+  return (
+    <div className={cn('jd-space-y-3 jd-h-full jd-flex jd-flex-col jd-overflow-y-auto', className)}>
+      {ordered.map(block => (
+        <div
+          key={block.id}
+          className="jd-relative jd-p-2 jd-rounded jd-border jd-border-transparent hover:jd-border-dashed hover:jd-border-primary/40"
+        >
+          <div
+            dangerouslySetInnerHTML={{
+              __html: buildPromptPartHtml(block.type, block.content, isDarkMode)
+            }}
+          />
+          <div className="jd-text-xs jd-text-muted-foreground jd-mt-1">
+            <span className={getBlockTextColors(block.type, isDarkMode)}>
+              {getBlockTypeLabel(block.type)}
+            </span>
+          </div>
+        </div>
+      ))}
+
+      <EditablePromptPreview
+        content={content}
+        onChange={onContentChange}
+        isDark={isDarkMode}
+        showColors
+      />
+    </div>
+  );
+};
+
+export default BlockEditablePreview;


### PR DESCRIPTION
## Summary
- add `BlockEditablePreview` for editable preview rendering
- swap out TemplatePreview in AdvancedEditor for this new component

## Testing
- `pnpm lint` *(fails: 582 problems)*
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_b_686ba253608083259871da56e55089f9