### PR TITLE
Fix metadata block filtering in Advanced editor

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
@@ -72,7 +72,16 @@ export const CompactMetadataSection: React.FC<CompactMetadataProps> = ({
   const { openDialog } = useDialogManager();
 
   const blocksForType = useMemo(() => {
-    if (mode !== 'customize') return availableMetadataBlocks;
+    if (mode !== 'customize') {
+      const result: Record<MetadataType, Block[]> = {} as Record<MetadataType, Block[]>;
+
+      (Object.keys(METADATA_CONFIGS) as MetadataType[]).forEach(type => {
+        const allBlocks = availableMetadataBlocks[type] || [];
+        result[type] = allBlocks.filter(b => (b as any).published);
+      });
+
+      return result;
+    }
 
     const result: Record<MetadataType, Block[]> = {} as Record<MetadataType, Block[]>;
 


### PR DESCRIPTION
## Summary
- ensure CompactMetadataSection shows only published blocks when creating

## Testing
- `npm run lint` *(fails: many lint errors in repo)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_686bccb45f24832585cb2cd71642157d