### PR TITLE
Add search content to Template Search Amplitude event

### DIFF
--- a/src/components/panels/BrowseTemplatesPanel/index.tsx
+++ b/src/components/panels/BrowseTemplatesPanel/index.tsx
@@ -72,7 +72,7 @@ const BrowseTemplatesPanel: React.FC<BrowseTemplatesPanelProps> = ({
   } = useFolderSearch(folders);
 
   useEffect(() => {
-    trackEvent(EVENTS.TEMPLATE_SEARCH, { query: searchQuery });
+    trackEvent(EVENTS.TEMPLATE_SEARCH, { search_content: searchQuery });
   }, [searchQuery]);
   
   // Get folder mutations

--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -195,7 +195,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
   }, [searchQuery, setGlobalSearchQuery]);
 
   useEffect(() => {
-    trackEvent(EVENTS.TEMPLATE_SEARCH, { query: searchQuery });
+    trackEvent(EVENTS.TEMPLATE_SEARCH, { search_content: searchQuery });
   }, [searchQuery]);
 
   // Navigation hook for combined user + organization folders


### PR DESCRIPTION
## Summary
- track search text for template searches in BrowseTemplatesPanel
- track search text for template searches in TemplatesPanel

## Testing
- `npm run lint` *(fails: registry access blocked)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_686c10278334832597c1bb7b402e4b34