### PR TITLE
Add Amplitude tutorial events

### DIFF
--- a/src/components/dialogs/tutorials/TutorialVideoDialog.tsx
+++ b/src/components/dialogs/tutorials/TutorialVideoDialog.tsx
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { BaseDialog } from '../BaseDialog';
 import { useDialog } from '../DialogContext';
 import { DIALOG_TYPES } from '../DialogRegistry';
 import { getMessage } from '@/core/utils/i18n';
+import { trackEvent, EVENTS } from '@/utils/amplitude';
 
 export const TutorialVideoDialog: React.FC = () => {
   const { isOpen, data, dialogProps } = useDialog(DIALOG_TYPES.TUTORIAL_VIDEO);
+
+  useEffect(() => {
+    if (isOpen) {
+      trackEvent(EVENTS.TUTORIAL_VIDEO_PLAYED, {
+        video_title: data?.title,
+      });
+    }
+  }, [isOpen, data]);
 
   if (!isOpen) return null;
 

--- a/src/components/dialogs/tutorials/TutorialsDialog.tsx
+++ b/src/components/dialogs/tutorials/TutorialsDialog.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Video, Play, ExternalLink, Sparkles } from 'lucide-react';
 import { BaseDialog } from '../BaseDialog';
 import { useDialog, useDialogManager } from '../DialogContext';
 import { DIALOG_TYPES } from '../DialogRegistry';
 import { Button } from '@/components/ui/button';
 import { getMessage } from '@/core/utils/i18n';
+import { trackEvent, EVENTS } from '@/utils/amplitude';
 
 const GIF_URLS = [
   {
@@ -80,6 +81,22 @@ export const TutorialsDialog: React.FC = () => {
   const { openDialog } = useDialogManager();
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 
+  useEffect(() => {
+    if (isOpen) {
+      trackEvent(EVENTS.TUTORIALS_LIST_OPENED);
+    }
+  }, [isOpen]);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        trackEvent(EVENTS.TUTORIALS_LIST_CLOSED);
+      }
+      dialogProps.onOpenChange(open);
+    },
+    [dialogProps]
+  );
+
   const openVideo = (url: string, title: string) => {
     openDialog(DIALOG_TYPES.TUTORIAL_VIDEO, { url, title });
   };
@@ -112,7 +129,7 @@ export const TutorialsDialog: React.FC = () => {
   return (
     <BaseDialog
       open={isOpen}
-      onOpenChange={dialogProps.onOpenChange}
+      onOpenChange={handleOpenChange}
       title={getMessage('tutorials', undefined, 'Tutorials')}
       className="jd-max-w-6xl"
       footer={footer}

--- a/src/utils/amplitude/index.ts
+++ b/src/utils/amplitude/index.ts
@@ -131,6 +131,11 @@ export const EVENTS = {
   QUICK_BLOCK_SELECTOR_CLOSED: 'Quick Block Selector Closed',
   QUICK_BLOCK_SELECTOR_BLOCKS_INSERTED: 'Quick Block Selector Blocks Inserted',
 
+  // Tutorial events
+  TUTORIALS_LIST_OPENED: 'Tutorials List Opened',
+  TUTORIALS_LIST_CLOSED: 'Tutorials List Closed',
+  TUTORIAL_VIDEO_PLAYED: 'Tutorial Video Played',
+
   // Notification events
   NOTIFICATIONS_PANEL_OPENED: 'Notifications Panel Opened',
   NOTIFICATION_ACTION_CLICKED: 'Notification Action Clicked',


### PR DESCRIPTION
## Summary
- add specific Amplitude events for tutorial interactions
- track list open/close in `TutorialsDialog`
- track tutorial video plays in `TutorialVideoDialog`

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_686c089a58008325bedffa75d8f9e984