### PR TITLE
Avoid fetching templates in folder queries

### DIFF
--- a/src/hooks/prompts/queries/folders/useUserCompanyOrganizationFolders.ts
+++ b/src/hooks/prompts/queries/folders/useUserCompanyOrganizationFolders.ts
@@ -13,8 +13,8 @@ export function useUserFolders() {
   const locale = getCurrentLanguage();
 
   return useQuery(QUERY_KEYS.USER_FOLDERS, async (): Promise<TemplateFolder[]> => {
-    // Get folders
-    const foldersResponse = await promptApi.getFolders('user', true, true, locale);
+    // Get folders without templates to minimize payload
+    const foldersResponse = await promptApi.getFolders('user', true, false, locale);
     if (!foldersResponse.success) {
       throw new Error(foldersResponse.message || 'Failed to load user folders');
     }
@@ -36,8 +36,8 @@ export function useCompanyFolders() {
   const locale = getCurrentLanguage();
 
   return useQuery(QUERY_KEYS.COMPANY_FOLDERS, async (): Promise<TemplateFolder[]> => {
-    // Get folders
-    const foldersResponse = await promptApi.getFolders('company', true, true, locale);
+    // Get folders without templates to minimize payload
+    const foldersResponse = await promptApi.getFolders('company', true, false, locale);
     if (!foldersResponse.success) {
       throw new Error(foldersResponse.message || 'Failed to load company folders');
     }
@@ -56,8 +56,8 @@ export function useOrganizationFolders() {
   const locale = getCurrentLanguage();
 
   return useQuery(QUERY_KEYS.ORGANIZATION_FOLDERS, async (): Promise<TemplateFolder[]> => {
-    // Get folders
-    const foldersResponse = await promptApi.getFolders('organization', true, true, locale);
+    // Get folders without templates to minimize payload
+    const foldersResponse = await promptApi.getFolders('organization', true, false, locale);
     
     if (!foldersResponse.success) {
       throw new Error(foldersResponse.message || 'Failed to load organization folders');


### PR DESCRIPTION
## Summary
- fetch folders in `useUserFolders`, `useCompanyFolders`, and `useOrganizationFolders` without template data
- update comments to note that templates aren't returned

The pinned folder utilities such as `useAllPinnedFolders` operate on folder IDs only and still work when folder `templates` arrays are empty.

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68713e984984832596289337050daca6