### PR TITLE
Update paywalls with PricingSection

### DIFF
--- a/src/components/pricing/pricing-section.tsx
+++ b/src/components/pricing/pricing-section.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { ArrowRightIcon, CheckIcon } from "@radix-ui/react-icons"
 import { cn } from "@/core/utils/classNames"
+import { useThemeDetector } from "@/hooks/useThemeDetector"
 
 interface Feature {
   name: string
@@ -28,36 +29,30 @@ interface PricingTier {
 interface PricingSectionProps {
   tiers: PricingTier[]
   className?: string
+  onSelectPlan?: (billingPeriod: 'monthly' | 'yearly', tier: PricingTier) => void
 }
 
-function PricingSection({ tiers, className }: PricingSectionProps) {
+function PricingSection({ tiers, className, onSelectPlan }: PricingSectionProps) {
   const [isYearly, setIsYearly] = useState(false)
+  const isDark = useThemeDetector()
 
   const buttonStyles = {
     default: cn(
-      "jd-h-12 jd-bg-white jd-dark:jd-bg-zinc-900",
-      "hover:jd-bg-zinc-50 dark:jd-hover:jd-bg-zinc-800",
-      "jd-text-zinc-900 dark:jd-text-zinc-100",
-      "jd-border jd-border-zinc-200 dark:jd-border-zinc-800",
-      "hover:jd-border-zinc-300 dark:hover:jd-border-zinc-700",
-      "jd-shadow-sm hover:jd-shadow-md",
-      "jd-text-sm jd-font-medium",
+      "jd-h-12",
+      isDark ? "jd-bg-zinc-900 jd-text-zinc-100 jd-border-zinc-800 hover:jd-bg-zinc-800 hover:jd-border-zinc-700" :
+        "jd-bg-white jd-text-zinc-900 jd-border-zinc-200 hover:jd-bg-zinc-50 hover:jd-border-zinc-300",
+      "jd-border jd-shadow-sm hover:jd-shadow-md jd-text-sm jd-font-medium"
     ),
     highlight: cn(
-      "jd-h-12 jd-bg-zinc-900 dark:jd-bg-zinc-100",
-      "hover:jd-bg-zinc-800 dark:jd-hover:jd-bg-zinc-300",
-      "jd-text-white dark:jd-text-zinc-900",
-      "jd-shadow-[0_1px_15px_rgba(0,0,0,0.1)]",
-      "hover:jd-shadow-[0_1px_20px_rgba(0,0,0,0.15)]",
-      "jd-font-semibold jd-text-base",
-    ),
+      "jd-h-12",
+      isDark ? "jd-bg-zinc-100 jd-text-zinc-900 hover:jd-bg-zinc-300" : "jd-bg-zinc-900 jd-text-white hover:jd-bg-zinc-800",
+      "jd-shadow-[0_1px_15px_rgba(0,0,0,0.1)] hover:jd-shadow-[0_1px_20px_rgba(0,0,0,0.15)] jd-font-semibold jd-text-base"
+    )
   }
 
   const badgeStyles = cn(
-    "jd-px-4 jd-py-1.5 jd-text-sm jd-font-medium",
-    "jd-bg-zinc-900 dark:jd-bg-zinc-100",
-    "jd-text-white dark:jd-text-zinc-900",
-    "jd-border-none jd-shadow-lg",
+    "jd-px-4 jd-py-1.5 jd-text-sm jd-font-medium jd-border-none jd-shadow-lg",
+    isDark ? "jd-bg-zinc-100 jd-text-zinc-900" : "jd-bg-zinc-900 jd-text-white"
   )
 
   return (
@@ -71,10 +66,18 @@ function PricingSection({ tiers, className }: PricingSectionProps) {
     >
       <div className="jd-w-full jd-max-w-5xl jd-mx-auto">
         <div className="jd-flex jd-flex-col jd-items-center jd-gap-4 jd-mb-12">
-          <h2 className="jd-text-3xl jd-font-bold jd-text-zinc-900 dark:jd-text-zinc-50">
+          <h2 className={cn(
+            "jd-text-3xl jd-font-bold",
+            isDark ? "jd-text-zinc-50" : "jd-text-zinc-900"
+          )}>
             Simple, transparent pricing
           </h2>
-          <div className="jd-inline-flex jd-items-center jd-p-1.5 jd-bg-white dark:jd-bg-zinc-800/50 jd-rounded-full jd-border jd-border-zinc-200 dark:jd-border-zinc-700 jd-shadow-sm">
+          <div
+            className={cn(
+              "jd-inline-flex jd-items-center jd-p-1.5 jd-rounded-full jd-border jd-shadow-sm",
+              isDark ? "jd-bg-zinc-800/50 jd-border-zinc-700" : "jd-bg-white jd-border-zinc-200"
+            )}
+          >
             {["Monthly", "Yearly"].map((period) => (
               <button
                 key={period}
@@ -82,8 +85,12 @@ function PricingSection({ tiers, className }: PricingSectionProps) {
                 className={cn(
                   "jd-px-8 jd-py-2.5 jd-text-sm jd-font-medium jd-rounded-full jd-transition-all jd-duration-300",
                   (period === "Yearly") === isYearly
-                    ? "jd-bg-zinc-900 dark:jd-bg-zinc-100 jd-text-white dark:jd-text-zinc-900 jd-shadow-lg"
-                    : "jd-text-zinc-600 dark:jd-text-zinc-400 jd-hover:jd-text-zinc-900 dark:jd-hover:jd-text-zinc-100",
+                    ? isDark
+                      ? "jd-bg-zinc-100 jd-text-zinc-900 jd-shadow-lg"
+                      : "jd-bg-zinc-900 jd-text-white jd-shadow-lg"
+                    : isDark
+                      ? "jd-text-zinc-400 hover:jd-text-zinc-100"
+                      : "jd-text-zinc-600 hover:jd-text-zinc-900"
                 )}
               >
                 {period}
@@ -101,12 +108,20 @@ function PricingSection({ tiers, className }: PricingSectionProps) {
                 "jd-rounded-3xl jd-transition-all jd-duration-300",
                 "jd-flex jd-flex-col",
                 tier.highlight
-                  ? "jd-bg-gradient-to-b jd-from-zinc-100/80 jd-to-transparent dark:jd-from-zinc-400/[0.15]"
-                  : "jd-bg-white dark:jd-bg-zinc-800/50",
+                  ? isDark
+                    ? "jd-bg-gradient-to-b jd-from-zinc-400/[0.15] jd-to-transparent"
+                    : "jd-bg-gradient-to-b jd-from-zinc-100/80 jd-to-transparent"
+                  : isDark
+                    ? "jd-bg-zinc-800/50"
+                    : "jd-bg-white",
                 "jd-border",
                 tier.highlight
-                  ? "jd-border-zinc-400/50 dark:jd-border-zinc-400/20 jd-shadow-xl"
-                  : "jd-border-zinc-200 dark:jd-border-zinc-700 jd-shadow-md",
+                  ? isDark
+                    ? "jd-border-zinc-400/20 jd-shadow-xl"
+                    : "jd-border-zinc-400/50 jd-shadow-xl"
+                  : isDark
+                    ? "jd-border-zinc-700 jd-shadow-md"
+                    : "jd-border-zinc-200 jd-shadow-md",
                 "hover:translate-y-0 hover:shadow-lg",
               )}
             >
@@ -122,27 +137,46 @@ function PricingSection({ tiers, className }: PricingSectionProps) {
                     className={cn(
                       "jd-p-3 jd-rounded-xl",
                       tier.highlight
-                        ? "jd-bg-zinc-100 dark:jd-bg-zinc-800 jd-text-zinc-900 dark:jd-text-zinc-100"
-                        : "jd-bg-zinc-100 dark:jd-bg-zinc-800 jd-text-zinc-600 dark:jd-text-zinc-400",
+                        ? isDark
+                          ? "jd-bg-zinc-800 jd-text-zinc-100"
+                          : "jd-bg-zinc-100 jd-text-zinc-900"
+                        : isDark
+                          ? "jd-bg-zinc-800 jd-text-zinc-400"
+                          : "jd-bg-zinc-100 jd-text-zinc-600"
                     )}
                   >
                     {tier.icon}
                   </div>
-                  <h3 className="jd-text-xl jd-font-semibold jd-text-zinc-900 dark:jd-text-zinc-100">
+                  <h3
+                    className={cn(
+                      "jd-text-xl jd-font-semibold",
+                      isDark ? "jd-text-zinc-100" : "jd-text-zinc-900"
+                    )}
+                  >
                     {tier.name}
                   </h3>
                 </div>
 
                 <div className="jd-mb-6">
                   <div className="jd-flex jd-items-baseline jd-gap-2">
-                    <span className="jd-text-4xl jd-font-bold jd-text-zinc-900 dark:jd-text-zinc-100">
-                      ${isYearly ? tier.price.yearly : tier.price.monthly}
+                    <span
+                      className={cn(
+                        "jd-text-4xl jd-font-bold",
+                        isDark ? "jd-text-zinc-100" : "jd-text-zinc-900"
+                      )}
+                    >
+                      {isYearly ? tier.price.yearly : tier.price.monthly}
                     </span>
-                    <span className="jd-text-sm jd-text-zinc-500 dark:jd-text-zinc-400">
+                    <span className={cn("jd-text-sm", isDark ? "jd-text-zinc-400" : "jd-text-zinc-500")}>
                       /{isYearly ? "year" : "month"}
                     </span>
                   </div>
-                  <p className="jd-mt-2 jd-text-sm jd-text-zinc-600 dark:jd-text-zinc-400">
+                  <p
+                    className={cn(
+                      "jd-mt-2 jd-text-sm",
+                      isDark ? "jd-text-zinc-400" : "jd-text-zinc-600"
+                    )}
+                  >
                     {tier.description}
                   </p>
                 </div>
@@ -154,17 +188,26 @@ function PricingSection({ tiers, className }: PricingSectionProps) {
                         className={cn(
                           "jd-mt-1 jd-p-0.5 jd-rounded-full jd-transition-colors jd-duration-200",
                           feature.included
-                            ? "jd-text-emerald-600 dark:jd-text-emerald-400"
-                            : "jd-text-zinc-400 dark:jd-text-zinc-600",
+                            ? isDark
+                              ? "jd-text-emerald-400"
+                              : "jd-text-emerald-600"
+                            : isDark
+                              ? "jd-text-zinc-600"
+                              : "jd-text-zinc-400"
                         )}
                       >
                         <CheckIcon className="jd-w-4 jd-h-4" />
                       </div>
                       <div>
-                        <div className="jd-text-sm jd-font-medium jd-text-zinc-900 dark:jd-text-zinc-100">
+                        <div
+                          className={cn(
+                            "jd-text-sm jd-font-medium",
+                            isDark ? "jd-text-zinc-100" : "jd-text-zinc-900"
+                          )}
+                        >
                           {feature.name}
                         </div>
-                        <div className="jd-text-sm jd-text-zinc-500 dark:jd-text-zinc-400">
+                        <div className={cn("jd-text-sm", isDark ? "jd-text-zinc-400" : "jd-text-zinc-500")}>
                           {feature.description}
                         </div>
                       </div>
@@ -175,6 +218,7 @@ function PricingSection({ tiers, className }: PricingSectionProps) {
 
               <div className="jd-p-8 jd-pt-0 jd-mt-auto">
                 <Button
+                  onClick={() => onSelectPlan?.(isYearly ? 'yearly' : 'monthly', tier)}
                   className={cn(
                     "jd-w-full jd-relative jd-transition-all jd-duration-300",
                     tier.highlight

--- a/src/components/welcome/onboarding/steps/PaymentStep.tsx
+++ b/src/components/welcome/onboarding/steps/PaymentStep.tsx
@@ -15,7 +15,8 @@ import {
 import { Button } from '@/components/ui/button';
 import { getMessage } from '@/core/utils/i18n';
 import { trackEvent, EVENTS } from '@/utils/amplitude';
-import { PricingPlans } from '@/components/pricing/PricingPlans';
+import { PricingSection } from '@/components/pricing/pricing-section';
+import { toast } from 'sonner';
 import { stripeService } from '@/services/stripe/StripeService';
 import { User } from '@/types';
 import { PaymentResult } from '@/types/stripe';
@@ -35,6 +36,31 @@ export const PaymentStep: React.FC<PaymentStepProps> = ({
 }) => {
   const [paymentResult, setPaymentResult] = useState<PaymentResult | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
+
+  const plans = stripeService.getPricingPlans();
+  const monthlyPlan = plans.find(p => p.id === 'monthly');
+  const yearlyPlan = plans.find(p => p.id === 'yearly');
+
+  const features = [
+    getMessage('feature1', undefined, 'Unlimited AI conversations'),
+    getMessage('feature2', undefined, 'Smart template library'),
+    getMessage('feature3', undefined, 'Energy usage insights'),
+    getMessage('feature4', undefined, 'Priority customer support'),
+    getMessage('feature5', undefined, 'Advanced analytics'),
+    getMessage('feature6', undefined, 'Custom folder organization'),
+  ].map(name => ({ name, description: '', included: true }));
+
+  const pricingTiers = [
+    {
+      name: getMessage('premium_plan', undefined, 'Jaydai Premium'),
+      price: { monthly: monthlyPlan?.price || 0, yearly: yearlyPlan?.price || 0 },
+      description: getMessage('premiumDescriptionShort', undefined, 'Unlock all premium features'),
+      features,
+      highlight: true,
+      badge: getMessage('best_value', undefined, 'Best value'),
+      icon: <Crown className="jd-w-5 jd-h-5" />,
+    },
+  ];
 
   // Check for payment result on component mount
   useEffect(() => {
@@ -68,23 +94,32 @@ export const PaymentStep: React.FC<PaymentStepProps> = ({
     }
   }, [user.id, onComplete]);
 
-  const handlePaymentSuccess = () => {
-    setIsProcessing(true);
-    trackEvent(EVENTS.ONBOARDING_PAYMENT_COMPLETED, {
-      userId: user.id
-    });
-    
-    // Show success state briefly before completing
-    setTimeout(() => {
-      onComplete();
-    }, 1500);
-  };
-
   const handleSkipPayment = () => {
     trackEvent(EVENTS.ONBOARDING_PAYMENT_SKIPPED, {
       userId: user.id
     });
     onSkip?.();
+  };
+
+  const handleSelectPlan = async (period: 'monthly' | 'yearly') => {
+    if (!user.email) {
+      trackEvent(EVENTS.PAYMENT_FAILED, { userId: user.id });
+      toast.error(getMessage('userEmailRequired', undefined, 'User email is required for payment'));
+      return;
+    }
+    setIsProcessing(true);
+    try {
+      await stripeService.redirectToCheckout(period, user.id, user.email);
+      trackEvent(EVENTS.PAYMENT_INITIATED, { userId: user.id, plan: period });
+      toast.info(
+        getMessage('redirectingToPayment', undefined, 'Redirecting to payment...'),
+        { description: getMessage('completePaymentInNewTab', undefined, 'Complete your payment in the new tab') }
+      );
+    } catch (error) {
+      console.error('Payment error:', error);
+      setIsProcessing(false);
+      toast.error(getMessage('paymentError', undefined, 'Payment failed'));
+    }
   };
 
   // Show success state
@@ -308,10 +343,9 @@ export const PaymentStep: React.FC<PaymentStepProps> = ({
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.7, duration: 0.5 }}
       >
-        <PricingPlans
-          user={user}
-          onPaymentSuccess={handlePaymentSuccess}
-          onPaymentCancel={() => setPaymentResult({ success: false, type: 'cancel' })}
+        <PricingSection
+          tiers={pricingTiers}
+          onSelectPlan={handleSelectPlan}
         />
       </motion.div>
 


### PR DESCRIPTION
## Summary
- replace old PricingPlans component in ManageSubscriptionDialog and onboarding Payment step
- add PricingSection dark-mode support via useThemeDetector
- hook up new plan selection handlers using Stripe service

## Testing
- `npm run lint` *(fails: 607 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6877ee6dffe88325862e187312f5f711