### PR TITLE
Fix metadata block filtering in Advanced editor

### DIFF
--- a/src/components/dialogs/prompts/TemplateEditorDialog/TemplateEditorContext.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/TemplateEditorContext.tsx
@@ -17,6 +17,8 @@ export interface MetadataUIState {
 export interface TemplateEditorContextValue extends MetadataUIState {
   metadata: PromptMetadata;
   setMetadata: (updater: (metadata: PromptMetadata) => PromptMetadata) => void;
+  initialMetadata: PromptMetadata;
+  resetMetadata: () => void;
 
   // Editor state - simplified
   content: string;

--- a/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
@@ -46,6 +46,8 @@ interface TemplateEditorDialogProps {
   
   // Metadata setter for child components
   setMetadata: (updater: (metadata: PromptMetadata) => PromptMetadata) => void;
+  initialMetadata: PromptMetadata;
+  resetMetadata: () => void;
   
   // UI state from base hook
   expandedMetadata: Set<string>;
@@ -91,8 +93,10 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
   applyFinalContentChanges,
   discardFinalContentChanges,
   updateBlockContent,
-  
+
   setMetadata,
+  initialMetadata,
+  resetMetadata,
   
   // UI state
   expandedMetadata,
@@ -122,6 +126,8 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
     () => ({
       metadata,
       setMetadata,
+      initialMetadata,
+      resetMetadata,
       expandedMetadata,
       toggleExpandedMetadata,
       activeSecondaryMetadata,
@@ -139,6 +145,8 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
     [
       metadata,
       setMetadata,
+      initialMetadata,
+      resetMetadata,
       expandedMetadata,
       toggleExpandedMetadata,
       activeSecondaryMetadata,

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
@@ -20,7 +20,8 @@ import {
   METADATA_CONFIGS,
   isMultipleMetadataType,
   SingleMetadataType,
-  MultipleMetadataType
+  MultipleMetadataType,
+  PromptMetadata
 } from '@/types/prompts/metadata';
 import type { MetadataItem } from '@/types/prompts/metadata';
 import { Block } from '@/types/prompts/blocks';
@@ -65,14 +66,25 @@ export const CompactMetadataSection: React.FC<CompactMetadataProps> = ({
   const {
     metadata,
     setMetadata,
-    addNewBlock
+    addNewBlock,
+    initialMetadata,
+    resetMetadata
   } = useTemplateEditor();
 
   const isDarkMode = useThemeDetector();
   const { openDialog } = useDialogManager();
 
   const blocksForType = useMemo(() => {
-    if (mode !== 'customize') return availableMetadataBlocks;
+    if (mode !== 'customize') {
+      const result: Record<MetadataType, Block[]> = {} as Record<MetadataType, Block[]>;
+
+      (Object.keys(METADATA_CONFIGS) as MetadataType[]).forEach(type => {
+        const allBlocks = availableMetadataBlocks[type] || [];
+        result[type] = allBlocks.filter(b => (b as any).published);
+      });
+
+      return result;
+    }
 
     const result: Record<MetadataType, Block[]> = {} as Record<MetadataType, Block[]>;
 
@@ -81,15 +93,21 @@ export const CompactMetadataSection: React.FC<CompactMetadataProps> = ({
       const published = allBlocks.filter(b => (b as any).published);
 
       const selectedIds: number[] = [];
-      if (isMultipleMetadataType(type)) {
-        const items = (metadata as any)[type as MultipleMetadataType] || [];
-        items.forEach((it: any) => {
-          if (it.blockId && !isNaN(it.blockId)) selectedIds.push(it.blockId);
-        });
-      } else {
-        const id = (metadata as any)[type as SingleMetadataType];
-        if (id && id !== 0) selectedIds.push(id);
-      }
+
+      const collectIds = (meta: PromptMetadata) => {
+        if (isMultipleMetadataType(type)) {
+          const items = (meta as any)[type as MultipleMetadataType] || [];
+          items.forEach((it: any) => {
+            if (it.blockId && !isNaN(it.blockId)) selectedIds.push(it.blockId);
+          });
+        } else {
+          const id = (meta as any)[type as SingleMetadataType];
+          if (id && id !== 0) selectedIds.push(id);
+        }
+      };
+
+      collectIds(metadata);
+      collectIds(initialMetadata);
 
       const selectedBlocks = selectedIds
         .map(id => allBlocks.find(b => b.id === id))
@@ -104,7 +122,7 @@ export const CompactMetadataSection: React.FC<CompactMetadataProps> = ({
     });
 
     return result;
-  }, [availableMetadataBlocks, metadata, mode]);
+  }, [availableMetadataBlocks, metadata, initialMetadata, mode]);
 
   // All metadata types combined
   const allMetadataTypes = [...PRIMARY_METADATA, ...SECONDARY_METADATA];
@@ -233,6 +251,14 @@ export const CompactMetadataSection: React.FC<CompactMetadataProps> = ({
         <span className="jd-w-2 jd-h-6 jd-bg-gradient-to-b jd-from-green-500 jd-to-teal-600 jd-rounded-full"></span>
         {getMessage('addBlocksTitle', undefined, 'Add some blocks to your prompt')}
       </h3>
+      {mode === 'customize' && (
+        <button
+          onClick={resetMetadata}
+          className="jd-text-xs jd-underline jd-text-muted-foreground hover:jd-text-foreground"
+        >
+          {getMessage('restoreOriginalMetadata', undefined, 'Restore original metadata')}
+        </button>
+      )}
 
       {/* Ultra-compact metadata grid */}
       <div className="jd-grid jd-grid-cols-8 jd-gap-3">

--- a/src/hooks/dialogs/useTemplateDialogBase.ts
+++ b/src/hooks/dialogs/useTemplateDialogBase.ts
@@ -20,6 +20,7 @@ import {
   reorderMetadataItems,
   addSecondaryMetadata,
   removeSecondaryMetadata,
+  cloneMetadata,
   getActiveSecondaryMetadata,
   getFilledMetadataTypes,
   extractCustomValues,
@@ -44,6 +45,7 @@ export interface TemplateDialogState {
   
   // Metadata state
   metadata: PromptMetadata;
+  initialMetadata: PromptMetadata;
   
   // UI state
   activeTab: 'basic' | 'advanced';
@@ -77,6 +79,7 @@ export interface TemplateDialogActions {
 
   // Direct metadata setter
   setMetadata: (updater: (metadata: PromptMetadata) => PromptMetadata) => void;
+  resetMetadata: () => void;
   
   // UI actions
   setActiveTab: (tab: 'basic' | 'advanced') => void;
@@ -106,6 +109,7 @@ export function useTemplateDialogBase(config: TemplateDialogConfig) {
     
     // Metadata state
     metadata: createMetadata(),
+    initialMetadata: createMetadata(),
     
     // UI state
     activeTab: 'basic',
@@ -218,6 +222,10 @@ export function useTemplateDialogBase(config: TemplateDialogConfig) {
     },
     []
   );
+
+  const resetMetadata = useCallback(() => {
+    setState(prev => ({ ...prev, metadata: cloneMetadata(prev.initialMetadata) }));
+  }, []);
   
   // ============================================================================
   // UI ACTIONS
@@ -314,6 +322,7 @@ export function useTemplateDialogBase(config: TemplateDialogConfig) {
       content: '',
       selectedFolderId: '',
       metadata: createMetadata(),
+      initialMetadata: createMetadata(),
       activeTab: 'basic',
       expandedMetadata: new Set(PRIMARY_METADATA),
       metadataCollapsed: false,
@@ -353,6 +362,7 @@ export function useTemplateDialogBase(config: TemplateDialogConfig) {
             content,
             selectedFolderId: initialData.selectedFolder?.id?.toString() || '',
             metadata: meta,
+            initialMetadata: meta,
             expandedMetadata: new Set([
               ...PRIMARY_METADATA,
               ...Array.from(getFilledMetadataTypes(meta))
@@ -368,14 +378,15 @@ export function useTemplateDialogBase(config: TemplateDialogConfig) {
             : createMetadata();
             
           const content = getLocalizedContent(initialData.content || '');
-  
-          
+
+
           const activeSecondary = getActiveSecondaryMetadata(meta);
 
           setState(prev => ({
             ...prev,
             content,
             metadata: meta,
+            initialMetadata: meta,
             // Expand only metadata types without a value
             expandedMetadata: new Set([]),
             // Keep primary metadata visible, but collapse secondary if there are many
@@ -415,11 +426,12 @@ export function useTemplateDialogBase(config: TemplateDialogConfig) {
     updateMultipleMetadataItem,
     reorderMultipleMetadataItems,
     addSecondaryMetadataType,
-    removeSecondaryMetadataType,
-    setMetadata,
-    
-    // UI actions
-    setActiveTab,
+  removeSecondaryMetadataType,
+  setMetadata,
+  resetMetadata,
+
+  // UI actions
+  setActiveTab,
     toggleExpandedMetadata,
     setMetadataCollapsed,
     setSecondaryMetadataCollapsed,


### PR DESCRIPTION
## Summary
- ensure CompactMetadataSection shows only published blocks when creating
- include initial metadata blocks when customizing and add reset button
- track and expose initial metadata via TemplateEditor context

## Testing
- `npm run lint` *(fails: many lint errors in repo)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_686bccb45f24832585cb2cd71642157d