### PR TITLE
Add amplitude event for template view switching

### DIFF
--- a/src/hooks/dialogs/useTemplateDialogBase.ts
+++ b/src/hooks/dialogs/useTemplateDialogBase.ts
@@ -28,6 +28,7 @@ import {
   parseTemplateMetadata,
   countMetadataItems
 } from '@/utils/prompts/metadataUtils';
+import { trackEvent, EVENTS } from '@/utils/amplitude';
 
 export interface TemplateDialogConfig {
   dialogType: 'create' | 'customize';
@@ -233,6 +234,7 @@ export function useTemplateDialogBase(config: TemplateDialogConfig) {
   
   const setActiveTab = useCallback((activeTab: 'basic' | 'advanced') => {
     setState(prev => ({ ...prev, activeTab }));
+    trackEvent(EVENTS.TEMPLATE_DIALOG_VIEW_CHANGED, { view: activeTab });
   }, []);
 
   const toggleExpandedMetadata = useCallback((type: MetadataType) => {

--- a/src/utils/amplitude/index.ts
+++ b/src/utils/amplitude/index.ts
@@ -114,6 +114,7 @@ export const EVENTS = {
   TEMPLATE_FOLDER_CREATED: 'Template Folder Created',
   TEMPLATE_EDIT_DIALOG_OPENED: 'Template Edit Dialog Opened',
   TEMPLATE_EDITOR_DIALOG_OPENED: 'Template Editor Dialog Opened',
+  TEMPLATE_DIALOG_VIEW_CHANGED: 'Template Dialog View Changed',
 
   BLOCK_CREATED: 'Block Created',
   BLOCK_DELETED: 'Block Deleted',


### PR DESCRIPTION
## Summary
- send `Template Dialog View Changed` events when switching between basic and advanced views
- add the event name to the amplitude constants

## Testing
- `npm run lint` *(fails: 583 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_686bd1ff53f883258765302920b1b217