### PR TITLE
Improve large list rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-resizable-panels": "^3.0.2",
     "recharts": "^2.15.1",
     "sonner": "^2.0.1",
+    "react-window": "^1.8.7",
     "tailwind-merge": "^2.6.0",
     "tailwind-scrollbar": "^4.0.2",
     "tailwindcss-animate": "^1.0.7",

--- a/src/components/common/VirtualizedList.tsx
+++ b/src/components/common/VirtualizedList.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { FixedSizeList, ListChildComponentProps } from 'react-window';
+
+export interface VirtualizedListProps<T> {
+  items: T[];
+  itemHeight: number;
+  height: number;
+  renderItem: (item: T) => React.ReactNode;
+}
+
+export function VirtualizedList<T>({ items, itemHeight, height, renderItem }: VirtualizedListProps<T>) {
+  const Row = ({ index, style }: ListChildComponentProps) => (
+    <div style={style}>{renderItem(items[index])}</div>
+  );
+
+  return (
+    <FixedSizeList
+      height={height}
+      itemCount={items.length}
+      itemSize={itemHeight}
+      width="100%"
+      overscanCount={5}
+    >
+      {Row}
+    </FixedSizeList>
+  );
+}

--- a/src/components/common/index.tsx
+++ b/src/components/common/index.tsx
@@ -4,6 +4,7 @@
 export { default as DeleteButton } from './DeleteButton';
 
 export { AddBlockButton } from './AddBlockButton';
+export { VirtualizedList } from './VirtualizedList';
 
 // Include types for better TypeScript integration
 export type { Props as DeleteButtonProps } from './DeleteButton';

