### PR TITLE
Track main button drag events

### DIFF
--- a/src/components/MainButton.tsx
+++ b/src/components/MainButton.tsx
@@ -56,6 +56,7 @@ const MainButton = () => {
     offsetRef.current = { x: e.clientX - rect.left, y: e.clientY - rect.top };
     setIsDragging(true);
     movedRef.current = false;
+    trackEvent(EVENTS.MAIN_BUTTON_DRAG_STARTED);
     
     // Prevent button click when starting drag
     e.preventDefault();
@@ -88,6 +89,7 @@ const MainButton = () => {
         } catch (error) {
           console.error('Error storing main button position:', error);
         }
+        trackEvent(EVENTS.MAIN_BUTTON_DRAG_ENDED, { x: newPos.x, y: newPos.y });
       }
     };
 

--- a/src/utils/amplitude/index.ts
+++ b/src/utils/amplitude/index.ts
@@ -58,6 +58,8 @@ export const EVENTS = {
   BUTTON_INJECTED: 'Button Injected',
   BUTTON_CLICKED: 'Button Clicked',
   MAIN_BUTTON_CLICKED: 'Main Button Clicked',
+  MAIN_BUTTON_DRAG_STARTED: 'Main Button Drag Started',
+  MAIN_BUTTON_DRAG_ENDED: 'Main Button Drag Ended',
   
   // Authentication events
   SIGNIN_STARTED: 'Sign In Started',


### PR DESCRIPTION
## Summary
- log start/end of main button drag operations to Amplitude

## Testing
- `npm run lint` *(fails: 583 errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_686c0fe436208325aead485d34908329