### PR TITLE
Filter blocks by published flag

### DIFF
--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -294,12 +294,9 @@ export const InsertBlockDialog: React.FC = () => {
       setSearch('');
       setSelectedTypeFilter('all');
       setShowInlineCreator(false);
-      blocksApi.getBlocks().then(res => {
+      blocksApi.getBlocks({ published: true }).then(res => {
         if (res.success) {
-          const published = res.data.filter(
-            b => (b as any).published
-          );
-          setBlocks(published);
+          setBlocks(res.data);
         } else {
           setBlocks([]);
         }
@@ -392,15 +389,14 @@ export const InsertBlockDialog: React.FC = () => {
     deleteBlock(block);
   };
 
-// Filter blocks based on search, type, and published status
+// Filter blocks based on search and type
 const filteredBlocks = blocks.filter(b => {
   const title = typeof b.title === 'string' ? b.title : b.title?.en || '';
   const content = typeof b.content === 'string' ? b.content : b.content.en || '';
   const term = search.toLowerCase();
   const matchesSearch = title.toLowerCase().includes(term) || content.toLowerCase().includes(term);
   const matchesType = selectedTypeFilter === 'all' || b.type === selectedTypeFilter;
-  const isPublished = (b as any).published;
-  return matchesSearch && matchesType && isPublished;
+  return matchesSearch && matchesType;
 });
 
   // Get unique block types for filter

--- a/src/components/prompts/blocks/quick-selector/useBlocks.ts
+++ b/src/components/prompts/blocks/quick-selector/useBlocks.ts
@@ -15,12 +15,9 @@ export function useBlocks() {
   const fetchBlocks = async () => {
     setLoading(true);
     try {
-      const res = await blocksApi.getBlocks();
+      const res = await blocksApi.getBlocks({ published: true });
       if (res.success) {
-        const published = res.data.filter(
-          b => (b as any).published
-        );
-        setBlocks(published);
+        setBlocks(res.data);
       } else {
         setBlocks([]);
       }

--- a/src/hooks/dialogs/useCustomizeTemplateDialog.ts
+++ b/src/hooks/dialogs/useCustomizeTemplateDialog.ts
@@ -48,7 +48,7 @@ export function useCustomizeTemplateDialog() {
     if (!isOpen) return;
     const loadBlocks = async () => {
       try {
-        const res = await blocksApi.getBlocks();
+        const res = await blocksApi.getBlocks({ published: true });
         if (res.success && Array.isArray(res.data)) {
           setBlockContentCache(buildBlockCache(res.data));
         }

--- a/src/services/api/BlocksApi.ts
+++ b/src/services/api/BlocksApi.ts
@@ -30,9 +30,17 @@ class BlocksApiClient {
   /**
    * Get all blocks
    */
-  async getBlocks(): Promise<ApiResponse<Block[]>> {
+  async getBlocks(options: { published?: boolean; q?: string } = {}): Promise<ApiResponse<Block[]>> {
     try {
-      const response = await apiClient.request('/prompts/blocks');
+      const params = new URLSearchParams();
+      if (typeof options.published === 'boolean') {
+        params.append('published', String(options.published));
+      }
+      if (options.q) {
+        params.append('q', options.q);
+      }
+      const query = params.toString() ? `?${params.toString()}` : '';
+      const response = await apiClient.request(`/prompts/blocks${query}`);
       return response;
     } catch (error) {
       console.error('Error fetching blocks:', error);


### PR DESCRIPTION
## Summary
- add optional query parameters to `BlocksApi.getBlocks`
- request published blocks when opening InsertBlockDialog
- remove client-side filtering for unpublished blocks
- request published blocks in QuickBlockSelector
- request published blocks in CustomizeTemplateDialog

## Testing
- `npm run lint` *(fails: 587 errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68713e96ebb083258886889fd2540a0d