### PR TITLE
Add default template fallback

### DIFF
--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -34,6 +34,7 @@ import {
 import { useDialogActions } from '@/hooks/dialogs/useDialogActions';
 import { useOrganizations } from '@/hooks/organizations';
 import { VirtualizedList } from '@/components/common/VirtualizedList';
+import { promptApi } from '@/services/api';
 
 import { FolderSearch } from '@/components/prompts/folders';
 import { LoadingState } from './LoadingState';
@@ -410,7 +411,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
   const handleUseTemplate = useCallback(async () => {
     try {
       // Find the first available user template
-      let firstTemplate = null;
+      let firstTemplate: Template | null = null;
       
       // Check unorganized templates first
       if (unorganizedTemplates.length > 0) {
@@ -422,6 +423,14 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
             firstTemplate = folder.templates[0];
             break;
           }
+        }
+      }
+
+      if (!firstTemplate) {
+        // If no user template exists, fall back to template with id 1
+        const response = await promptApi.getTemplateById(1);
+        if (response.success && response.data) {
+          firstTemplate = response.data as Template;
         }
       }
 

--- a/src/services/api/PromptApi.ts
+++ b/src/services/api/PromptApi.ts
@@ -16,10 +16,10 @@ import {
         getUnorganizedTemplates,
         getUserTemplates,
         getTemplatesByFolder,
+        getTemplateById,
         trackTemplateUsage,
         toggleTemplatePin
       } from './prompts/templates';
-import { getTemplatesByFolder } from './prompts/templates/getTemplatesByFolder';
 
 /**
  * API client for working with prompt templates
@@ -77,6 +77,10 @@ class PromptApiClient {
 
   async getTemplatesByFolder(folderId: number): Promise<any> {
     return getTemplatesByFolder(folderId);
+  }
+
+  async getTemplateById(templateId: number): Promise<any> {
+    return getTemplateById(templateId);
   }
 
   async createFolder(folderData: { title: string; description?: string; parent_folder_id?: number | null }): Promise<any> {

--- a/src/services/api/prompts/templates/getTemplateById.ts
+++ b/src/services/api/prompts/templates/getTemplateById.ts
@@ -1,0 +1,17 @@
+import { apiClient } from '@/services/api/ApiClient';
+
+export async function getTemplateById(templateId: number): Promise<any> {
+  try {
+    const response = await apiClient.request(`/prompts/templates/${templateId}`, {
+      method: 'GET'
+    });
+    return response;
+  } catch (error) {
+    console.error('Error fetching template by id:', error);
+    return {
+      success: false,
+      data: null,
+      message: error instanceof Error ? error.message : 'Unknown error'
+    };
+  }
+}

--- a/src/services/api/prompts/templates/index.ts
+++ b/src/services/api/prompts/templates/index.ts
@@ -6,3 +6,4 @@ export { getUserTemplates } from './getUserTemplates';
 export { getTemplatesByFolder } from './getTemplatesByFolder';
 export { trackTemplateUsage } from './trackTemplateUsage';
 export { toggleTemplatePin } from './toggleTemplatePin';
+export { getTemplateById } from './getTemplateById';


### PR DESCRIPTION
## Summary
- export prompt fetching by id from API
- use fallback template with id=1 for onboarding checklist action

## Testing
- `npm run type-check`
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687cfeaedcc88320bc89c9ecec4e68cf