### PR TITLE
Add templates by folder hook and API

### DIFF
--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -13,6 +13,7 @@ export const QUERY_KEYS = {
     ALL_FOLDERS: 'allFolders',
     USER_TEMPLATES: 'userTemplates',
     UNORGANIZED_TEMPLATES: 'unorganizedTemplates',
+    TEMPLATES_BY_FOLDER: 'templatesByFolder',
     PINNED_FOLDERS: 'pinnedFolders',
     PINNED_TEMPLATES: 'pinnedTemplates',
     

--- a/src/hooks/prompts/queries/templates/index.ts
+++ b/src/hooks/prompts/queries/templates/index.ts
@@ -1,3 +1,4 @@
 export { useUserTemplates } from './useUserTemplates';
 export { useUnorganizedTemplates } from './useUnorganizedTemplates';
 export { usePinnedTemplates } from './usePinnedTemplates';
+export { useTemplatesByFolder } from './useTemplatesByFolder';

--- a/src/hooks/prompts/queries/templates/useTemplatesByFolder.ts
+++ b/src/hooks/prompts/queries/templates/useTemplatesByFolder.ts
@@ -1,0 +1,25 @@
+import { useQuery } from 'react-query';
+import { promptApi } from '@/services/api';
+import { toast } from 'sonner';
+import { QUERY_KEYS } from '@/constants/queryKeys';
+import { Template } from '@/types/prompts/templates';
+
+export function useTemplatesByFolder(folderId: number) {
+  return useQuery(
+    [QUERY_KEYS.TEMPLATES_BY_FOLDER, folderId],
+    async () => {
+      const response = await promptApi.getTemplatesByFolder(folderId);
+      if (!response.success) {
+        throw new Error(response.message || 'Failed to fetch templates');
+      }
+      return response.data as Template[];
+    },
+    {
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false,
+      onError: (error: Error) => {
+        toast.error(`Failed to load templates: ${error.message}`);
+      }
+    }
+  );
+}

--- a/src/services/api/PromptApi.ts
+++ b/src/services/api/PromptApi.ts
@@ -15,6 +15,7 @@ import {
         deleteTemplate,
         getUnorganizedTemplates,
         getUserTemplates,
+        getTemplatesByFolder,
         trackTemplateUsage,
         toggleTemplatePin
       } from './prompts/templates';
@@ -71,6 +72,10 @@ class PromptApiClient {
 
   async getUserTemplates(): Promise<any> {
     return getUserTemplates();
+  }
+
+  async getTemplatesByFolder(folderId: number): Promise<any> {
+    return getTemplatesByFolder(folderId);
   }
 
   async createFolder(folderData: { title: string; description?: string; parent_folder_id?: number | null }): Promise<any> {

--- a/src/services/api/prompts/templates/getTemplatesByFolder.ts
+++ b/src/services/api/prompts/templates/getTemplatesByFolder.ts
@@ -1,0 +1,20 @@
+import { apiClient } from "@/services/api/ApiClient";
+
+/**
+ * Get templates by folder ID
+ */
+export async function getTemplatesByFolder(folderId: number): Promise<any> {
+  try {
+    const response = await apiClient.request(`/prompts/templates?folder_id=${folderId}`, {
+      method: 'GET'
+    });
+    return response;
+  } catch (error) {
+    console.error('Error fetching templates by folder:', error);
+    return {
+      success: false,
+      data: [],
+      message: error instanceof Error ? error.message : 'Unknown error'
+    };
+  }
+}

--- a/src/services/api/prompts/templates/index.ts
+++ b/src/services/api/prompts/templates/index.ts
@@ -3,5 +3,6 @@ export { updateTemplate } from './updateTemplate';
 export { deleteTemplate } from './deleteTemplate';
 export { getUnorganizedTemplates } from './getUnorganizedTemplates';
 export { getUserTemplates } from './getUserTemplates';
+export { getTemplatesByFolder } from './getTemplatesByFolder';
 export { trackTemplateUsage } from './trackTemplateUsage';
 export { toggleTemplatePin } from './toggleTemplatePin';


### PR DESCRIPTION
## Summary
- add getTemplatesByFolder API call
- expose the API via PromptApi
- add React Query hook `useTemplatesByFolder`
- export hook and API
- extend QUERY_KEYS with `TEMPLATES_BY_FOLDER`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68713e9973f08325ad53be8d9a0d7de6