### PR TITLE
Fix null requestBody handling in fetch interceptor

### DIFF
--- a/src/extension/content/networkInterceptor/fetchInterceptor.js
+++ b/src/extension/content/networkInterceptor/fetchInterceptor.js
@@ -84,7 +84,7 @@ export function initFetchInterceptor() {
     }
     
     // Extract request body
-    const requestBody = extractRequestBody(init);
+    const requestBody = extractRequestBody(init) || {};
     
     // Call original fetch
     const response = await originalFetch.apply(this, arguments);
@@ -100,7 +100,9 @@ export function initFetchInterceptor() {
         
         // Detect streaming more reliably
         const isStreaming = isStreamingResponse(response, init, platform);
-        requestBody['parentMessageId'] = requestBody.messageId;
+        if (requestBody) {
+          requestBody['parentMessageId'] = requestBody.messageId;
+        }
         
         if (isStreaming) {
           // Process streaming responses


### PR DESCRIPTION
## Summary
- prevent `fetchInterceptor` from crashing when `extractRequestBody` returns `null`

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_686d222de8188325b999e8d5a17f34ab