### PR TITLE
Fix Amplitude tracking for popup

### DIFF
--- a/src/extension/popup/ExtensionPopup.tsx
+++ b/src/extension/popup/ExtensionPopup.tsx
@@ -37,16 +37,20 @@ const ExtensionPopup: React.FC = () => {
     if (!authService.isInitialized()) {
       authService.initialize();
     }
-    if (authState.user) {
-      initAmplitude(authState.user.id, false);
-      trackEvent(EVENTS.POPUP_OPENED);
-    }
 
     // Cleanup subscription
     return () => {
       unsubscribe();
     };
   }, []);
+
+  // Track popup opened event once the user information is available
+  useEffect(() => {
+    if (authState.user) {
+      initAmplitude(authState.user.id, false);
+      trackEvent(EVENTS.POPUP_OPENED);
+    }
+  }, [authState.user]);
 
   const handleLogout = async () => {
     try {


### PR DESCRIPTION
## Summary
- trigger `Popup Opened` event after auth state loads

## Testing
- `pnpm lint` *(fails: 562 errors)*
- `pnpm type-check`

------
https://chatgpt.com/codex/tasks/task_b_686d1c7f5184832590f6c051919b001d