### PR TITLE
Fix onboarding keyboard shortcut dialog overlay

### DIFF
--- a/src/components/dialogs/onboarding/KeyboardShortcutDialog.tsx
+++ b/src/components/dialogs/onboarding/KeyboardShortcutDialog.tsx
@@ -1,8 +1,10 @@
 // src/components/onboarding/KeyboardShortcutDialog.tsx
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { BaseDialog } from '@/components/dialogs/BaseDialog';
 import { getMessage } from '@/core/utils/i18n';
 import { Keyboard, Zap } from 'lucide-react';
+import { useShadowRoot } from '@/core/utils/componentInjector';
 
 interface KeyboardShortcutDialogProps {
   open: boolean;
@@ -15,7 +17,9 @@ export const KeyboardShortcutDialog: React.FC<KeyboardShortcutDialogProps> = ({
   onOpenChange,
   onShortcutUsed
 }) => {
-  return (
+  const shadowRoot = useShadowRoot();
+
+  const dialog = (
     <BaseDialog
       open={open}
       onOpenChange={onOpenChange}
@@ -81,4 +85,6 @@ export const KeyboardShortcutDialog: React.FC<KeyboardShortcutDialogProps> = ({
       </div>
     </BaseDialog>
   );
+
+  return createPortal(dialog, shadowRoot || document.body);
 };


### PR DESCRIPTION
## Summary
- show `KeyboardShortcutDialog` using a portal so it displays as a normal dialog

## Testing
- `npm run lint` *(fails: cannot pass current repo lint rules)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687cfe6d546c83209dc6c18475646137