### PR TITLE
Fix new block button style & behavior

### DIFF
--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -530,9 +530,9 @@ const filteredBlocks = blocks.filter(b => {
                 ))}
                 <Button
                   size="sm"
-                  variant="outline"
-                  onClick={() => openCreateBlock()}
-                  className="jd-h-6 jd-text-xs jd-px-2 jd-border-dashed"
+                  variant="default"
+                  onClick={handleCreate}
+                  className="jd-h-6 jd-text-xs jd-px-2"
                 >
                   <Plus className="jd-h-3 jd-w-3 jd-mr-1" />
                   {getMessage('newBlock', undefined, 'New Block')}


### PR DESCRIPTION
## Summary
- update the "New Block" filter button in `InsertBlockDialog`
  - use primary color for visibility
  - trigger inline block creator like the footer button

## Testing
- `npm run lint` *(fails: 556 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_686c478f83688325bf92a01ee90cb64a