### PR TITLE
Add subscription status prefetch with caching

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -8,6 +8,7 @@ import ErrorBoundary from '@/components/common/ErrorBoundary';
 import { DialogProvider } from '@/components/dialogs/DialogProvider';
 import { QueryProvider } from '@/providers/QueryProvider';
 import { ThemeProvider } from '@/components/theme-provider';
+import SubscriptionPrefetcher from '@/components/subscription/SubscriptionPrefetcher';
 import { initAmplitude, setUserProperties } from '@/utils/amplitude';
 import { authService } from '@/services/auth/AuthService';
 import { getCurrentLanguage } from '@/core/utils/i18n';
@@ -102,6 +103,8 @@ const Main: React.FC = () => {
             <QueryProvider>
               {/* Updated to use our new dialog system */}
               <DialogProvider>
+                {/* Prefetch subscription status */}
+                <SubscriptionPrefetcher />
                 {/* UI Components */}
                 <MainButton />
                 {/* Toast notifications */}

--- a/src/components/subscription/SubscriptionPrefetcher.tsx
+++ b/src/components/subscription/SubscriptionPrefetcher.tsx
@@ -1,0 +1,12 @@
+import { useSubscriptionStatus } from '@/hooks/subscription/useSubscriptionStatus';
+
+/**
+ * Component that prefetches the user's subscription status on app load.
+ * It renders nothing but ensures the data is cached for later use.
+ */
+export const SubscriptionPrefetcher: React.FC = () => {
+  useSubscriptionStatus();
+  return null;
+};
+
+export default SubscriptionPrefetcher;

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -27,4 +27,7 @@ export const QUERY_KEYS = {
 
     ORGANIZATIONS: 'organizations',
     ORGANIZATION_BY_ID: 'organizationById',
+
+    // Subscription related
+    SUBSCRIPTION_STATUS: 'subscriptionStatus',
   };


### PR DESCRIPTION
## Summary
- cache subscription status via React Query for 1 hour
- prefetch subscription status when app mounts

## Testing
- `npm run lint` *(fails: 574 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68793c742f188325b0ac72e9f1f43f5a