### PR TITLE
Internationalize pricing components

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2189,4 +2189,117 @@
     "message": "Free Trial",
     "description": "Free trial text"
   }
+  ,
+  "monthlyPlan": {
+    "message": "Monthly Plan",
+    "description": "Label for monthly plan"
+  },
+  "yearlyPlan": {
+    "message": "Yearly Plan",
+    "description": "Label for yearly plan"
+  },
+  "freePlan": {
+    "message": "Free Plan",
+    "description": "Label for free plan"
+  },
+  "choosePlan": {
+    "message": "Choose Your Plan",
+    "description": "Pricing plans section title"
+  },
+  "premiumTemplates": {
+    "message": "Access to 1000+ premium prompt templates",
+    "description": "Feature title: premium prompt templates"
+  },
+  "premiumTemplatesDesc": {
+    "message": "Curated templates for all use cases",
+    "description": "Feature description for premium templates"
+  },
+  "unlimitedPersonalTemplates": {
+    "message": "Unlimited personal prompt templates",
+    "description": "Feature title for unlimited personal templates"
+  },
+  "unlimitedPersonalTemplatesDesc": {
+    "message": "Create and save your own templates",
+    "description": "Feature description for unlimited personal templates"
+  },
+  "unlimitedPromptBlocks": {
+    "message": "Unlimited personal prompt blocks",
+    "description": "Feature title for unlimited prompt blocks"
+  },
+  "unlimitedPromptBlocksDesc": {
+    "message": "Build reusable prompt components",
+    "description": "Feature description for unlimited prompt blocks"
+  },
+  "advancedAnalytics": {
+    "message": "Advanced Data Analytics",
+    "description": "Feature title for analytics"
+  },
+  "advancedAnalyticsDesc": {
+    "message": "Detailed insights and usage statistics (coming soon)",
+    "description": "Feature description for analytics"
+  },
+  "plusPlan": {
+    "message": "Jaydai Plus",
+    "description": "Name of the premium subscription plan"
+  },
+  "startWith3DayFreeTrial": {
+    "message": "Start with 3-Day FREE Trial",
+    "description": "Free trial banner text"
+  },
+  "tryAllFeaturesFree": {
+    "message": "Try all features free for 3 days",
+    "description": "Free trial feature text"
+  },
+  "cancelAnytimeDuringTrial": {
+    "message": "Cancel anytime during trial",
+    "description": "Free trial cancellation note"
+  },
+  "billedAnnually": {
+    "message": "Billed annually",
+    "description": "Billing frequency note"
+  },
+  "afterTrialPeriod": {
+    "message": "After your 3-day free trial period",
+    "description": "Trial reminder subtext"
+  },
+  "startFreeTrial": {
+    "message": "Start Free Trial",
+    "description": "CTA button text"
+  },
+  "noChargeFor3Days": {
+    "message": "No charge for 3 days. Cancel anytime during trial.",
+    "description": "CTA subtext"
+  },
+  "securePayment": {
+    "message": "Secure payment powered by Stripe",
+    "description": "Payment security note"
+  },
+  "trialPaymentNote": {
+    "message": "Your payment method will be saved securely but not charged during your 3-day trial period.",
+    "description": "Note about payment during trial"
+  },
+  "userEmailRequired": {
+    "message": "User email is required for payment",
+    "description": "Error shown when user email missing for checkout"
+  },
+  "redirectingToPayment": {
+    "message": "Redirecting to payment...",
+    "description": "Informational toast before redirect to payment"
+  },
+  "completePaymentInNewTab": {
+    "message": "Complete your payment in the new tab",
+    "description": "Info toast description about finishing payment"
+  },
+  "paymentError": {
+    "message": "Payment failed",
+    "description": "Generic payment error title"
+  },
+  "tryAgainLater": {
+    "message": "Please try again later",
+    "description": "Generic suggestion to retry later"
+  },
+  "invalidPlanSelected": {
+    "message": "Invalid plan selected",
+    "description": "Error message when an invalid plan is chosen"
+  }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -2171,4 +2171,117 @@
     "message": "Essai gratuit",
     "description": "Texte essai gratuit"
   }
