### PR TITLE
Enable scrollable previews in template editors

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
@@ -169,12 +169,14 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
           
           {/* Metadata and Preview Panel */}
           <ResizablePanel defaultSize={75} minSize={50}>
-            <div className={cn(
-              'jd-h-full jd-flex jd-flex-col jd-relative jd-overflow-hidden jd-p-4',
-              isDarkMode
-                ? 'jd-bg-gradient-to-br jd-from-gray-900 jd-via-gray-800 jd-to-gray-900'
-                : 'jd-bg-gradient-to-br jd-from-slate-50 jd-via-white jd-to-slate-100'
-            )}>
+            <div
+              className={cn(
+                'jd-h-full jd-flex jd-flex-col jd-relative jd-overflow-y-auto jd-p-4 jd-scrollbar-thin jd-scrollbar-thumb-gray-300 jd-scrollbar-track-gray-100 dark:jd-scrollbar-thumb-gray-600 dark:jd-scrollbar-track-gray-800',
+                isDarkMode
+                  ? 'jd-bg-gradient-to-br jd-from-gray-900 jd-via-gray-800 jd-to-gray-900'
+                  : 'jd-bg-gradient-to-br jd-from-slate-50 jd-via-white jd-to-slate-100'
+              )}
+            >
               
               {/* Compact Metadata Section */}
               <div className="jd-flex-shrink-0 jd-mb-4">
@@ -211,12 +213,14 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
 
   // For create mode (no placeholder panel)
   return (
-    <div className={cn(
-      'jd-h-full jd-flex jd-flex-col jd-relative jd-overflow-hidden jd-p-6',
-      isDarkMode
-        ? 'jd-bg-gradient-to-br jd-from-gray-900 jd-via-gray-800 jd-to-gray-900'
-        : 'jd-bg-gradient-to-br jd-from-slate-50 jd-via-white jd-to-slate-100'
-    )}>
+    <div
+      className={cn(
+        'jd-h-full jd-flex jd-flex-col jd-relative jd-overflow-y-auto jd-p-6 jd-scrollbar-thin jd-scrollbar-thumb-gray-300 jd-scrollbar-track-gray-100 dark:jd-scrollbar-thumb-gray-600 dark:jd-scrollbar-track-gray-800',
+        isDarkMode
+          ? 'jd-bg-gradient-to-br jd-from-gray-900 jd-via-gray-800 jd-to-gray-900'
+          : 'jd-bg-gradient-to-br jd-from-slate-50 jd-via-white jd-to-slate-100'
+      )}
+    >
       
       {/* Compact Metadata Section */}
       <div className="jd-flex-shrink-0 jd-mb-6">

--- a/src/components/dialogs/prompts/editors/BasicEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/BasicEditor/index.tsx
@@ -250,7 +250,9 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
         <ResizableHandle withHandle />
         
         <ResizablePanel defaultSize={70} minSize={40}>
-          <div className="jd-h-full jd-border jd-rounded-md jd-p-4 jd-flex jd-flex-col jd-min-h-0 jd-overflow-hidden">
+          <div
+            className="jd-h-full jd-border jd-rounded-md jd-p-4 jd-flex jd-flex-col jd-min-h-0 jd-overflow-y-auto jd-scrollbar-thin jd-scrollbar-thumb-gray-300 jd-scrollbar-track-gray-100 dark:jd-scrollbar-thumb-gray-600 dark:jd-scrollbar-track-gray-800"
+          >
             <TemplatePreview
               metadata={metadata}
               content={previewContent}


### PR DESCRIPTION
## Summary
- allow scrolling in BasicEditor preview container
- make AdvancedEditor preview container scrollable in both customize and create modes

## Testing
- `npm run lint` *(fails: 550 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_686bb8f72aac8325b8285173172b34b0