### PR TITLE
Allow templates without primary metadata

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2039,5 +2039,9 @@
   "moreActions": { "message": "More actions", "description": "Label for the more actions button" },
   "edit": { "message": "Edit", "description": "Label for the edit button" },
   "aPerfectPrompt": { "message": "A perfect prompt contains at least a role, context and goal", "description": "Label for the a perfect prompt" },
+  "noPrimaryMetadataWarning": { "message": "Add at least one of role, context or goal", "description": "Warning when no primary metadata is set" },
+  "missingSomePrimaryMetadata": { "message": "Fill role, context and goal for best results", "description": "Warning when primary metadata is incomplete" },
+  "allPrimaryMetadataSet": { "message": "Great! All primary metadata added", "description": "Message when all primary metadata are set" },
+  "contentOrMetadataRequired": { "message": "Provide template content or at least one metadata item", "description": "Validation error when creating template" },
   "addBlocksTitle": { "message": "Add blocks", "description": "Label for the add blocks title" }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -2020,5 +2020,9 @@
   "moreActions": { "message": "Plus d'actions", "description": "Libellé pour le bouton de clic pour plus d'actions" },
   "edit": { "message": "Modifier", "description": "Libellé pour le bouton de clic pour modifier" },
   "aPerfectPrompt": { "message": "Un prompt parfait contient au moins un rôle, un contexte et un objectif", "description": "Libellé pour le prompt parfait" },
+  "noPrimaryMetadataWarning": { "message": "Ajoutez au moins un rôle, un contexte ou un objectif", "description": "Avertissement lorsqu'aucune métadonnée primaire n'est définie" },
+  "missingSomePrimaryMetadata": { "message": "Renseignez le rôle, le contexte et l'objectif pour de meilleurs résultats", "description": "Avertissement lorsque les métadonnées primaires sont incomplètes" },
+  "allPrimaryMetadataSet": { "message": "Parfait ! Toutes les métadonnées principales sont ajoutées", "description": "Message lorsque toutes les métadonnées principales sont définies" },
+  "contentOrMetadataRequired": { "message": "Ajoutez du contenu ou au moins une métadonnée", "description": "Erreur de validation lors de la création du template" },
   "addBlocksTitle": { "message": "Ajouter des blocs", "description": "Libellé pour le titre de la section des blocs" }
 }

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
@@ -13,6 +13,8 @@ import {
   convertMetadataToVirtualBlocks,
   extractPlaceholdersFromBlocks
 } from '@/utils/templates/enhancedPreviewUtils';
+import { PRIMARY_METADATA, SingleMetadataType } from '@/types/prompts/metadata';
+import { AlertTriangle, Check } from 'lucide-react';
 
 interface AdvancedEditorProps {
   mode?: 'create' | 'customize';
@@ -37,6 +39,38 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
   } = useTemplateEditor();
   
   const isDarkMode = useThemeDetector();
+
+  const primaryCount = React.useMemo(() => {
+    return PRIMARY_METADATA.reduce((acc, type) => {
+      const blockId = metadata[type as SingleMetadataType];
+      const val = metadata.values?.[type as SingleMetadataType];
+      return (blockId && blockId !== 0) || (val && val.trim()) ? acc + 1 : acc;
+    }, 0);
+  }, [metadata]);
+
+  let metadataBanner: React.ReactNode = null;
+  if (primaryCount === 0) {
+    metadataBanner = (
+      <div className="jd-flex jd-items-center jd-gap-2 jd-bg-red-100 jd-text-red-700 jd-border jd-border-red-200 jd-rounded jd-p-2 jd-text-sm">
+        <AlertTriangle className="jd-h-4 jd-w-4 jd-text-red-500" />
+        {getMessage('noPrimaryMetadataWarning', undefined, 'Add at least one of role, context or goal')}
+      </div>
+    );
+  } else if (primaryCount < PRIMARY_METADATA.length) {
+    metadataBanner = (
+      <div className="jd-flex jd-items-center jd-gap-2 jd-bg-amber-50 jd-text-amber-700 jd-border jd-border-amber-200 jd-rounded jd-p-2 jd-text-sm">
+        <AlertTriangle className="jd-h-4 jd-w-4 jd-text-amber-500" />
+        {getMessage('missingSomePrimaryMetadata', undefined, 'Add role, context and goal for best results')}
+      </div>
+    );
+  } else {
+    metadataBanner = (
+      <div className="jd-flex jd-items-center jd-gap-2 jd-bg-green-100 jd-text-green-700 jd-border jd-border-green-200 jd-rounded jd-p-2 jd-text-sm">
+        <Check className="jd-h-4 jd-w-4 jd-text-green-600" />
+        {getMessage('allPrimaryMetadataSet', undefined, 'Great! You added role, context and goal')}
+      </div>
+    );
+  }
 
   // Placeholder management for customize mode
   const originalContentRef = useRef(content);