--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -251,6 +251,8 @@ export const InsertBlockDialog: React.FC = () => {
   const [showShortcutHelp, setShowShortcutHelp] = useState(false);
   const [editableContent, setEditableContent] = useState('');
   const [blockContents, setBlockContents] = useState<Record<number, string>>({});
+  const [visibleCount, setVisibleCount] = useState(20);
+  const listRef = React.useRef<HTMLDivElement>(null);
   const isDark = useThemeDetector();
   const { editBlock, deleteBlock, createBlock } = useBlockActions({
     onBlockUpdated: (updated) => {
@@ -398,6 +400,22 @@ const filteredBlocks = blocks.filter(b => {
   const matchesType = selectedTypeFilter === 'all' || b.type === selectedTypeFilter;
   return matchesSearch && matchesType;
 });
+
+useEffect(() => {
+  setVisibleCount(20);
+}, [search, selectedTypeFilter, blocks]);
+
+useEffect(() => {
+  const el = listRef.current;
+  if (!el) return;
+  const onScroll = () => {
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 100) {
+      setVisibleCount(v => Math.min(filteredBlocks.length, v + 20));
+    }
+  };
+  el.addEventListener('scroll', onScroll);
+  return () => el.removeEventListener('scroll', onScroll);
+}, [filteredBlocks.length]);
 
   // Get unique block types for filter
   const blockTypes = Array.from(new Set(blocks.map(b => b.type || 'custom')));
@@ -582,7 +600,7 @@ const filteredBlocks = blocks.filter(b => {
           )}
 
           {/* Available Blocks */}
-          <ScrollArea className="jd-h-[65vh]">
+          <ScrollArea className="jd-h-[65vh]" ref={listRef}>
             <div className="jd-space-y-3 jd-pr-4">
               {loading ? (
                 <LoadingSpinner size="sm" message={getMessage('loadingBlocks', undefined, 'Loading blocks...')} />
@@ -593,7 +611,7 @@ const filteredBlocks = blocks.filter(b => {
                     : getMessage('noBlocksAvailable', undefined, 'No blocks available')}
                 </EmptyMessage>
               ) : (
-                filteredBlocks.map(block => (
+                filteredBlocks.slice(0, visibleCount).map(block => (
                   <AvailableBlockCard
                     key={block.id}
                     block={block}

--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/hooks/prompts';
 import { useDialogActions } from '@/hooks/dialogs/useDialogActions';
 import { useOrganizations } from '@/hooks/organizations';
+import { VirtualizedList } from '@/components/common/VirtualizedList';
 
 import { FolderSearch } from '@/components/prompts/folders';
 import { LoadingState } from './LoadingState';
@@ -551,55 +552,108 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
                 </EmptyMessage>
               ) : (
                 <>
-                  {displayItems.items.map(item => {
-                    const isFolder = 'templates' in item || 'Folders' in item;
-                    if (isFolder) {
-                      const folder = item as TemplateFolder;
+                  {displayItems.items.length > 30 ? (
+                    <VirtualizedList
+                      items={displayItems.items}
+                      height={384}
+                      itemHeight={60}
+                      renderItem={(item) => {
+                        const isFolder = 'templates' in item || 'Folders' in item;
+                        if (isFolder) {
+                          const folder = item as TemplateFolder;
+                          return (
+                            <FolderItem
+                              key={`${displayItems.isGlobalSearch ? 'search-' : ''}folder-${folder.id}`}
+                              folder={folder}
+                              type={navigation.getItemType(folder)}
+                              enableNavigation={!displayItems.isGlobalSearch}
+                              onNavigateToFolder={displayItems.isGlobalSearch ? undefined : navigation.navigateToFolder}
+                              onTogglePin={handleTogglePin}
+                              onToggleTemplatePin={handleToggleTemplatePin}
+                              onEditFolder={handleEditFolder}
+                              onDeleteFolder={handleDeleteFolder}
+                              onUseTemplate={useTemplate}
+                              onEditTemplate={editTemplate}
+                              onDeleteTemplate={handleDeleteTemplate}
+                              organizations={organizations}
+                              showPinControls={true}
+                              showEditControls={navigation.getItemType(folder) === 'user'}
+                              showDeleteControls={navigation.getItemType(folder) === 'user'}
+                              pinnedFolderIds={allPinnedFolderIds}
+                            />
+                          );
+                        }
+                        const template = item as Template;
+                        const templateType = displayItems.isGlobalSearch
+                          ? (template as any).folderType || 'user'
+                          : navigation.getItemType(template);
+                        return (
+                          <div key={`${displayItems.isGlobalSearch ? 'search-' : ''}template-${template.id}`}> 
+                            <TemplateItem
+                              template={template}
+                              type={templateType}
+                              onUseTemplate={useTemplate}
+                              onEditTemplate={editTemplate}
+                              onDeleteTemplate={handleDeleteTemplate}
+                              onTogglePin={handleToggleTemplatePin}
+                              showEditControls={templateType === 'user'}
+                              showDeleteControls={templateType === 'user'}
+                              showPinControls={true}
+                              organizations={organizations}
+                            />
+                          </div>
+                        );
+                      }}
+                    />
+                  ) : (
+                    displayItems.items.map(item => {
+                      const isFolder = 'templates' in item || 'Folders' in item;
+                      if (isFolder) {
+                        const folder = item as TemplateFolder;
+                        return (
+                          <FolderItem
+                            key={`${displayItems.isGlobalSearch ? 'search-' : ''}folder-${folder.id}`}
+                            folder={folder}
+                            type={navigation.getItemType(folder)}
+                            enableNavigation={!displayItems.isGlobalSearch}
+                            onNavigateToFolder={displayItems.isGlobalSearch ? undefined : navigation.navigateToFolder}
+                            onTogglePin={handleTogglePin}
+                            onToggleTemplatePin={handleToggleTemplatePin}
+                            onEditFolder={handleEditFolder}
+                            onDeleteFolder={handleDeleteFolder}
+                            onUseTemplate={useTemplate}
+                            onEditTemplate={editTemplate}
+                            onDeleteTemplate={handleDeleteTemplate}
+                            organizations={organizations}
+                            showPinControls={true}
+                            showEditControls={navigation.getItemType(folder) === 'user'}
+                            showDeleteControls={navigation.getItemType(folder) === 'user'}
+                            pinnedFolderIds={allPinnedFolderIds}
+                          />
+                        );
+                      }
+                      const template = item as Template;
+                      const templateType = displayItems.isGlobalSearch
+                        ? (template as any).folderType || 'user'
+                        : navigation.getItemType(template);
                       return (
-                        <FolderItem
-                          key={`${displayItems.isGlobalSearch ? 'search-' : ''}folder-${folder.id}`}
-                          folder={folder}
-                          type={navigation.getItemType(folder)}
-                          enableNavigation={!displayItems.isGlobalSearch}
-                          onNavigateToFolder={displayItems.isGlobalSearch ? undefined : navigation.navigateToFolder}
-                          onTogglePin={handleTogglePin}
-                          onToggleTemplatePin={handleToggleTemplatePin}
-                          onEditFolder={handleEditFolder}
-                          onDeleteFolder={handleDeleteFolder}
-                          onUseTemplate={useTemplate}
-                          onEditTemplate={editTemplate}
-                          onDeleteTemplate={handleDeleteTemplate}
-                          organizations={organizations}
-                          showPinControls={true}
-                          showEditControls={navigation.getItemType(folder) === 'user'}
-                          showDeleteControls={navigation.getItemType(folder) === 'user'}
-                          pinnedFolderIds={allPinnedFolderIds}
-                        />
+                        <div key={`${displayItems.isGlobalSearch ? 'search-' : ''}template-${template.id}`}> 
+                          <TemplateItem
+                            template={template}
+                            type={templateType}
+                            onUseTemplate={useTemplate}
+                            onEditTemplate={editTemplate}
+                            onDeleteTemplate={handleDeleteTemplate}
+                            onTogglePin={handleToggleTemplatePin}
+                            showEditControls={templateType === 'user'}
+                            showDeleteControls={templateType === 'user'}
+                            showPinControls={true}
+                            organizations={organizations}
+                          />
+                        </div>
                       );
-                    }
-                    const template = item as Template;
-                    const templateType = displayItems.isGlobalSearch
-                      ? (template as any).folderType || 'user'
-                      : navigation.getItemType(template);
-
-                    return (
-                      <div key={`${displayItems.isGlobalSearch ? 'search-' : ''}template-${template.id}`}>
-                        
-                        <TemplateItem
-                          template={template}
-                          type={templateType}
-                          onUseTemplate={useTemplate}
-                          onEditTemplate={editTemplate}
-                          onDeleteTemplate={handleDeleteTemplate}
-                          onTogglePin={handleToggleTemplatePin}
-                          showEditControls={templateType === 'user'}
-                          showDeleteControls={templateType === 'user'}
-                          showPinControls={true}
-                          organizations={organizations}
-                        />
-                      </div>
-                    );
-                  })}
+                    })
+                  )}
                 </>
               )}
             </div>


### PR DESCRIPTION
## Summary
- add `react-window` for list virtualization
- implement a reusable `VirtualizedList` component
- use virtualization for big template lists in `TemplatesPanel`
- lazy load blocks in `InsertBlockDialog`

## Testing
- `pnpm lint` *(fails: Unexpected any errors)*
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_b_687147b5f6788325b73a4f46456e025e