### PR TITLE
Track template metadata in analytics

### DIFF
--- a/src/hooks/dialogs/useCreateTemplateDialog.ts
+++ b/src/hooks/dialogs/useCreateTemplateDialog.ts
@@ -7,7 +7,7 @@ import { useTemplateCreation } from '@/hooks/prompts/useTemplateCreation';
 import { toast } from 'sonner';
 import { getMessage } from '@/core/utils/i18n';
 import { PromptMetadata } from '@/types/prompts/metadata';
-import { metadataToBlockMapping } from '@/utils/prompts/metadataUtils';
+import { metadataToBlockMapping, listFilledMetadataFields } from '@/utils/prompts/metadataUtils';
 
 export function useCreateTemplateDialog() {
   const createDialog = useDialog(DIALOG_TYPES.CREATE_TEMPLATE);
@@ -29,7 +29,8 @@ export function useCreateTemplateDialog() {
         content: content, // Use the base content directly
         description: baseHook.description?.trim(),
         folder_id: baseHook.selectedFolderId ? parseInt(baseHook.selectedFolderId, 10) : undefined,
-        metadata: metadataToBlockMapping(metadata)
+        metadata: metadataToBlockMapping(metadata),
+        metadata_fields: listFilledMetadataFields(metadata)
       };
             
       const currentTemplate = data?.template;

--- a/src/hooks/prompts/useTemplateCreation.ts
+++ b/src/hooks/prompts/useTemplateCreation.ts
@@ -15,6 +15,7 @@ interface TemplateFormData {
   tags?: string[];
   locale?: string;
   metadata?: Record<string, number | number[]>;
+  metadata_fields?: string[];
   source?: string;
 }
 
@@ -34,7 +35,7 @@ export function useTemplateCreation() {
   // Create template mutation
   const createTemplateMutation = useMutation(
     async (data: TemplateFormData) => {
-      const { source, ...form } = data;
+      const { source, metadata_fields, ...form } = data;
       // Prepare API payload
       const templateData = {
         title: form.name.trim(),
@@ -60,6 +61,7 @@ export function useTemplateCreation() {
         template_id: response.data.id,
         template_name: response.data.title,
         template_type: response.data.type,
+        metadata_fields: metadata_fields,
         source: source || 'CreateTemplateDialog'
       });
       return response.data;
@@ -81,13 +83,14 @@ export function useTemplateCreation() {
   const updateTemplateMutation = useMutation(
     async ({ id, data }: { id: number; data: TemplateFormData }) => {
       // Prepare API payload
+      const { metadata_fields, ...rest } = data;
       const templateData = {
-        title: data.name.trim(),
-        content: data.content.trim(),
-        description: data.description?.trim(),
-        folder_id: data.folder_id || null,
-        tags: data.tags || [],
-        ...(data.metadata ? { metadata: data.metadata } : {})
+        title: rest.name.trim(),
+        content: rest.content.trim(),
+        description: rest.description?.trim(),
+        folder_id: rest.folder_id || null,
+        tags: rest.tags || [],
+        ...(rest.metadata ? { metadata: rest.metadata } : {})
       };
       
       const response = await promptApi.updateTemplate(id, templateData);

--- a/src/utils/prompts/metadataUtils.ts
+++ b/src/utils/prompts/metadataUtils.ts
@@ -392,6 +392,37 @@ export function countMetadataItems(metadata: PromptMetadata): number {
   return count;
 }
 
+/**
+ * Create a list of metadata types that contain values. Multiple metadata
+ * types (like `example`) will appear as many times as there are filled items.
+ */
+export function listFilledMetadataFields(metadata: PromptMetadata): string[] {
+  const fields: string[] = [];
+
+  [...PRIMARY_METADATA, ...SECONDARY_METADATA].forEach(type => {
+    if (isMultipleMetadataType(type)) {
+      const key = MULTI_TYPE_KEY_MAP[type];
+      const items = (metadata as any)[key];
+      if (Array.isArray(items)) {
+        items.forEach((item: MetadataItem) => {
+          if (item.value && item.value.trim()) {
+            fields.push(type);
+          }
+        });
+      }
+    } else {
+      const singleType = type as SingleMetadataType;
+      const blockId = metadata[singleType];
+      const customValue = metadata.values?.[singleType];
+      if ((blockId && blockId !== 0) || (customValue && customValue.trim())) {
+        fields.push(type);
+      }
+    }
+  });
+
+  return fields;
+}
+
 // ============================================================================
 // METADATA CONVERSION
 // ============================================================================


### PR DESCRIPTION
## Summary
- gather filled metadata fields when creating templates
- send metadata field list in amplitude events for new templates

## Testing
- `npm run lint` *(fails: 585 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_686c10cb4e2c8325a816b7993a8da6fc