### PR TITLE
Add onboarding completion video

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1746,6 +1746,8 @@
   "onboardingCompleteDescription": { "message": "Thank you for completing your profile. Your personalized AI templates are now ready to use.", "description": "Description for onboarding completion step" },
   "whatNext": { "message": "What's next?", "description": "Title for next steps after onboarding" },
   "whatNextDescription": { "message": "Open ChatGPT or Claude to start using our extension. Look for our button in the bottom right corner of your screen to access your templates and track your AI usage.", "description": "Description for next steps after onboarding" },
+  "watchVideo": { "message": "Quick Start Video", "description": "Title for video walkthrough" },
+  "watchVideoDescription": { "message": "Watch this short video to see how JayDai works.", "description": "Description for video walkthrough" },
   "goToChatGPT": { "message": "Go to ChatGPT", "description": "Button to go to ChatGPT after onboarding" },
   "goToClaude": { "message": "Go to Claude", "description": "Button to go to Claude after onboarding" },
   "returnToHome": { "message": "Return to Home", "description": "Button to return to home after onboarding" },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1729,6 +1729,8 @@
   "onboardingCompleteDescription": { "message": "Merci d'avoir complété votre profil. Vos templates IA personnalisés sont maintenant prêts à l'emploi.", "description": "Description pour l'étape de fin d'onboarding" },
   "whatNext": { "message": "Et ensuite ?", "description": "Titre pour les prochaines étapes après l'onboarding" },
   "whatNextDescription": { "message": "Ouvrez ChatGPT ou un autre pour commencer à utiliser notre extension. Retrouvez notre bouton en bas à droite de votre écran pour accéder à vos templates et suivre votre utilisation de l'IA.", "description": "Description pour les prochaines étapes après l'onboarding" },
+  "watchVideo": { "message": "Vidéo de démarrage rapide", "description": "Titre pour la vidéo de démonstration" },
+  "watchVideoDescription": { "message": "Regardez cette courte vidéo pour découvrir comment fonctionne l'extension.", "description": "Description de la vidéo de démonstration" },
   "goToChatGPT": { "message": "Aller sur ChatGPT", "description": "Bouton pour aller sur ChatGPT après l'onboarding" },
   "goToClaude": { "message": "Aller sur Claude", "description": "Bouton pour aller sur Claude après l'onboarding" },
   "returnToHome": { "message": "Retour à l'accueil", "description": "Bouton pour retourner à l'accueil après l'onboarding" },

--- a/src/components/welcome/onboarding/steps/CompletionStep.tsx
+++ b/src/components/welcome/onboarding/steps/CompletionStep.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
-import { CheckCircle2, Sparkles, Star, Folder, TrendingUp } from 'lucide-react';
+import { CheckCircle2, Sparkles, Star, Folder, TrendingUp, Play } from 'lucide-react';
 import { getMessage } from '@/core/utils/i18n';
 import { trackEvent, EVENTS } from '@/utils/amplitude';
 import { AIToolGrid } from '@/components/welcome/AIToolGrid';
@@ -159,11 +159,38 @@ export const CompletionStep: React.FC<CompletionStepProps> = ({
           </div>
           <p className="jd-text-gray-400 jd-text-xs jd-leading-relaxed">
             {getMessage(
-              'whatNextDescription', 
-              undefined, 
+              'whatNextDescription',
+              undefined,
               'Open your preferred AI tool above to start using personalized templates. Look for our extension button in the bottom corner.'
             )}
           </p>
+        </div>
+
+        {/* Video Walkthrough */}
+        <div className="jd-bg-gray-800/40 jd-border jd-border-gray-700/50 jd-rounded-lg jd-p-4 jd-flex-1 jd-backdrop-blur-sm">
+          <div className="jd-flex jd-items-center jd-gap-2 jd-mb-3">
+            <Play className="jd-h-4 jd-w-4 jd-text-blue-400" />
+            <h4 className="jd-text-blue-400 jd-font-medium jd-text-sm">
+              {getMessage('watchVideo', undefined, 'Quick Start Video')}
+            </h4>
+          </div>
+          <p className="jd-text-gray-400 jd-text-xs jd-leading-relaxed jd-mb-3">
+            {getMessage(
+              'watchVideoDescription',
+              undefined,
+              'Watch this short video to see how JayDai works.'
+            )}
+          </p>
+          <div style={{ position: 'relative', paddingBottom: '62.5%', height: 0 }}>
+            <iframe
+              src="https://www.loom.com/embed/c910c2ceeea042d99b977b12bd8dba3e?sid=0ffed202-793e-4924-afad-8e89569a68c4"
+              frameBorder="0"
+              allow="fullscreen"
+              webkitAllowFullScreen
+              mozAllowFullScreen
+              style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+            />
+          </div>
         </div>
       </motion.div>
     </motion.div>


### PR DESCRIPTION
## Summary
- add embedded loom video on completion step
- add translation strings for video walkthrough in English and French

## Testing
- `npm run lint` *(fails: 555 problems)*

------
https://chatgpt.com/codex/tasks/task_b_686be02d4f448325b32f9becb195c8d6