@@ -183,6 +217,7 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
                   availableMetadataBlocks={availableMetadataBlocks}
                 />
               </div>
+              <div className="jd-mb-4">{metadataBanner}</div>
 
               {/* Preview Section */}
               <div className="jd-flex-1 jd-min-h-0">
@@ -220,6 +255,7 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
           availableMetadataBlocks={availableMetadataBlocks}
         />
       </div>
+      <div className="jd-mb-4">{metadataBanner}</div>
 
       {/* Preview Section */}
       <div className="jd-flex-1 jd-min-h-0">

--- a/src/hooks/dialogs/useTemplateDialogBase.ts
+++ b/src/hooks/dialogs/useTemplateDialogBase.ts
@@ -24,7 +24,8 @@ import {
   getFilledMetadataTypes,
   extractCustomValues,
   validateMetadata,
-  parseTemplateMetadata
+  parseTemplateMetadata,
+  countMetadataItems
 } from '@/utils/prompts/metadataUtils';
 
 export interface TemplateDialogConfig {
@@ -260,6 +261,14 @@ export function useTemplateDialogBase(config: TemplateDialogConfig) {
     // insert a prompt even if some fields are missing.
     if (state.activeTab === 'advanced' && dialogType !== 'customize') {
       const metadataValidation = validateMetadata(state.metadata);
+      if (!state.content.trim() && countMetadataItems(state.metadata) === 0) {
+        errors.content = getMessage(
+          'contentOrMetadataRequired',
+          undefined,
+          'Provide content or at least one metadata element'
+        );
+      }
+      // metadataValidation currently only yields warnings
       if (!metadataValidation.isValid) {
         errors.content = metadataValidation.errors.join(', ');
       }

--- a/src/utils/prompts/metadataUtils.ts
+++ b/src/utils/prompts/metadataUtils.ts
@@ -333,20 +333,17 @@ export function validateMetadata(metadata: PromptMetadata): {
 } {
   const errors: string[] = [];
   const warnings: string[] = [];
-  
-  // Check if at least one primary metadata is filled
-  const hasPrimaryMetadata = PRIMARY_METADATA.some(type => {
-    if (!isMultipleMetadataType(type)) {
-      const singleType = type as SingleMetadataType;
-      const blockId = metadata[singleType];
-      const customValue = metadata.values?.[singleType];
-      return (blockId && blockId !== 0) || (customValue && customValue.trim());
-    }
-    return false;
-  });
-  
-  if (!hasPrimaryMetadata) {
-    errors.push('At least one of Role, Context, or Goal is required');
+
+  const primaryCount = PRIMARY_METADATA.reduce((count, type) => {
+    const blockId = metadata[type as SingleMetadataType];
+    const custom = metadata.values?.[type as SingleMetadataType];
+    return (blockId && blockId !== 0) || (custom && custom.trim()) ? count + 1 : count;
+  }, 0);
+
+  if (primaryCount === 0) {
+    warnings.push('noPrimary');
+  } else if (primaryCount < PRIMARY_METADATA.length) {
+    warnings.push('missingPrimary');
   }
   
   // Check for empty multiple metadata items


### PR DESCRIPTION
## Summary
- relax form validation to allow saving templates with only content or a single metadata element
- surface primary metadata status in Advanced Editor with color coded banners
- provide translations for new messages in English and French
- adjust metadata validation to warn instead of error when primary metadata is missing

## Testing
- `npm run lint` *(fails: 581 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_686bbaa9dbfc832584d0a776a12b99d8