### PR TITLE
Add skip option to pricing plans

### DIFF
--- a/src/components/pricing/PricingPlans.tsx
+++ b/src/components/pricing/PricingPlans.tsx
@@ -18,13 +18,18 @@ interface PricingPlansProps {
   onPaymentSuccess?: () => void;
   onPaymentCancel?: () => void;
   isDark?: boolean;
+  /**
+   * Optional action shown below the plan toggle to skip selecting a plan.
+   */
+  skipAction?: () => void;
 }
 
 export const PricingPlans: React.FC<PricingPlansProps> = ({
   user,
   onPaymentSuccess,
   onPaymentCancel,
-  isDark = true
+  isDark = true,
+  skipAction
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [selectedPlan, setSelectedPlan] = useState<'monthly' | 'yearly'>('yearly');
@@ -196,6 +201,15 @@ export const PricingPlans: React.FC<PricingPlansProps> = ({
               </button>
             ))}
           </motion.div>
+
+          {skipAction && (
+            <button
+              onClick={skipAction}
+              className="jd-text-sm jd-text-gray-400 hover:jd-text-gray-300 jd-underline jd-mt-2"
+            >
+              {getMessage('continueWithFree', undefined, 'Continue with free')}
+            </button>
+          )}
         </div>
 
 

--- a/src/components/welcome/onboarding/OnboardingFlow.tsx
+++ b/src/components/welcome/onboarding/OnboardingFlow.tsx
@@ -290,6 +290,7 @@ export const OnboardingFlow: React.FC<OnboardingFlowProps> = ({
             user={user}
             onComplete={onComplete}
             onBack={handlePreviousStep}
+            onSkip={handleSkip}
           />
         );
       case 4:

--- a/src/components/welcome/onboarding/steps/PaymentStep/PaymentDefault.tsx
+++ b/src/components/welcome/onboarding/steps/PaymentStep/PaymentDefault.tsx
@@ -59,10 +59,11 @@ export const PaymentDefault: React.FC<PaymentDefaultProps> = ({
       animate={{ opacity: 1, y: 0 }} 
       transition={{ delay: 1.0, duration: 0.5 }}
     >
-      <PricingPlans 
-        user={user} 
-        onPaymentSuccess={onPaymentSuccess} 
-        onPaymentCancel={onPaymentCancel} 
+      <PricingPlans
+        user={user}
+        onPaymentSuccess={onPaymentSuccess}
+        onPaymentCancel={onPaymentCancel}
+        skipAction={onSkip}
       />
     </motion.div>
 


### PR DESCRIPTION
## Summary
- allow skipping pricing plan selection with new optional `skipAction` prop
- use skip action in onboarding payment step to move to the next step

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687e055d35408320bb12a2b00a38a415