### PR TITLE
Add list virtualization for large block and template lists

### DIFF
--- a/src/components/common/VirtualizedList.tsx
+++ b/src/components/common/VirtualizedList.tsx
@@ -6,15 +6,17 @@ export interface VirtualizedListProps<T> {
   itemHeight: number;
   height: number;
   renderItem: (item: T) => React.ReactNode;
+  listRef?: React.Ref<FixedSizeList>;
 }
 
-export function VirtualizedList<T>({ items, itemHeight, height, renderItem }: VirtualizedListProps<T>) {
+export function VirtualizedList<T>({ items, itemHeight, height, renderItem, listRef }: VirtualizedListProps<T>) {
   const Row = ({ index, style }: ListChildComponentProps) => (
     <div style={style}>{renderItem(items[index])}</div>
   );
 
   return (
     <FixedSizeList
+      ref={listRef as any}
       height={height}
       itemCount={items.length}
       itemSize={itemHeight}

--- a/src/components/dialogs/prompts/BrowseMoreFoldersDialog/index.tsx
+++ b/src/components/dialogs/prompts/BrowseMoreFoldersDialog/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { BaseDialog } from '@/components/dialogs/BaseDialog';
 import { useDialog } from '@/components/dialogs/DialogContext';
 import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
@@ -22,6 +22,8 @@ import { useOrganizations } from '@/hooks/organizations';
 import { LoadingState } from '@/components/panels/TemplatesPanel/LoadingState';
 import { EmptyMessage } from '@/components/panels/TemplatesPanel/EmptyMessage';
 import { useFolderSearch } from '@/hooks/prompts/utils/useFolderSearch';
+import { VirtualizedList } from '@/components/common/VirtualizedList';
+import { FixedSizeList } from 'react-window';
 
 export const BrowseMoreFoldersDialog: React.FC = () => {
   const { isOpen, dialogProps, close } = useDialog(
@@ -39,6 +41,7 @@ export const BrowseMoreFoldersDialog: React.FC = () => {
 
   const pinnedFolderIds = useMemo(() => pinnedData?.pinnedIds || [], [pinnedData]);
   const [localPinnedIds, setLocalPinnedIds] = useState<number[]>(pinnedFolderIds);
+  const listRef = useRef<FixedSizeList>(null);
 
   useEffect(() => {
     setLocalPinnedIds(pinnedFolderIds);
@@ -141,37 +144,84 @@ export const BrowseMoreFoldersDialog: React.FC = () => {
               </EmptyMessage>
             ) : (
               <div className="jd-space-y-1 jd-px-2">
-                {foldersWithPin.map(folder => (
-                  <FolderItem
-                    key={`browse-folder-${folder.id}`}
-                    folder={folder}
-                    type={folder.type as any}
-                    enableNavigation={false}
-                    onUseTemplate={handleUseTemplateFromDialog}
-                    onTogglePin={(id, pinned) =>
-                      handleTogglePin(id, pinned, folder.type as any)
-                    }
-                    onToggleTemplatePin={handleToggleTemplatePin}
-                    organizations={organizations}
-                    showPinControls={true}
-                    showEditControls={false}
-                    showDeleteControls={false}
-                    pinnedFolderIds={localPinnedIds}
-                  />
-                ))}
-                {filteredTemplates.map(template => (
-                  (template.type !== 'user') &&
-                  <TemplateItem
-                    key={`browse-template-${template.id}`}
-                    template={template}
-                    type="user"
-                    onUseTemplate={handleUseTemplateFromDialog}
-                    onTogglePin={(id, pinned) => handleToggleTemplatePin(id, pinned, 'user')}
-                    showEditControls={false}
-                    showDeleteControls={false}
-                    showPinControls={true}
-                  />
-                ))}
+                {(() => {
+                  const combinedItems = [...foldersWithPin, ...filteredTemplates];
+                  return combinedItems.length > 30 ? (
+                    <VirtualizedList
+                      items={combinedItems}
+                      height={500}
+                      itemHeight={60}
+                      listRef={listRef}
+                      renderItem={item => {
+                        const isFolder = 'templates' in item || 'Folders' in item;
+                        if (isFolder) {
+                          const folder = item as any;
+                          return (
+                            <FolderItem
+                              key={`browse-folder-${folder.id}`}
+                              folder={folder}
+                              type={folder.type as any}
+                              enableNavigation={false}
+                              onUseTemplate={handleUseTemplateFromDialog}
+                              onTogglePin={(id, pinned) => handleTogglePin(id, pinned, folder.type as any)}
+                              onToggleTemplatePin={handleToggleTemplatePin}
+                              organizations={organizations}
+                              showPinControls={true}
+                              showEditControls={false}
+                              showDeleteControls={false}
+                              pinnedFolderIds={localPinnedIds}
+                            />
+                          );
+                        }
+                        const template = item as Template;
+                        return (
+                          <TemplateItem
+                            key={`browse-template-${template.id}`}
+                            template={template}
+                            type="user"
+                            onUseTemplate={handleUseTemplateFromDialog}
+                            onTogglePin={(id, pinned) => handleToggleTemplatePin(id, pinned, 'user')}
+                            showEditControls={false}
+                            showDeleteControls={false}
+                            showPinControls={true}
+                          />
+                        );
+                      }}
+                    />
+                  ) : (
+                    <>
+                      {foldersWithPin.map(folder => (
+                        <FolderItem
+                          key={`browse-folder-${folder.id}`}
+                          folder={folder}
+                          type={folder.type as any}
+                          enableNavigation={false}
+                          onUseTemplate={handleUseTemplateFromDialog}
+                          onTogglePin={(id, pinned) => handleTogglePin(id, pinned, folder.type as any)}
+                          onToggleTemplatePin={handleToggleTemplatePin}
+                          organizations={organizations}
+                          showPinControls={true}
+                          showEditControls={false}
+                          showDeleteControls={false}
+                          pinnedFolderIds={localPinnedIds}
+                        />
+                      ))}
+                      {filteredTemplates.map(template => (
+                        (template.type !== 'user') &&
+                        <TemplateItem
+                          key={`browse-template-${template.id}`}
+                          template={template}
+                          type="user"
+                          onUseTemplate={handleUseTemplateFromDialog}
+                          onTogglePin={(id, pinned) => handleToggleTemplatePin(id, pinned, 'user')}
+                          showEditControls={false}
+                          showDeleteControls={false}
+                          showPinControls={true}
+                        />
+                      ))}
+                    </>
+                  );
+                })()}
               </div>
             )}
           </div>

--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { BaseDialog } from '@/components/dialogs/BaseDialog';
 import { useDialog } from '@/components/dialogs/DialogContext';
 import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
@@ -8,6 +8,8 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { VirtualizedList } from '@/components/common/VirtualizedList';
+import { FixedSizeList } from 'react-window';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
@@ -251,8 +253,7 @@ export const InsertBlockDialog: React.FC = () => {
   const [showShortcutHelp, setShowShortcutHelp] = useState(false);
   const [editableContent, setEditableContent] = useState('');
   const [blockContents, setBlockContents] = useState<Record<number, string>>({});
-  const [visibleCount, setVisibleCount] = useState(20);
-  const listRef = React.useRef<HTMLDivElement>(null);
+  const listRef = useRef<FixedSizeList>(null);
   const isDark = useThemeDetector();
   const { editBlock, deleteBlock, createBlock } = useBlockActions({
     onBlockUpdated: (updated) => {
@@ -400,22 +401,6 @@ const filteredBlocks = blocks.filter(b => {
   const matchesType = selectedTypeFilter === 'all' || b.type === selectedTypeFilter;
   return matchesSearch && matchesType;
 });
-
-useEffect(() => {
-  setVisibleCount(20);
-}, [search, selectedTypeFilter, blocks]);
-
-useEffect(() => {
-  const el = listRef.current;
-  if (!el) return;
-  const onScroll = () => {
-    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 100) {
-      setVisibleCount(v => Math.min(filteredBlocks.length, v + 20));
-    }
-  };
-  el.addEventListener('scroll', onScroll);
-  return () => el.removeEventListener('scroll', onScroll);
-}, [filteredBlocks.length]);
 
   // Get unique block types for filter
   const blockTypes = Array.from(new Set(blocks.map(b => b.type || 'custom')));
@@ -600,7 +585,7 @@ useEffect(() => {
           )}
 
           {/* Available Blocks */}
-          <ScrollArea className="jd-h-[65vh]" ref={listRef}>
+          <ScrollArea className="jd-h-[65vh]">
             <div className="jd-space-y-3 jd-pr-4">
               {loading ? (
                 <LoadingSpinner size="sm" message={getMessage('loadingBlocks', undefined, 'Loading blocks...')} />
@@ -611,19 +596,44 @@ useEffect(() => {
                     : getMessage('noBlocksAvailable', undefined, 'No blocks available')}
                 </EmptyMessage>
               ) : (
-                filteredBlocks.slice(0, visibleCount).map(block => (
-                  <AvailableBlockCard
-                    key={block.id}
-                    block={block}
-                    isDark={isDark}
-                    onAdd={addBlock}
-                    onEdit={handleEditBlock}
-                    onDelete={handleDeleteBlock}
-                    isSelected={!!selectedBlocks.find(b => b.id === block.id)}
-                    onRemove={removeBlock}
-                    showActions={block.user_id ? true : false}
-                  />
-                )))}
+                <>
+                  {filteredBlocks.length > 30 ? (
+                    <VirtualizedList
+                      items={filteredBlocks}
+                      height={500}
+                      itemHeight={160}
+                      listRef={listRef}
+                      renderItem={block => (
+                        <AvailableBlockCard
+                          key={block.id}
+                          block={block}
+                          isDark={isDark}
+                          onAdd={addBlock}
+                          onEdit={handleEditBlock}
+                          onDelete={handleDeleteBlock}
+                          isSelected={!!selectedBlocks.find(b => b.id === block.id)}
+                          onRemove={removeBlock}
+                          showActions={block.user_id ? true : false}
+                        />
+                      )}
+                    />
+                  ) : (
+                    filteredBlocks.map(block => (
+                      <AvailableBlockCard
+                        key={block.id}
+                        block={block}
+                        isDark={isDark}
+                        onAdd={addBlock}
+                        onEdit={handleEditBlock}
+                        onDelete={handleDeleteBlock}
+                        isSelected={!!selectedBlocks.find(b => b.id === block.id)}
+                        onRemove={removeBlock}
+                        showActions={block.user_id ? true : false}
+                      />
+                    ))
+                  )}
+                </>
+              ))}
             </div>
           </ScrollArea>
         </div>


### PR DESCRIPTION
## Summary
- extend `VirtualizedList` to optionally expose its ref
- apply virtualization to QuickBlockSelector lists
- use `VirtualizedList` for InsertBlockDialog block list
- virtualize BrowseMoreFoldersDialog entries for folders/templates

## Testing
- `npm run lint` *(fails: 554 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68714cfcef5c8325bcf84f8580fd4937