### PR TITLE
Fix CreateBlockDialog closing

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
@@ -159,6 +159,7 @@ export const CompactMetadataSection: React.FC<CompactMetadataProps> = ({
               updateSingleMetadata(prev, type as SingleMetadataType, b.id)
             );
           }
+          return true;
         }
       });
       return;
@@ -199,6 +200,7 @@ export const CompactMetadataSection: React.FC<CompactMetadataProps> = ({
                 value: getLocalizedContent(b.content)
               })
             );
+            return true;
           }
         });
         return;


### PR DESCRIPTION
## Summary
- ensure CreateBlockDialog closes after creating a block from CompactMetadataSection

## Testing
- `npm run lint` *(fails: 559 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_686c54952c2c8325a83cddbc88c36072