### PR TITLE
Show pricing in paywall

### DIFF
--- a/src/components/dialogs/subscription/PaywallDialog.tsx
+++ b/src/components/dialogs/subscription/PaywallDialog.tsx
@@ -1,17 +1,23 @@
 import React from 'react';
-import { Button } from '@/components/ui/button';
 import { BaseDialog } from '../BaseDialog';
 import { useDialog, useDialogManager } from '../DialogContext';
 import { DIALOG_TYPES } from '../DialogRegistry';
 import { getMessage } from '@/core/utils/i18n';
+import { useAuthState } from '@/hooks/auth/useAuthState';
+import { PricingPlans } from '@/components/pricing/PricingPlans';
 
 export const PaywallDialog: React.FC = () => {
   const { isOpen, dialogProps } = useDialog(DIALOG_TYPES.PAYWALL);
   const { openDialog } = useDialogManager();
+  const { authState } = useAuthState();
 
-  const handleUpgrade = () => {
+  const handlePaymentSuccess = () => {
     dialogProps.onOpenChange(false);
     openDialog(DIALOG_TYPES.MANAGE_SUBSCRIPTION);
+  };
+
+  const handlePaymentCancel = () => {
+    // No-op for now
   };
 
   if (!isOpen) return null;
@@ -21,21 +27,23 @@ export const PaywallDialog: React.FC = () => {
       open={isOpen}
       onOpenChange={dialogProps.onOpenChange}
       title={getMessage('upgrade_required', undefined, 'Upgrade Required')}
-      className="jd-max-w-md"
+      className="jd-max-w-2xl"
     >
-      <div className="jd-space-y-4">
-        <p>
+      <div className="jd-space-y-6">
+        <p className="jd-text-muted-foreground">
           {getMessage(
             'paywall_message',
             undefined,
             'Free users can create up to 5 custom templates or blocks. Upgrade your subscription to add more.'
           )}
         </p>
-        <div className="jd-flex jd-justify-end">
-          <Button onClick={handleUpgrade}>
-            {getMessage('upgrade_now', undefined, 'Upgrade Now')}
-          </Button>
-        </div>
+        {authState.user && (
+          <PricingPlans
+            user={authState.user}
+            onPaymentSuccess={handlePaymentSuccess}
+            onPaymentCancel={handlePaymentCancel}
+          />
+        )}
       </div>
     </BaseDialog>
   );


### PR DESCRIPTION
## Summary
- display subscription pricing directly in the paywall dialog

## Testing
- `npm run lint` *(fails: 620 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68794b65b84c8325b55c45a050793d8f