### PR TITLE
Add Segment analytics integration

### DIFF
--- a/src/extension/popup/popup.html
+++ b/src/extension/popup/popup.html
@@ -5,9 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AI Tool Launcher</title>
   <link rel="stylesheet" href="assets/popup.css">
+  <script>
+  !function(){var i="analytics",analytics=window[i]=window[i]||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","screen","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware","register"];analytics.factory=function(e){return function(){if(window[i].initialized)return window[i][e].apply(window[i],arguments);var n=Array.prototype.slice.call(arguments);if(["track","screen","alias","group","page","identify"].indexOf(e)>-1){var c=document.querySelector("link[rel='canonical']");n.push({__t:"bpc",c:c&&c.getAttribute("href")||void 0,p:location.pathname,u:location.href,s:location.search,t:document.title,r:document.referrer})}n.unshift(e);analytics.push(n);return analytics}};for(var n=0;n<analytics.methods.length;n++){var key=analytics.methods[n];analytics[key]=analytics.factory(key)}analytics.load=function(key,n){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.setAttribute("data-global-segment-analytics-key",i);t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(t,r);analytics._loadOptions=n};analytics._writeKey="78FDgY1UHZOjCH2Yx15hjpxAWzgPUpxA";;analytics.SNIPPET_VERSION="5.2.0";
+  analytics.load("78FDgY1UHZOjCH2Yx15hjpxAWzgPUpxA");
+  analytics.page();
+  }}();
+  </script>
 </head>
 <body class="jaydai-popup">
   <div id="root"></div>
   <script type="module" src="popup.js"></script>
-</body>
-</html>
+</body></html>

--- a/src/extension/welcome/welcome.html
+++ b/src/extension/welcome/welcome.html
@@ -9,6 +9,12 @@
     <link rel="icon" type="image/png" href="icons/icon16.png" />
 
     <link rel="stylesheet" href="assets/welcome.css">
+    <script>
+    !function(){var i="analytics",analytics=window[i]=window[i]||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","screen","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware","register"];analytics.factory=function(e){return function(){if(window[i].initialized)return window[i][e].apply(window[i],arguments);var n=Array.prototype.slice.call(arguments);if(["track","screen","alias","group","page","identify"].indexOf(e)>-1){var c=document.querySelector("link[rel='canonical']");n.push({__t:"bpc",c:c&&c.getAttribute("href")||void 0,p:location.pathname,u:location.href,s:location.search,t:document.title,r:document.referrer})}n.unshift(e);analytics.push(n);return analytics}};for(var n=0;n<analytics.methods.length;n++){var key=analytics.methods[n];analytics[key]=analytics.factory(key)}analytics.load=function(key,n){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.setAttribute("data-global-segment-analytics-key",i);t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(t,r);analytics._loadOptions=n};analytics._writeKey="78FDgY1UHZOjCH2Yx15hjpxAWzgPUpxA";;analytics.SNIPPET_VERSION="5.2.0";
+    analytics.load("78FDgY1UHZOjCH2Yx15hjpxAWzgPUpxA");
+    analytics.page();
+    }}();
+    </script>
 </head>
 <body class="jaydai-welcome">
     <div id="root"></div>

--- a/src/utils/amplitude/index.ts
+++ b/src/utils/amplitude/index.ts
@@ -2,6 +2,15 @@
 import * as amplitude from '@amplitude/analytics-browser';
 import { detectPlatform } from '@/platforms/platformManager';
 
+declare global {
+  interface Window {
+    analytics?: {
+      track: (event: string, properties?: Record<string, unknown>) => void;
+      page?: (properties?: Record<string, unknown>) => void;
+    };
+  }
+}
+
 /**
  * Initialize Amplitude with the API key and user ID (if available)
  * @param userId Optional user ID to identify the user
@@ -45,7 +54,15 @@ export const setAmplitudeUserId = (userId: string) => {
  */
 export const trackEvent = (eventName: string, eventProperties = {}) => {
   const platform = detectPlatform();
-  amplitude.track(eventName, { ...eventProperties, 'ai_platform': platform });
+  const props = { ...eventProperties, 'ai_platform': platform };
+  amplitude.track(eventName, props);
+  if (window.analytics && typeof window.analytics.track === 'function') {
+    try {
+      window.analytics.track(eventName, props);
+    } catch (err) {
+      console.error('Segment track error', err);
+    }
+  }
 };
 
 /**
@@ -224,5 +241,12 @@ export const incrementUserProperty = (property: string, value: number = 1) => {
  * @param pageName Name of the page being viewed
  */
 export const trackPageView = (pageName: string) => {
-  amplitude.track('Page Viewed', { page_name: pageName });
-};
+  const props = { page_name: pageName };
+  amplitude.track('Page Viewed', props);
+  if (window.analytics && typeof window.analytics.page === 'function') {
+    try {
+      window.analytics.page(props);
+    } catch (err) {
+      console.error('Segment page error', err);
+    }
+  }};


### PR DESCRIPTION
## Summary
- integrate Segment snippet in popup and welcome pages
- update amplitude utilities to forward events to Segment

## Testing
- `npm run type-check`
- `npm run lint` *(fails: 590 problems)*

------
https://chatgpt.com/codex/tasks/task_b_686efa9020a88325a576229001699ca3