### PR TITLE
Refactor ManageSubscriptionDialog into smaller parts

### DIFF
--- a/src/components/dialogs/subscription/ManageSubscriptionDialog.tsx
+++ b/src/components/dialogs/subscription/ManageSubscriptionDialog.tsx
@@ -1,9 +1,7 @@
 // src/components/dialogs/subscription/ManageSubscriptionDialog.tsx - Fixed version
 import React, { useState, useEffect, useRef } from 'react';
-import { Crown, ExternalLink, AlertTriangle, CheckCircle, XCircle, RefreshCw, AlertCircle, Clock } from 'lucide-react';
+import { RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { toast } from 'sonner';
 import { BaseDialog } from '../BaseDialog';
@@ -14,6 +12,11 @@ import { stripeService } from '@/services/stripe/StripeService';
 import { useAuthState } from '@/hooks/auth/useAuthState';
 import { useSubscription, useSubscriptionActions } from '@/state/SubscriptionContext';
 import { PricingPlans } from '@/components/pricing/PricingPlans';
+import {
+  getStatusInfo,
+  SubscriptionStatusCard,
+  ActionButtons,
+} from './manage';
 
 /**
  * Dialog for managing user subscription
@@ -106,71 +109,6 @@ export const ManageSubscriptionDialog: React.FC = () => {
     }
   };
 
-  const formatDate = (dateString: string | null | undefined) => {
-    if (!dateString) return '-';
-    return new Date(dateString).toLocaleDateString();
-  };
-
-  const getPlanDisplayName = (planId: string | null) => {
-    switch (planId) {
-      case 'monthly':
-        return getMessage('monthly_plan', undefined, 'Monthly Plan');
-      case 'yearly':
-        return getMessage('yearly_plan', undefined, 'Yearly Plan');
-      case 'plus':
-        return getMessage('plus_plan', undefined, 'Plus Plan');
-      default:
-        return getMessage('free_plan', undefined, 'Free Plan');
-    }
-  };
-
-  const getStatusInfo = (status: string) => {
-    switch (status) {
-      case 'active':
-        return {
-          icon: <CheckCircle className="jd-w-5 jd-h-5 jd-text-green-500" />,
-          color: 'jd-bg-green-100 jd-text-green-800',
-          label: getMessage('active', undefined, 'Active'),
-          message: getMessage('active_subscription', undefined, 'Your subscription is active')
-        };
-      case 'trialing':
-        return {
-          icon: <Clock className="jd-w-5 jd-h-5 jd-text-blue-500" />,
-          color: 'jd-bg-blue-100 jd-text-blue-800',
-          label: getMessage('trial', undefined, 'Trial'),
-          message: getMessage('trial_subscription', undefined, 'You are in your trial period')
-        };
-      case 'past_due':
-        return {
-          icon: <AlertTriangle className="jd-w-5 jd-h-5 jd-text-orange-500" />,
-          color: 'jd-bg-orange-100 jd-text-orange-800',
-          label: getMessage('past_due', undefined, 'Past Due'),
-          message: getMessage('past_due_subscription', undefined, 'Your payment is overdue')
-        };
-      case 'cancelled':
-        return {
-          icon: <XCircle className="jd-w-5 jd-h-5 jd-text-red-500" />,
-          color: 'jd-bg-red-100 jd-text-red-800',
-          label: getMessage('cancelled', undefined, 'Cancelled'),
-          message: getMessage('cancelled_subscription', undefined, 'Your subscription has been cancelled')
-        };
-      case 'incomplete':
-        return {
-          icon: <AlertCircle className="jd-w-5 jd-h-5 jd-text-yellow-500" />,
-          color: 'jd-bg-yellow-100 jd-text-yellow-800',
-          label: getMessage('incomplete', undefined, 'Incomplete'),
-          message: getMessage('incomplete_subscription', undefined, 'Your subscription setup is incomplete')
-        };
-      default:
-        return {
-          icon: <XCircle className="jd-w-5 jd-h-5 jd-text-gray-500" />,
-          color: 'jd-bg-gray-100 jd-text-gray-600',
-          label: getMessage('inactive', undefined, 'Inactive'),
-          message: getMessage('no_active_subscription', undefined, 'No active subscription')
-        };
-    }
-  };
-
   const handlePaymentSuccess = () => {
     toast.success(getMessage('payment_successful', undefined, 'Payment successful! Your subscription is now active.'));
     refreshSubscription();
@@ -209,13 +147,13 @@ export const ManageSubscriptionDialog: React.FC = () => {
                 {getMessage('unlock_premium_features', undefined, 'Unlock all premium features and get the most out of Jaydai')}
               </p>
             </div>
-            
-            <PricingPlans 
+
+            <PricingPlans
               user={authState.user!}
               onPaymentSuccess={handlePaymentSuccess}
               onPaymentCancel={handlePaymentCancel}
             />
-            
+
             <div className="jd-flex jd-justify-center jd-pt-4">
               <Button
                 variant="outline"
@@ -228,202 +166,22 @@ export const ManageSubscriptionDialog: React.FC = () => {
           </>
         ) : (
           <>
-            {/* Current Subscription Status */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="jd-flex jd-items-center jd-space-x-2">
-                  <Crown className="jd-w-5 jd-h-5" />
-                  <span>{getMessage('current_subscription', undefined, 'Current Subscription')}</span>
-                </CardTitle>
-              </CardHeader>
-              
-              <CardContent className="jd-space-y-4">
-                <div className="jd-flex jd-items-center jd-justify-between jd-p-4 jd-bg-muted jd-rounded-lg">
-                  <div className="jd-flex jd-items-center jd-space-x-3">
-                    {statusInfo.icon}
-                    <div>
-                      <p className="jd-font-medium">
-                        {getPlanDisplayName(subscription?.subscription_plan)}
-                      </p>
-                      <p className="jd-text-sm jd-text-muted-foreground">
-                        {statusInfo.message}
-                      </p>
-                    </div>
-                  </div>
-                  
-                  <Badge className={statusInfo.color}>
-                    {statusInfo.label}
-                  </Badge>
-                </div>
-
-                {/* Subscription Details */}
-                {subscription?.hasSubscription && (
-                  <div className="jd-grid jd-grid-cols-1 md:jd-grid-cols-2 jd-gap-4 jd-pt-4">
-                    {subscription.isTrialing && subscription.trialEnd && (
-                      <div className="jd-space-y-2">
-                        <p className="jd-text-sm jd-text-muted-foreground">
-                          {getMessage('trial_ends', undefined, 'Trial ends')}
-                        </p>
-                        <p className="jd-font-medium">
-                          {formatDate(subscription.trialEnd)}
-                        </p>
-                      </div>
-                    )}
-                    
-                    {(subscription.isActive || subscription.isTrialing) && subscription.currentPeriodEnd && (
-                      <div className="jd-space-y-2">
-                        <p className="jd-text-sm jd-text-muted-foreground">
-                          {subscription.isTrialing 
-                            ? getMessage('trial_period_end', undefined, 'Trial period ends')
-                            : getMessage('next_billing_date', undefined, 'Next billing date')
-                          }
-                        </p>
-                        <p className="jd-font-medium">
-                          {formatDate(subscription.currentPeriodEnd)}
-                        </p>
-                      </div>
-                    )}
-                    
-                    <div className="jd-space-y-2">
-                      <p className="jd-text-sm jd-text-muted-foreground">
-                        {getMessage('billing_status', undefined, 'Billing status')}
-                      </p>
-                      <p className="jd-font-medium">
-                        {subscription.cancelAtPeriodEnd 
-                          ? getMessage('cancelling_at_period_end', undefined, 'Cancelling at period end')
-                          : subscription.isActive
-                          ? getMessage('active_renewing', undefined, 'Active & renewing')
-                          : subscription.isTrialing
-                          ? getMessage('trial_period', undefined, 'Trial period')
-                          : getMessage('inactive', undefined, 'Inactive')
-                        }
-                      </p>
-                    </div>
-                  </div>
-                )}
-
-                {/* Warning Messages */}
-                {subscription?.cancelAtPeriodEnd && subscription.currentPeriodEnd && (
-                  <div className="jd-flex jd-items-start jd-space-x-2 jd-p-3 jd-bg-yellow-50 jd-border jd-border-yellow-200 jd-rounded-lg">
-                    <AlertTriangle className="jd-w-5 jd-h-5 jd-text-yellow-600 jd-mt-0.5" />
-                    <div>
-                      <p className="jd-text-yellow-800 jd-text-sm jd-font-medium">
-                        {getMessage('subscription_cancelling_title', undefined, 'Subscription Cancelling')}
-                      </p>
-                      <p className="jd-text-yellow-700 jd-text-sm">
-                        {getMessage('subscription_cancelling_message', undefined, 'Your subscription will end on {0}. You\'ll continue to have access until then.')
-                          .replace('{0}', formatDate(subscription.currentPeriodEnd))}
-                      </p>
-                    </div>
-                  </div>
-                )}
-
-                {subscription?.isPastDue && (
-                  <div className="jd-flex jd-items-start jd-space-x-2 jd-p-3 jd-bg-red-50 jd-border jd-border-red-200 jd-rounded-lg">
-                    <AlertTriangle className="jd-w-5 jd-h-5 jd-text-red-600 jd-mt-0.5" />
-                    <div>
-                      <p className="jd-text-red-800 jd-text-sm jd-font-medium">
-                        {getMessage('payment_overdue_title', undefined, 'Payment Overdue')}
-                      </p>
-                      <p className="jd-text-red-700 jd-text-sm">
-                        {getMessage('payment_overdue_message', undefined, 'Your payment is overdue. Please update your payment method to continue using premium features.')}
-                      </p>
-                    </div>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
+            {subscription && (
+              <SubscriptionStatusCard subscription={subscription} statusInfo={statusInfo} />
+            )}
 
             <Separator />
 
-            {/* Action Buttons */}
-            <div className="jd-space-y-3">
-              {subscription?.isActive || subscription?.isTrialing ? (
-                <>
-                  <Button
-                    onClick={handleManageSubscription}
-                    disabled={loading || isLoading}
-                    className="jd-w-full jd-flex jd-items-center jd-justify-center jd-space-x-2"
-                  >
-                    {loading ? (
-                      <RefreshCw className="jd-w-4 jd-h-4 jd-animate-spin" />
-                    ) : (
-                      <ExternalLink className="jd-w-4 jd-h-4" />
-                    )}
-                    <span>
-                      {getMessage('manage_billing', undefined, 'Manage Billing & Payment')}
-                    </span>
-                  </Button>
-
-                  {!subscription.cancelAtPeriodEnd && (
-                    <Button
-                      onClick={handleCancelSubscription}
-                      disabled={loading || isLoading}
-                      variant="outline"
-                      className="jd-w-full jd-text-red-600 jd-border-red-600 hover:jd-bg-red-50"
-                    >
-                      {getMessage('cancel_subscription', undefined, 'Cancel Subscription')}
-                    </Button>
-                  )}
-                </>
-              ) : subscription?.isCancelled && subscription.cancelAtPeriodEnd ? (
-                <Button
-                  onClick={handleReactivateSubscription}
-                  disabled={loading || isLoading}
-                  className="jd-w-full jd-flex jd-items-center jd-justify-center jd-space-x-2 jd-bg-green-600 hover:jd-bg-green-700"
-                >
-                  {loading ? (
-                    <RefreshCw className="jd-w-4 jd-h-4 jd-animate-spin" />
-                  ) : (
-                    <Crown className="jd-w-4 jd-h-4" />
-                  )}
-                  <span>
-                    {getMessage('reactivate_subscription', undefined, 'Reactivate Subscription')}
-                  </span>
-                </Button>
-              ) : subscription?.isPastDue ? (
-                <>
-                  <Button
-                    onClick={handleManageSubscription}
-                    disabled={loading || isLoading}
-                    className="jd-w-full jd-flex jd-items-center jd-justify-center jd-space-x-2 jd-bg-orange-600 hover:jd-bg-orange-700"
-                  >
-                    {loading ? (
-                      <RefreshCw className="jd-w-4 jd-h-4 jd-animate-spin" />
-                    ) : (
-                      <ExternalLink className="jd-w-4 jd-h-4" />
-                    )}
-                    <span>
-                      {getMessage('update_payment_method', undefined, 'Update Payment Method')}
-                    </span>
-                  </Button>
-                </>
-              ) : (
-                <Button
-                  onClick={() => setShowPricing(true)}
-                  className="jd-w-full jd-flex jd-items-center jd-justify-center jd-space-x-2 jd-bg-green-600 hover:jd-bg-green-700"
-                >
-                  <Crown className="jd-w-4 jd-h-4" />
-                  <span>
-                    {getMessage('upgrade_to_premium', undefined, 'Upgrade to Premium')}
-                  </span>
-                </Button>
-              )}
-            </div>
-
-            {/* Refresh Button */}
-            <div className="jd-flex jd-justify-center jd-pt-4">
-              <Button
-                onClick={handleRefreshSubscription}
-                disabled={loading || isLoading}
-                variant="ghost"
-                size="sm"
-                className="jd-text-muted-foreground hover:jd-text-foreground"
-              >
-                <RefreshCw className={`jd-w-4 jd-h-4 jd-mr-2 ${loading || isLoading ? 'jd-animate-spin' : ''}`} />
-                {getMessage('refresh_status', undefined, 'Refresh Status')}
-              </Button>
-            </div>
+            <ActionButtons
+              subscription={subscription}
+              loading={loading}
+              isLoading={isLoading}
+              onManage={handleManageSubscription}
+              onCancel={handleCancelSubscription}
+              onReactivate={handleReactivateSubscription}
+              onRefresh={handleRefreshSubscription}
+              onUpgrade={() => setShowPricing(true)}
+            />
           </>
         )}
       </div>

--- a/src/components/dialogs/subscription/manage/ActionButtons.tsx
+++ b/src/components/dialogs/subscription/manage/ActionButtons.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { RefreshCw, ExternalLink, Crown } from 'lucide-react';
+import { getMessage } from '@/core/utils/i18n';
+import { SubscriptionData } from '@/state/SubscriptionContext';
+
+interface Props {
+  subscription: SubscriptionData | null;
+  loading: boolean;
+  isLoading: boolean;
+  onManage: () => void;
+  onCancel: () => void;
+  onReactivate: () => void;
+  onRefresh: () => void;
+  onUpgrade: () => void;
+}
+
+export const ActionButtons: React.FC<Props> = ({
+  subscription,
+  loading,
+  isLoading,
+  onManage,
+  onCancel,
+  onReactivate,
+  onRefresh,
+  onUpgrade,
+}) => (
+  <>
+    <div className="jd-space-y-3">
+      {subscription?.isActive || subscription?.isTrialing ? (
+        <>
+          <Button
+            onClick={onManage}
+            disabled={loading || isLoading}
+            className="jd-w-full jd-flex jd-items-center jd-justify-center jd-space-x-2"
+          >
+            {loading ? (
+              <RefreshCw className="jd-w-4 jd-h-4 jd-animate-spin" />
+            ) : (
+              <ExternalLink className="jd-w-4 jd-h-4" />
+            )}
+            <span>{getMessage('manage_billing', undefined, 'Manage Billing & Payment')}</span>
+          </Button>
+
+          {!subscription.cancelAtPeriodEnd && (
+            <Button
+              onClick={onCancel}
+              disabled={loading || isLoading}
+              variant="outline"
+              className="jd-w-full jd-text-red-600 jd-border-red-600 hover:jd-bg-red-50"
+            >
+              {getMessage('cancel_subscription', undefined, 'Cancel Subscription')}
+            </Button>
+          )}
+        </>
+      ) : subscription?.isCancelled && subscription.cancelAtPeriodEnd ? (
+        <Button
+          onClick={onReactivate}
+          disabled={loading || isLoading}
+          className="jd-w-full jd-flex jd-items-center jd-justify-center jd-space-x-2 jd-bg-green-600 hover:jd-bg-green-700"
+        >
+          {loading ? (
+            <RefreshCw className="jd-w-4 jd-h-4 jd-animate-spin" />
+          ) : (
+            <Crown className="jd-w-4 jd-h-4" />
+          )}
+          <span>{getMessage('reactivate_subscription', undefined, 'Reactivate Subscription')}</span>
+        </Button>
+      ) : subscription?.isPastDue ? (
+        <>
+          <Button
+            onClick={onManage}
+            disabled={loading || isLoading}
+            className="jd-w-full jd-flex jd-items-center jd-justify-center jd-space-x-2 jd-bg-orange-600 hover:jd-bg-orange-700"
+          >
+            {loading ? (
+              <RefreshCw className="jd-w-4 jd-h-4 jd-animate-spin" />
+            ) : (
+              <ExternalLink className="jd-w-4 jd-h-4" />
+            )}
+            <span>{getMessage('update_payment_method', undefined, 'Update Payment Method')}</span>
+          </Button>
+        </>
+      ) : (
+        <Button
+          onClick={onUpgrade}
+          className="jd-w-full jd-flex jd-items-center jd-justify-center jd-space-x-2 jd-bg-green-600 hover:jd-bg-green-700"
+        >
+          <Crown className="jd-w-4 jd-h-4" />
+          <span>{getMessage('upgrade_to_premium', undefined, 'Upgrade to Premium')}</span>
+        </Button>
+      )}
+    </div>
+
+    <div className="jd-flex jd-justify-center jd-pt-4">
+      <Button
+        onClick={onRefresh}
+        disabled={loading || isLoading}
+        variant="ghost"
+        size="sm"
+        className="jd-text-muted-foreground hover:jd-text-foreground"
+      >
+        <RefreshCw className={`jd-w-4 jd-h-4 jd-mr-2 ${loading || isLoading ? 'jd-animate-spin' : ''}`} />
+        {getMessage('refresh_status', undefined, 'Refresh Status')}
+      </Button>
+    </div>
+  </>
+);

--- a/src/components/dialogs/subscription/manage/SubscriptionStatusCard.tsx
+++ b/src/components/dialogs/subscription/manage/SubscriptionStatusCard.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { AlertTriangle, Crown } from 'lucide-react';
+import { SubscriptionData } from '@/state/SubscriptionContext';
+import { getMessage } from '@/core/utils/i18n';
+import { formatDate, getPlanDisplayName, StatusInfo } from './helpers';
+
+interface Props {
+  subscription: SubscriptionData;
+  statusInfo: StatusInfo;
+}
+
+export const SubscriptionStatusCard: React.FC<Props> = ({ subscription, statusInfo }) => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="jd-flex jd-items-center jd-space-x-2">
+          <Crown className="jd-w-5 jd-h-5" />
+          <span>{getMessage('current_subscription', undefined, 'Current Subscription')}</span>
+        </CardTitle>
+      </CardHeader>
+
+      <CardContent className="jd-space-y-4">
+        <div className="jd-flex jd-items-center jd-justify-between jd-p-4 jd-bg-muted jd-rounded-lg">
+          <div className="jd-flex jd-items-center jd-space-x-3">
+            {statusInfo.icon}
+            <div>
+              <p className="jd-font-medium">
+                {getPlanDisplayName(subscription.subscription_plan)}
+              </p>
+              <p className="jd-text-sm jd-text-muted-foreground">{statusInfo.message}</p>
+            </div>
+          </div>
+
+          <Badge className={statusInfo.color}>{statusInfo.label}</Badge>
+        </div>
+
+        {subscription.hasSubscription && (
+          <div className="jd-grid jd-grid-cols-1 md:jd-grid-cols-2 jd-gap-4 jd-pt-4">
+            {subscription.isTrialing && subscription.trialEnd && (
+              <div className="jd-space-y-2">
+                <p className="jd-text-sm jd-text-muted-foreground">
+                  {getMessage('trial_ends', undefined, 'Trial ends')}
+                </p>
+                <p className="jd-font-medium">{formatDate(subscription.trialEnd)}</p>
+              </div>
+            )}
+
+            {(subscription.isActive || subscription.isTrialing) && subscription.currentPeriodEnd && (
+              <div className="jd-space-y-2">
+                <p className="jd-text-sm jd-text-muted-foreground">
+                  {subscription.isTrialing
+                    ? getMessage('trial_period_end', undefined, 'Trial period ends')
+                    : getMessage('next_billing_date', undefined, 'Next billing date')}
+                </p>
+                <p className="jd-font-medium">{formatDate(subscription.currentPeriodEnd)}</p>
+              </div>
+            )}
+
+            <div className="jd-space-y-2">
+              <p className="jd-text-sm jd-text-muted-foreground">
+                {getMessage('billing_status', undefined, 'Billing status')}
+              </p>
+              <p className="jd-font-medium">
+                {subscription.cancelAtPeriodEnd
+                  ? getMessage('cancelling_at_period_end', undefined, 'Cancelling at period end')
+                  : subscription.isActive
+                  ? getMessage('active_renewing', undefined, 'Active & renewing')
+                  : subscription.isTrialing
+                  ? getMessage('trial_period', undefined, 'Trial period')
+                  : getMessage('inactive', undefined, 'Inactive')}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {subscription.cancelAtPeriodEnd && subscription.currentPeriodEnd && (
+          <div className="jd-flex jd-items-start jd-space-x-2 jd-p-3 jd-bg-yellow-50 jd-border jd-border-yellow-200 jd-rounded-lg">
+            <AlertTriangle className="jd-w-5 jd-h-5 jd-text-yellow-600 jd-mt-0.5" />
+            <div>
+              <p className="jd-text-yellow-800 jd-text-sm jd-font-medium">
+                {getMessage('subscription_cancelling_title', undefined, 'Subscription Cancelling')}
+              </p>
+              <p className="jd-text-yellow-700 jd-text-sm">
+                {getMessage(
+                  'subscription_cancelling_message',
+                  undefined,
+                  "Your subscription will end on {0}. You'll continue to have access until then."
+                ).replace('{0}', formatDate(subscription.currentPeriodEnd))}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {subscription.isPastDue && (
+          <div className="jd-flex jd-items-start jd-space-x-2 jd-p-3 jd-bg-red-50 jd-border jd-border-red-200 jd-rounded-lg">
+            <AlertTriangle className="jd-w-5 jd-h-5 jd-text-red-600 jd-mt-0.5" />
+            <div>
+              <p className="jd-text-red-800 jd-text-sm jd-font-medium">
+                {getMessage('payment_overdue_title', undefined, 'Payment Overdue')}
+              </p>
+              <p className="jd-text-red-700 jd-text-sm">
+                {getMessage(
+                  'payment_overdue_message',
+                  undefined,
+                  'Your payment is overdue. Please update your payment method to continue using premium features.'
+                )}
+              </p>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/dialogs/subscription/manage/helpers.ts
+++ b/src/components/dialogs/subscription/manage/helpers.ts
@@ -1,0 +1,75 @@
+import React from 'react';
+import { CheckCircle, Clock, AlertTriangle, XCircle, AlertCircle } from 'lucide-react';
+import { getMessage } from '@/core/utils/i18n';
+
+export interface StatusInfo {
+  icon: React.ReactNode;
+  color: string;
+  label: string;
+  message: string;
+}
+
+export const formatDate = (dateString: string | null | undefined) => {
+  if (!dateString) return '-';
+  return new Date(dateString).toLocaleDateString();
+};
+
+export const getPlanDisplayName = (planId: string | null) => {
+  switch (planId) {
+    case 'monthly':
+      return getMessage('monthly_plan', undefined, 'Monthly Plan');
+    case 'yearly':
+      return getMessage('yearly_plan', undefined, 'Yearly Plan');
+    case 'plus':
+      return getMessage('plus_plan', undefined, 'Plus Plan');
+    default:
+      return getMessage('free_plan', undefined, 'Free Plan');
+  }
+};
+
+export const getStatusInfo = (status: string): StatusInfo => {
+  switch (status) {
+    case 'active':
+      return {
+        icon: <CheckCircle className="jd-w-5 jd-h-5 jd-text-green-500" />,
+        color: 'jd-bg-green-100 jd-text-green-800',
+        label: getMessage('active', undefined, 'Active'),
+        message: getMessage('active_subscription', undefined, 'Your subscription is active'),
+      };
+    case 'trialing':
+      return {
+        icon: <Clock className="jd-w-5 jd-h-5 jd-text-blue-500" />,
+        color: 'jd-bg-blue-100 jd-text-blue-800',
+        label: getMessage('trial', undefined, 'Trial'),
+        message: getMessage('trial_subscription', undefined, 'You are in your trial period'),
+      };
+    case 'past_due':
+      return {
+        icon: <AlertTriangle className="jd-w-5 jd-h-5 jd-text-orange-500" />,
+        color: 'jd-bg-orange-100 jd-text-orange-800',
+        label: getMessage('past_due', undefined, 'Past Due'),
+        message: getMessage('past_due_subscription', undefined, 'Your payment is overdue'),
+      };
+    case 'cancelled':
+      return {
+        icon: <XCircle className="jd-w-5 jd-h-5 jd-text-red-500" />,
+        color: 'jd-bg-red-100 jd-text-red-800',
+        label: getMessage('cancelled', undefined, 'Cancelled'),
+        message: getMessage('cancelled_subscription', undefined, 'Your subscription has been cancelled'),
+      };
+    case 'incomplete':
+      return {
+        icon: <AlertCircle className="jd-w-5 jd-h-5 jd-text-yellow-500" />,
+        color: 'jd-bg-yellow-100 jd-text-yellow-800',
+        label: getMessage('incomplete', undefined, 'Incomplete'),
+        message: getMessage('incomplete_subscription', undefined, 'Your subscription setup is incomplete'),
+      };
+    default:
+      return {
+        icon: <XCircle className="jd-w-5 jd-h-5 jd-text-gray-500" />,
+        color: 'jd-bg-gray-100 jd-text-gray-600',
+        label: getMessage('inactive', undefined, 'Inactive'),
+        message: getMessage('no_active_subscription', undefined, 'No active subscription'),
+      };
+  }
+};

--- a/src/components/dialogs/subscription/manage/index.ts
+++ b/src/components/dialogs/subscription/manage/index.ts
@@ -1,0 +1,4 @@
+export { formatDate, getPlanDisplayName, getStatusInfo } from './helpers';
+export type { StatusInfo } from './helpers';
+export { SubscriptionStatusCard } from './SubscriptionStatusCard';
+export { ActionButtons } from './ActionButtons';


### PR DESCRIPTION
## Summary
- split `ManageSubscriptionDialog` into helper and UI components
- new `SubscriptionStatusCard` handles status display
- new `ActionButtons` encapsulates actions
- added util functions in `manage/helpers`
- simplified main dialog file to use new components

## Testing
- `pnpm lint` *(fails: 611 problems)*
- `pnpm type-check`

------
https://chatgpt.com/codex/tasks/task_b_6878e1765f188325b181e0ed1d01e341