### PR TITLE
Add source property to creation events

### DIFF
--- a/src/components/dialogs/prompts/CreateBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateBlockDialog/index.tsx
@@ -15,6 +15,7 @@ import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
 import { BlockType } from '@/types/prompts/blocks';
 import { BLOCK_TYPE_LABELS, getBlockTypeIcon, getBlockTypeColors } from '@/utils/prompts/blockUtils';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
+import { trackEvent, EVENTS } from '@/utils/amplitude';
 
 const AVAILABLE_BLOCK_TYPES: BlockType[] = [
   'role', 'context', 'goal', 'custom',
@@ -103,6 +104,11 @@ export const CreateBlockDialog: React.FC = () => {
         const response = await blocksApi.createBlock(blockData);
         if (response.success && response.data) {
           toast.success(getMessage('blockCreated', undefined, 'Block created successfully'));
+          trackEvent(EVENTS.BLOCK_CREATED, {
+            block_id: response.data.id,
+            block_type: response.data.type,
+            source: (data?.source as string) || 'CreateBlockDialog'
+          });
           handleClose();
         } else {
           toast.error(response.message || getMessage('errorCreatingBlock', undefined, 'Failed to create block'));

--- a/src/components/dialogs/prompts/CreateTemplateDialog/BasicInfoForm.tsx
+++ b/src/components/dialogs/prompts/CreateTemplateDialog/BasicInfoForm.tsx
@@ -10,6 +10,7 @@ import { QUERY_KEYS } from '@/constants/queryKeys';
 import { TemplateFolder } from '@/types/prompts/templates';
 import { getMessage } from '@/core/utils/i18n';
 import { FolderData, truncateFolderPath } from '@/utils/prompts/templateUtils';
+import { trackEvent, EVENTS } from '@/utils/amplitude';
 
 interface Props {
   name: string;
@@ -65,6 +66,11 @@ export const BasicInfoForm: React.FC<Props> = ({
         onFolderCreated: async (folder: TemplateFolder) => {
           await queryClient.invalidateQueries(QUERY_KEYS.USER_FOLDERS);
           handleFolderSelect(folder.id.toString());
+          trackEvent(EVENTS.TEMPLATE_FOLDER_CREATED, {
+            folder_id: folder.id,
+            folder_name: typeof folder.title === 'string' ? folder.title : (folder.title as any)?.en || folder.name,
+            source: 'CreateTemplateDialog'
+          });
         }
       });
       return;

--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -107,7 +107,11 @@ const InlineBlockCreator: React.FC<{
 
       if (response.success && response.data) {
         toast.success(getMessage('blockCreated', undefined, 'Block created successfully'));
-        trackEvent(EVENTS.BLOCK_CREATED, { block_id: response.data.id, block_type: response.data.type });
+        trackEvent(EVENTS.BLOCK_CREATED, {
+          block_id: response.data.id,
+          block_type: response.data.type,
+          source: 'InsertBlockDialog'
+        });
         onBlockCreated(response.data);
       } else {
         toast.error(response.message || getMessage('blockCreateFailed', undefined, 'Failed to create block'));
@@ -547,7 +551,7 @@ const filteredBlocks = blocks.filter(b => {
                 <Button
                   size="sm"
                   variant="outline"
-                  onClick={() => openCreateBlock()}
+                  onClick={() => openCreateBlock({ source: 'InsertBlockDialog' })}
                   className="jd-h-6 jd-text-xs jd-px-2 jd-border-dashed"
                 >
                   <Plus className="jd-h-3 jd-w-3 jd-mr-1" />

--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -427,12 +427,17 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
       },
       onFolderCreated: async (folder: TemplateFolder) => {
         await refetchUser();
+        trackEvent(EVENTS.TEMPLATE_FOLDER_CREATED, {
+          folder_id: folder.id,
+          folder_name: typeof folder.title === 'string' ? folder.title : (folder.title as any)?.en || folder.name,
+          source: 'TemplatesPanel'
+        });
       },
     });
   }, [openCreateFolder, createFolder, refetchUser]);
 
   const handleCreateBlock = useCallback(() => {
-    openCreateBlock();
+    openCreateBlock({ source: 'TemplatesPanel' });
   }, [openCreateBlock]);
 
   const handleContactSales = useCallback(() => {

--- a/src/components/prompts/blocks/quick-selector/QuickBlockSelector.tsx
+++ b/src/components/prompts/blocks/quick-selector/QuickBlockSelector.tsx
@@ -82,7 +82,7 @@ export const QuickBlockSelector: React.FC<QuickBlockSelectorProps> = ({
   });
 
   const handleCreateBlock = () => {
-    createBlock();
+    createBlock(undefined, 'QuickBlockSelector');
   };
 
   const handleEditBlock = (block: Block) => {

--- a/src/hooks/dialogs/useCreateTemplateDialog.ts
+++ b/src/hooks/dialogs/useCreateTemplateDialog.ts
@@ -33,7 +33,7 @@ export function useCreateTemplateDialog() {
       };
             
       const currentTemplate = data?.template;
-      const success = await saveTemplate(formData, currentTemplate?.id);
+      const success = await saveTemplate(formData, currentTemplate?.id, 'CreateTemplateDialog');
       
       if (success) {
         if (currentTemplate) {

--- a/src/hooks/prompts/actions/useBlockActions.ts
+++ b/src/hooks/prompts/actions/useBlockActions.ts
@@ -140,13 +140,14 @@ export function useBlockActions({
   /**
    * Create a new block
    */
-  const createBlock = useCallback((initialData?: Partial<Block>) => {
+  const createBlock = useCallback((initialData?: Partial<Block>, source: string = 'CreateBlockDialog') => {
     openDialog(DIALOG_TYPES.CREATE_BLOCK, {
       isEdit: false,
       initialType: initialData?.type || 'custom',
       initialTitle: initialData?.title || '',
       initialContent: initialData?.content || '',
       initialDescription: initialData?.description || '',
+      source,
       onBlockCreated: async (blockData: any) => {
         try {
           setIsLoading(true);
@@ -163,7 +164,11 @@ export function useBlockActions({
           
           if (response.success && response.data) {
             toast.success(getMessage('blockCreated', undefined, 'Block created successfully'));
-            trackEvent(EVENTS.BLOCK_CREATED, { block_id: response.data.id, block_type: response.data.type });
+            trackEvent(EVENTS.BLOCK_CREATED, {
+              block_id: response.data.id,
+              block_type: response.data.type,
+              source
+            });
             if (onBlockCreated) {
               onBlockCreated(response.data);
             }

--- a/src/hooks/prompts/actions/useTemplateActions.ts
+++ b/src/hooks/prompts/actions/useTemplateActions.ts
@@ -217,7 +217,8 @@ const useTemplate = useCallback(async (template: Template) => {
           queryClient.invalidateQueries(QUERY_KEYS.USER_FOLDERS);
           trackEvent(EVENTS.TEMPLATE_FOLDER_CREATED, {
             folder_id: newFolder.id,
-            folder_name: newfolder.title
+            folder_name: newFolder.title,
+            source: 'TemplatesPanel'
           });
           
           // Open create template dialog with the new folder selected

--- a/src/hooks/prompts/useTemplateCreation.ts
+++ b/src/hooks/prompts/useTemplateCreation.ts
@@ -15,6 +15,7 @@ interface TemplateFormData {
   tags?: string[];
   locale?: string;
   metadata?: Record<string, number | number[]>;
+  source?: string;
 }
 
 interface TemplateValidationErrors {
@@ -33,16 +34,17 @@ export function useTemplateCreation() {
   // Create template mutation
   const createTemplateMutation = useMutation(
     async (data: TemplateFormData) => {
+      const { source, ...form } = data;
       // Prepare API payload
       const templateData = {
-        title: data.name.trim(),
-        content: data.content.trim(),
-        description: data.description?.trim(),
-        folder_id: data.folder_id || null,
-        metadata: data.metadata || {},
-        tags: data.tags || [],
-        locale: data.locale || navigator.language || 'en',
-        ...(data.metadata ? { metadata: data.metadata } : {})
+        title: form.name.trim(),
+        content: form.content.trim(),
+        description: form.description?.trim(),
+        folder_id: form.folder_id || null,
+        metadata: form.metadata || {},
+        tags: form.tags || [],
+        locale: form.locale || navigator.language || 'en',
+        ...(form.metadata ? { metadata: form.metadata } : {})
       };
 
       
@@ -57,7 +59,8 @@ export function useTemplateCreation() {
       trackEvent(EVENTS.TEMPLATE_CREATE, {
         template_id: response.data.id,
         template_name: response.data.title,
-        template_type: response.data.type
+        template_type: response.data.type,
+        source: source || 'CreateTemplateDialog'
       });
       return response.data;
     },
@@ -126,8 +129,9 @@ export function useTemplateCreation() {
    * Save a template (create new or update existing)
    */
   const saveTemplate = useCallback(async (
-    data: TemplateFormData, 
-    templateId?: number
+    data: TemplateFormData,
+    templateId?: number,
+    source: string = 'CreateTemplateDialog'
   ): Promise<boolean> => {
 
     
@@ -142,7 +146,7 @@ export function useTemplateCreation() {
         await updateTemplateMutation.mutateAsync({ id: templateId, data });
       } else {
         // Create new template
-        await createTemplateMutation.mutateAsync(data);
+        await createTemplateMutation.mutateAsync({ ...data, source });
       }
       return true;
     } catch (error) {
@@ -167,7 +171,7 @@ export function useTemplateCreation() {
         folder_id: template.folder_id
       };
       
-      await createTemplateMutation.mutateAsync(clonedData);
+      await createTemplateMutation.mutateAsync({ ...clonedData, source: 'CreateTemplateDialog' });
       return true;
     } catch (error) {
       console.error('Error cloning template:', error);


### PR DESCRIPTION
## Summary
- extend template creation data to include a `source` field
- pass event `source` when saving templates
- track folder creation source in template dialog and templates panel
- include `source` for block creation events from dialogs and panels

## Testing
- `npm run lint` *(fails: 582 problems)*
- `npm run type-check`
- `npm run build:local`


------
https://chatgpt.com/codex/tasks/task_b_686bcd3ef06c83258bb55db9b3142410