### PR TITLE
Add stale time to prompt query hooks

### DIFF
--- a/src/hooks/prompts/queries/folders/useAllFolders.ts
+++ b/src/hooks/prompts/queries/folders/useAllFolders.ts
@@ -19,6 +19,8 @@ export function useAllFolders() {
       organization: (organizationResponse.data.folders.organization || []) as TemplateFolder[]
     };
   }, {
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
     onError: (error: Error) => {
       toast.error(`Failed to load folders: ${error.message}`);

--- a/src/hooks/prompts/queries/folders/useAllFoldersOfType.ts
+++ b/src/hooks/prompts/queries/folders/useAllFoldersOfType.ts
@@ -23,6 +23,8 @@ export function useAllFoldersOfType(folderType: 'organization' | 'company') {
       return (response.data.folders[folderType] || []) as TemplateFolder[];
     },
     {
+      staleTime: 5 * 60 * 1000,
+      cacheTime: 5 * 60 * 1000,
       refetchOnWindowFocus: false,
       onError: (error: Error) => {
         toast.error(`Failed to load ${folderType} folders: ${error.message}`);

--- a/src/hooks/prompts/queries/folders/usePinnedFolders.ts
+++ b/src/hooks/prompts/queries/folders/usePinnedFolders.ts
@@ -56,6 +56,8 @@ export function usePinnedFolders() {
       pinnedIds
     };
   }, {
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
     onError: (error: Error) => {
       toast.error(`Failed to load pinned folders: ${error.message}`);

--- a/src/hooks/prompts/queries/folders/useUserCompanyOrganizationFolders.ts
+++ b/src/hooks/prompts/queries/folders/useUserCompanyOrganizationFolders.ts
@@ -25,6 +25,8 @@ export function useUserFolders() {
     // causing parent_folder_id to always be null in CreateFolderDialog
     return folders;
   }, {
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
     onError: (error: Error) => {
       toast.error(`Failed to load user folders: ${error.message}`);
@@ -45,6 +47,8 @@ export function useCompanyFolders() {
     // Return all folders to allow nested selection in folder pickers
     return folders;
   }, {
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
     onError: (error: Error) => {
       toast.error(`Failed to load company folders: ${error.message}`);
@@ -66,6 +70,8 @@ export function useOrganizationFolders() {
     // Return the full hierarchy so nested folders are preserved
     return folders;
   }, {
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
     onError: (error: Error) => {
       toast.error(`Failed to load organization folders: ${error.message}`);

--- a/src/hooks/prompts/queries/templates/usePinnedTemplates.ts
+++ b/src/hooks/prompts/queries/templates/usePinnedTemplates.ts
@@ -13,6 +13,8 @@ export function usePinnedTemplates() {
     const pinnedIds: number[] = metadata.data?.pinned_template_ids || [];
     return pinnedIds;
   }, {
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
     onError: (error: Error) => {
       toast.error(`Failed to load pinned templates: ${error.message}`);

--- a/src/hooks/prompts/queries/templates/useUnorganizedTemplates.ts
+++ b/src/hooks/prompts/queries/templates/useUnorganizedTemplates.ts
@@ -16,6 +16,8 @@ export function useUnorganizedTemplates() {
     }
     return response.data.filter((template: Template) => !template.folder_id) as Template[];
   }, {
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
     onError: (error: Error) => {
       toast.error(`Failed to load unorganized templates: ${error.message}`);

--- a/src/hooks/prompts/queries/templates/useUserTemplates.ts
+++ b/src/hooks/prompts/queries/templates/useUserTemplates.ts
@@ -12,6 +12,8 @@ export function useUserTemplates() {
     }
     return response.data as Template[];
   }, {
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
     onError: (error: Error) => {
       toast.error(`Failed to load user templates: ${error.message}`);


### PR DESCRIPTION
## Summary
- keep folder & template queries fresh for 5 minutes

## Testing
- `pnpm lint` *(fails: 590 problems)*
- `pnpm type-check`

------
https://chatgpt.com/codex/tasks/task_b_68713e9e21fc8325a7c7ba33bd34eb1f