### PR TITLE
Fix fallback blocks in metadata cards

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
@@ -115,7 +115,8 @@ export const CompactMetadataSection: React.FC<CompactMetadataProps> = ({
         .filter(Boolean) as Block[];
 
       const combined: Block[] = [...selectedBlocks];
-      published.forEach(b => {
+      const toAdd = published.length > 0 ? published : allBlocks;
+      toAdd.forEach(b => {
         if (!combined.some(sb => sb.id === b.id)) combined.push(b);
       });
 

--- a/src/components/dialogs/prompts/editors/AdvancedEditor/MetadataSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/MetadataSection.tsx
@@ -92,7 +92,7 @@ export const MetadataSection: React.FC<MetadataSectionProps> = ({
       const allBlocks = availableMetadataBlocks[type] || [];
       const published = allBlocks.filter(
 
-        b => (b as any).published 
+        b => (b as any).published
       );
 
       const selectedIds: number[] = [];
@@ -112,7 +112,8 @@ export const MetadataSection: React.FC<MetadataSectionProps> = ({
         .filter(Boolean) as Block[];
 
       const combined: Block[] = [...selectedBlocks];
-      published.forEach(b => {
+      const toAdd = published.length > 0 ? published : allBlocks;
+      toAdd.forEach(b => {
         if (!combined.some(sb => sb.id === b.id)) combined.push(b);
       });
 


### PR DESCRIPTION
## Summary
- ensure published or all blocks are used in compact metadata cards when customizing
- mirror same logic in metadata section

## Testing
- `npm run lint` *(fails: 592 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_686d138250ec832584bf4758204948a1