+  ,
+  "monthlyPlan": {
+    "message": "Abonnement mensuel",
+    "description": "Libellé pour l'offre mensuelle"
+  },
+  "yearlyPlan": {
+    "message": "Abonnement annuel",
+    "description": "Libellé pour l'offre annuelle"
+  },
+  "freePlan": {
+    "message": "Offre gratuite",
+    "description": "Libellé pour l'offre gratuite"
+  },
+  "choosePlan": {
+    "message": "Choisissez votre offre",
+    "description": "Titre de la section des abonnements"
+  },
+  "premiumTemplates": {
+    "message": "Accès à plus de 1000 modèles de prompts premium",
+    "description": "Titre de fonctionnalité : modèles premium"
+  },
+  "premiumTemplatesDesc": {
+    "message": "Modèles sélectionnés pour tous les cas d'usage",
+    "description": "Description des modèles premium"
+  },
+  "unlimitedPersonalTemplates": {
+    "message": "Modèles personnels illimités",
+    "description": "Titre de fonctionnalité pour modèles personnels illimités"
+  },
+  "unlimitedPersonalTemplatesDesc": {
+    "message": "Créez et enregistrez vos propres modèles",
+    "description": "Description pour modèles personnels illimités"
+  },
+  "unlimitedPromptBlocks": {
+    "message": "Blocs de prompt personnels illimités",
+    "description": "Titre de fonctionnalité pour blocs illimités"
+  },
+  "unlimitedPromptBlocksDesc": {
+    "message": "Construisez des composants de prompt réutilisables",
+    "description": "Description pour blocs de prompt illimités"
+  },
+  "advancedAnalytics": {
+    "message": "Analyses de données avancées",
+    "description": "Titre de fonctionnalité pour les analyses"
+  },
+  "advancedAnalyticsDesc": {
+    "message": "Informations détaillées et statistiques d'utilisation (bientôt disponible)",
+    "description": "Description pour les analyses"
+  },
+  "plusPlan": {
+    "message": "Jaydai Plus",
+    "description": "Nom de l'offre premium"
+  },
+  "startWith3DayFreeTrial": {
+    "message": "Commencez avec 3 jours d'essai GRATUIT",
+    "description": "Texte de la bannière d'essai gratuit"
+  },
+  "tryAllFeaturesFree": {
+    "message": "Testez toutes les fonctionnalités gratuitement pendant 3 jours",
+    "description": "Texte d'essai gratuit"
+  },
+  "cancelAnytimeDuringTrial": {
+    "message": "Annulez à tout moment pendant l'essai",
+    "description": "Note d'annulation pendant l'essai"
+  },
+  "billedAnnually": {
+    "message": "Facturé annuellement",
+    "description": "Note de fréquence de facturation"
+  },
+  "afterTrialPeriod": {
+    "message": "Après votre période d'essai gratuite de 3 jours",
+    "description": "Texte rappel de l'essai"
+  },
+  "startFreeTrial": {
+    "message": "Démarrer l'essai gratuit",
+    "description": "Texte du bouton CTA"
+  },
+  "noChargeFor3Days": {
+    "message": "Aucun frais pendant 3 jours. Annulation possible à tout moment.",
+    "description": "Sous-texte du bouton CTA"
+  },
+  "securePayment": {
+    "message": "Paiement sécurisé par Stripe",
+    "description": "Note de sécurité du paiement"
+  },
+  "trialPaymentNote": {
+    "message": "Votre moyen de paiement sera enregistré en toute sécurité mais ne sera pas débité pendant les 3 jours d'essai.",
+    "description": "Note sur le paiement pendant l'essai"
+  },
+  "userEmailRequired": {
+    "message": "L'adresse e-mail est requise pour le paiement",
+    "description": "Erreur lorsqu'aucun email n'est fourni"
+  },
+  "redirectingToPayment": {
+    "message": "Redirection vers le paiement...",
+    "description": "Toast d'information avant la redirection"
+  },
+  "completePaymentInNewTab": {
+    "message": "Finalisez votre paiement dans le nouvel onglet",
+    "description": "Description du toast de paiement"
+  },
+  "paymentError": {
+    "message": "Échec du paiement",
+    "description": "Titre générique d'erreur de paiement"
+  },
+  "tryAgainLater": {
+    "message": "Veuillez réessayer plus tard",
+    "description": "Suggestion générique de réessayer"
+  },
+  "invalidPlanSelected": {
+    "message": "Offre invalide sélectionnée",
+    "description": "Message d'erreur lorsque l'offre est invalide"
+  }
 }

--- a/src/components/pricing/PricingPlans.tsx
+++ b/src/components/pricing/PricingPlans.tsx
@@ -32,7 +32,7 @@ export const PricingPlans: React.FC<PricingPlansProps> = ({
   const plans = [
     {
       id: 'yearly' as const,
-      name: 'Yearly Plan',
+      name: getMessage('yearlyPlan', undefined, 'Yearly Plan'),
       price: 6.99,
       currency: 'EUR',
       interval: 'year' as const,
@@ -42,7 +42,7 @@ export const PricingPlans: React.FC<PricingPlansProps> = ({
     },
     {
       id: 'monthly' as const,
-      name: 'Monthly Plan',
+      name: getMessage('monthlyPlan', undefined, 'Monthly Plan'),
       price: 8.99,
       currency: 'EUR',
       interval: 'month' as const,
@@ -61,7 +61,7 @@ export const PricingPlans: React.FC<PricingPlansProps> = ({
 
     try {
       const plan = plans.find(p => p.id === selectedPlan);
-      if (!plan) throw new Error('Invalid plan selected');
+      if (!plan) throw new Error(getMessage('invalidPlanSelected', undefined, 'Invalid plan selected'));
 
       const session = await stripeApi.createCheckoutSession({
         priceId: plan.priceId,

--- a/src/services/stripe/StripeService.ts
+++ b/src/services/stripe/StripeService.ts
@@ -1,15 +1,16 @@
 // src/services/stripe/StripeService.ts
 import { apiClient } from '@/services/api/ApiClient';
 import { trackEvent, EVENTS } from '@/utils/amplitude';
-import { 
-  StripeConfig, 
-  PricingPlan, 
-  CreateCheckoutSessionRequest, 
+import {
+  StripeConfig,
+  PricingPlan,
+  CreateCheckoutSessionRequest,
   CreateCheckoutSessionResponse,
   SubscriptionStatus,
   PaymentResult
 } from '@/types/stripe';
 import { detectPlatform } from '@/extension/content/networkInterceptor/detectPlatform';
+import { getMessage } from '@/core/utils/i18n';
 
 export class StripeService {
   private config: StripeConfig;
@@ -67,7 +68,7 @@ export class StripeService {
     try {
       const plan = this.getPricingPlans().find(p => p.id === planName);
       if (!plan) {
-        throw new Error('Invalid plan selected');
+        throw new Error(getMessage('invalidPlanSelected', undefined, 'Invalid plan selected'));
       }
 
       // Track payment attempt


### PR DESCRIPTION
## Summary
- localize plan names and error string in `PricingPlans`
- handle invalid plan in `StripeService` using i18n
- add numerous pricing-related strings to en/fr locale files

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687d0819df748320b43dbdef66873cf7