### PR TITLE
Fetch folders without templates

### DIFF
--- a/src/hooks/prompts/queries/folders/useUserCompanyOrganizationFolders.ts
+++ b/src/hooks/prompts/queries/folders/useUserCompanyOrganizationFolders.ts
@@ -13,8 +13,8 @@ export function useUserFolders() {
   const locale = getCurrentLanguage();
 
   return useQuery(QUERY_KEYS.USER_FOLDERS, async (): Promise<TemplateFolder[]> => {
-    // Get folders including their templates so BrowseMoreDialog can display them
-    const foldersResponse = await promptApi.getFolders('user', true, true, locale);
+    // Get folders without templates; templates are fetched on demand
+    const foldersResponse = await promptApi.getFolders('user', true, false, locale);
 
     if (!foldersResponse.success) {
       throw new Error(foldersResponse.message || 'Failed to load user folders');
@@ -39,8 +39,8 @@ export function useCompanyFolders() {
   const locale = getCurrentLanguage();
 
   return useQuery(QUERY_KEYS.COMPANY_FOLDERS, async (): Promise<TemplateFolder[]> => {
-    // Get folders including their templates so BrowseMoreDialog can display them
-    const foldersResponse = await promptApi.getFolders('company', true, true, locale);
+    // Get folders without templates; templates are fetched on demand
+    const foldersResponse = await promptApi.getFolders('company', true, false, locale);
 
     if (!foldersResponse.success) {
       throw new Error(foldersResponse.message || 'Failed to load company folders');
@@ -62,8 +62,8 @@ export function useOrganizationFolders() {
   const locale = getCurrentLanguage();
 
   return useQuery(QUERY_KEYS.ORGANIZATION_FOLDERS, async (): Promise<TemplateFolder[]> => {
-    // Get folders including their templates so BrowseMoreDialog can display them
-    const foldersResponse = await promptApi.getFolders('organization', true, true, locale);
+    // Get folders without templates; templates are fetched on demand
+    const foldersResponse = await promptApi.getFolders('organization', true, false, locale);
     
     if (!foldersResponse.success) {
       throw new Error(foldersResponse.message || 'Failed to load organization folders');


### PR DESCRIPTION
## Summary
- fetch folder lists without templates
- leave templates to be fetched on demand when a folder is opened

## Testing
- `npm run lint` *(fails: 590 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687d074f2ce88320a796ba4e8a93eb61