### PR TITLE
Fix small-screen banner display and track website clicks

### DIFF
--- a/src/components/dialogs/BaseDialog.tsx
+++ b/src/components/dialogs/BaseDialog.tsx
@@ -1,6 +1,5 @@
 // src/components/dialogs/BaseDialog.tsx
 import React, { useRef, useEffect, useState } from 'react';
-import { useDialogFocusGuard } from '@/core/utils/shadowDomFocusManager';
 import { getMessage } from '@/core/utils/i18n';
 import { cn } from "@/core/utils/classNames";
 import { X } from "lucide-react";
@@ -137,7 +136,7 @@ export const BaseDialog: React.FC<BaseDialogProps> = ({
   return (
     <div
       data-dialog-root
-      className="jd-fixed jd-inset-0 jd-bg-black/50 jd-flex jd-items-center jd-justify-center jd-overflow-hidden"
+      className="jd-fixed jd-inset-0 jd-bg-black/50 jd-flex jd-items-start md:jd-items-center jd-justify-center jd-overflow-y-auto"
       onClick={handleBackdropClick}
       onMouseDown={(e) => e.stopPropagation()}
       style={{ isolation: 'isolate', zIndex: baseZIndex }} // Create new stacking context

--- a/src/components/organizations/OrganizationBanner.tsx
+++ b/src/components/organizations/OrganizationBanner.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/core/utils/classNames';
 import { OrganizationImage } from '@/components/organizations';
 import { Organization } from '@/types/organizations';
 import { getMessage } from '@/core/utils/i18n';
+import { trackEvent, EVENTS } from '@/utils/amplitude';
 
 interface OrganizationBannerProps {
   organization: Organization;
@@ -106,6 +107,12 @@ export const OrganizationBanner: React.FC<OrganizationBannerProps> = ({
               href={organization.website_url}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() =>
+                trackEvent(EVENTS.ORGANIZATION_WEBSITE_CLICKED, {
+                  organization_id: organization.id,
+                  organization_name: organization.name,
+                })
+              }
               className={cn(
                 'jd-group jd-inline-flex jd-items-center jd-gap-2 jd-px-3 jd-py-2 jd-rounded-full jd-text-xs jd-font-medium jd-transition-all jd-duration-200 jd-transform hover:jd-scale-105 jd-shadow-sm hover:jd-shadow-md',
                 organization.banner_url

--- a/src/utils/amplitude/index.ts
+++ b/src/utils/amplitude/index.ts
@@ -112,6 +112,7 @@ export const EVENTS = {
   TEMPLATE_BROWSE_ORGANIZATION: 'Template Browse Organization',
   ENTERPRISE_LIBRARY_ACCESSED: 'Enterprise Library Accessed',
   ENTERPRISE_CTA_CLICKED: 'Enterprise CTA Clicked',
+  ORGANIZATION_WEBSITE_CLICKED: 'Organization Website Clicked',
   TEMPLATE_REFRESH: 'Template Refresh',
   TEMPLATE_FOLDER_CREATED: 'Template Folder Created',
   TEMPLATE_EDIT_DIALOG_OPENED: 'Template Edit Dialog Opened',
@@ -174,7 +175,7 @@ export const EVENTS = {
  * Set user properties to track
  * @param properties User properties to track
  */
-export const setUserProperties = (properties: Record<string, any>) => {
+export const setUserProperties = (properties: Record<string, unknown>) => {
   // Create a new Identify object
   const identify = new amplitude.Identify();
   


### PR DESCRIPTION
## Summary
- allow dialog to scroll vertically when viewport is short
- add ORGANIZATION_WEBSITE_CLICKED amplitude event
- track click on organization website link

## Testing
- `npx eslint src/components/organizations/OrganizationBanner.tsx src/components/dialogs/BaseDialog.tsx src/utils/amplitude/index.ts`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_686c1168b3a4832593c5dd8ff01cefb5