### PR TITLE
Fix onboarding progress refresh

### DIFF
--- a/src/components/panels/TemplatesPanel/OnboardingChecklist.tsx
+++ b/src/components/panels/TemplatesPanel/OnboardingChecklist.tsx
@@ -86,6 +86,16 @@ export const OnboardingChecklist: React.FC<OnboardingChecklistProps> = ({
 
   useEffect(() => {
     fetchChecklistData();
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<OnboardingChecklistData>).detail;
+      if (detail) {
+        setChecklistData(detail);
+      } else {
+        fetchChecklistData();
+      }
+    };
+    document.addEventListener('jaydai:onboarding-checklist-updated', handler);
+    return () => document.removeEventListener('jaydai:onboarding-checklist-updated', handler);
   }, [fetchChecklistData]);
 
   // Handle item clicks

--- a/src/hooks/useOnboardingChecklist.tsx
+++ b/src/hooks/useOnboardingChecklist.tsx
@@ -29,6 +29,13 @@ export function useOnboardingChecklist() {
           action: 'first_template_created',
           progress: response.data?.progress || 'unknown'
         });
+        if (response.data) {
+          document.dispatchEvent(
+            new CustomEvent('jaydai:onboarding-checklist-updated', {
+              detail: response.data
+            })
+          );
+        }
         return response.data;
       }
     } catch (error) {
@@ -46,6 +53,13 @@ export function useOnboardingChecklist() {
           action: 'first_template_used',
           progress: response.data?.progress || 'unknown'
         });
+        if (response.data) {
+          document.dispatchEvent(
+            new CustomEvent('jaydai:onboarding-checklist-updated', {
+              detail: response.data
+            })
+          );
+        }
         return response.data;
       }
     } catch (error) {
@@ -63,6 +77,13 @@ export function useOnboardingChecklist() {
           action: 'first_block_created',
           progress: response.data?.progress || 'unknown'
         });
+        if (response.data) {
+          document.dispatchEvent(
+            new CustomEvent('jaydai:onboarding-checklist-updated', {
+              detail: response.data
+            })
+          );
+        }
         return response.data;
       }
     } catch (error) {
@@ -80,6 +101,13 @@ export function useOnboardingChecklist() {
           action: 'keyboard_shortcut_used',
           progress: response.data?.progress || 'unknown'
         });
+        if (response.data) {
+          document.dispatchEvent(
+            new CustomEvent('jaydai:onboarding-checklist-updated', {
+              detail: response.data
+            })
+          );
+        }
         return response.data;
       }
     } catch (error) {
@@ -107,6 +135,13 @@ export function useOnboardingChecklist() {
             });
           }
         });
+        if (response.data) {
+          document.dispatchEvent(
+            new CustomEvent('jaydai:onboarding-checklist-updated', {
+              detail: response.data
+            })
+          );
+        }
         return response.data;
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- trigger a `jaydai:onboarding-checklist-updated` event whenever onboarding API calls complete
- listen for that event in `OnboardingChecklist` so the progress bar refreshes automatically

## Testing
- `pnpm lint` *(fails: 622 errors)*
- `pnpm type-check`

------
https://chatgpt.com/codex/tasks/task_b_687bd11cdce48325895c215b8abe8fee