### PR TITLE
Refactor subscription API handling

### DIFF
--- a/src/services/api/StripeApi.ts
+++ b/src/services/api/StripeApi.ts
@@ -1,10 +1,31 @@
 // src/services/api/StripeApi.ts
 import { apiClient } from './ApiClient';
-import { 
-  CreateCheckoutSessionRequest, 
+import {
+  CreateCheckoutSessionRequest,
   CreateCheckoutSessionResponse,
-  SubscriptionStatus 
+  SubscriptionStatus
 } from '@/types/stripe';
+
+export interface SubscriptionStatusResponse {
+  success: boolean;
+  data: {
+    hasSubscription: boolean;
+    subscription_status: 'active' | 'trialing' | 'past_due' | 'cancelled' | 'inactive' | 'incomplete' | 'unpaid';
+    subscription_plan: string | null;
+    isActive: boolean;
+    isTrialing: boolean;
+    isPastDue: boolean;
+    isCancelled: boolean;
+    cancelAtPeriodEnd: boolean;
+    currentPeriodStart?: string;
+    currentPeriodEnd?: string;
+    trialStart?: string;
+    trialEnd?: string;
+    cancelledAt?: string;
+    stripeCustomerId?: string;
+    stripeSubscriptionId?: string;
+  };
+}
 
 export class StripeApi {
   /**
@@ -33,34 +54,19 @@ export class StripeApi {
   }
 
   /**
-   * Get subscription status for a user
+   * Get detailed subscription status for the current user
    */
-  async getSubscriptionStatus(userId: string): Promise<SubscriptionStatus> {
-    try {
-      const response = await apiClient.request(`/stripe/subscription-status/${userId}`, {
-        method: 'GET'
-      });
+  async getSubscriptionStatus(): Promise<SubscriptionStatusResponse> {
+    return apiClient.request('/user/subscription-status');
+  }
 
-      console.log('response --->', response);
-
-      if (!response.success) {
-        throw new Error(response.error || 'Failed to get subscription status');
-      }
-
-      return response.subscription;
-    } catch (error) {
-      console.error('❌ Error getting subscription status:', error);
-      
-      // Return default status on error
-      return {
-        isActive: false,
-        planId: null,
-        currentPeriodEnd: null,
-        cancelAtPeriodEnd: false,
-        stripeCustomerId: null,
-        stripeSubscriptionId: null
-      };
-    }
+  /**
+   * Reactivate a cancelled subscription
+   */
+  async reactivateSubscription(): Promise<any> {
+    return apiClient.request('/user/subscription/reactivate', {
+      method: 'POST'
+    });
   }
 
   /**

--- a/src/services/api/UserApi.ts
+++ b/src/services/api/UserApi.ts
@@ -19,26 +19,6 @@ export interface DataCollectionRequest {
   data_collection: boolean;
 }
 
-export interface SubscriptionStatusResponse {
-  success: boolean;
-  data: {
-    hasSubscription: boolean;
-    subscription_status: 'active' | 'trialing' | 'past_due' | 'cancelled' | 'inactive' | 'incomplete' | 'unpaid';
-    subscription_plan: string | null;
-    isActive: boolean;
-    isTrialing: boolean;
-    isPastDue: boolean;
-    isCancelled: boolean;
-    cancelAtPeriodEnd: boolean;
-    currentPeriodStart?: string;
-    currentPeriodEnd?: string;
-    trialStart?: string;
-    trialEnd?: string;
-    cancelledAt?: string;
-    stripeCustomerId?: string;
-    stripeSubscriptionId?: string;
-  };
-}
 
 export class UserApi {
   /**
@@ -75,21 +55,6 @@ export class UserApi {
     return apiClient.request('/stats/user');
   }
 
-  /**
-   * Get detailed subscription status
-   */
-  async getSubscriptionStatus(): Promise<SubscriptionStatusResponse> {
-    return apiClient.request('/user/subscription-status');
-  }
-
-  /**
-   * Reactivate a cancelled subscription
-   */
-  async reactivateSubscription(): Promise<any> {
-    return apiClient.request('/user/subscription/reactivate', {
-      method: 'POST'
-    });
-  }
 
   /**
    * Get weekly conversation statistics

--- a/src/services/stripe/StripeService.ts
+++ b/src/services/stripe/StripeService.ts
@@ -1,5 +1,6 @@
 // src/services/stripe/StripeService.ts
 import { apiClient } from '@/services/api/ApiClient';
+import { stripeApi, SubscriptionStatusResponse } from '@/services/api/StripeApi';
 import { trackEvent, EVENTS } from '@/utils/amplitude';
 import { 
   StripeConfig, 
@@ -137,20 +138,31 @@ export class StripeService {
    */
   async getSubscriptionStatus(userId: string): Promise<SubscriptionStatus> {
     try {
-      const response = await apiClient.request(`/user/subscription-status`, {
-        method: 'GET'
-      });
+      const response: SubscriptionStatusResponse = await stripeApi.getSubscriptionStatus();
 
       console.log('response --->', response);
 
       if (!response.success) {
-        throw new Error(response.error || 'Failed to get subscription status');
+        throw new Error(response.message || 'Failed to get subscription status');
       }
 
       return response.data;
     } catch (error) {
       console.error('❌ Error getting subscription status:', error);
       throw error;
+    }
+  }
+
+  /**
+   * Reactivate a cancelled subscription
+   */
+  async reactivateSubscription(): Promise<boolean> {
+    try {
+      const response = await stripeApi.reactivateSubscription();
+      return response.success ?? true;
+    } catch (error) {
+      console.error('❌ Error reactivating subscription:', error);
+      return false;
     }
   }
 

--- a/src/state/SubscriptionContext.tsx
+++ b/src/state/SubscriptionContext.tsx
@@ -1,7 +1,6 @@
 // src/state/SubscriptionContext.tsx - Fixed version with proper memoization
 import React, { createContext, useContext, useState, useEffect, ReactNode, useCallback } from 'react';
 import { useAuthState } from '@/hooks/auth/useAuthState';
-import { userApi } from '@/services/api/UserApi';
 import { stripeService } from '@/services/stripe/StripeService';
 import { toast } from 'sonner';
 import { getMessage } from '@/core/utils/i18n';
@@ -77,14 +76,8 @@ export const SubscriptionProvider: React.FC<SubscriptionProviderProps> = ({ chil
       setIsLoading(true);
       setError(null);
 
-      const response = await userApi.getSubscriptionStatus();
-      
-      if (response.success) {
-        setSubscription(response.data);
-      } else {
-        setError(response.message || 'Failed to fetch subscription status');
-        setSubscription(defaultSubscription);
-      }
+      const data = await stripeService.getSubscriptionStatus(userId);
+      setSubscription(data);
     } catch (error) {
       console.error('Error fetching subscription status:', error);
       setError('Failed to fetch subscription status');
@@ -131,9 +124,9 @@ export const SubscriptionProvider: React.FC<SubscriptionProviderProps> = ({ chil
 
     try {
       setIsLoading(true);
-      const response = await userApi.reactivateSubscription();
-      
-      if (response.success) {
+      const success = await stripeService.reactivateSubscription();
+
+      if (success) {
         await refreshSubscription();
         toast.success(getMessage('subscription_reactivated', undefined, 'Subscription reactivated successfully'));
         return true;


### PR DESCRIPTION
## Summary
- remove obsolete subscription methods from `UserApi`
- add `getSubscriptionStatus` and `reactivateSubscription` to `StripeApi`
- expose the new endpoints through `stripeService`
- update `SubscriptionContext` to use `stripeService`

## Testing
- `npm run lint` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878ca33098c8325ab0a1a2f5f6cd291