### PR TITLE
Fix folder search state updates

### DIFF
--- a/src/components/dialogs/prompts/BrowseMoreFoldersDialog/index.tsx
+++ b/src/components/dialogs/prompts/BrowseMoreFoldersDialog/index.tsx
@@ -45,7 +45,13 @@ export const BrowseMoreFoldersDialog: React.FC = () => {
   }, [pinnedFolderIds]);
 
   const allFolders = organizationFolders;
-  const { searchQuery, setSearchQuery, filteredFolders, clearSearch } = useFolderSearch(allFolders);
+  const {
+    searchQuery,
+    setSearchQuery,
+    filteredFolders,
+    filteredTemplates,
+    clearSearch
+  } = useFolderSearch(allFolders, unorganizedTemplates);
 
   const [expandedFolders, setExpandedFolders] = useState<Set<number>>(new Set());
   const toggleExpanded = useCallback((id: number) => {
@@ -56,16 +62,6 @@ export const BrowseMoreFoldersDialog: React.FC = () => {
     });
   }, []);
 
-  // Filter unorganized templates based on search query
-  const filteredTemplates = useMemo(() => {
-    if (!searchQuery.trim()) return unorganizedTemplates;
-    const q = searchQuery.toLowerCase();
-    return unorganizedTemplates.filter(t =>
-      (t.type !== 'user') &&
-      (t.title || '').toLowerCase().includes(q) ||
-      (t.description || '').toLowerCase().includes(q)
-    );
-  }, [unorganizedTemplates, searchQuery]);
 
   const handleTogglePin = useCallback(
     async (


### PR DESCRIPTION
## Summary
- fix invalid state updates in useFolderSearch
- allow searching templates and folders together
- show matching templates in BrowseMoreFoldersDialog

## Testing
- `npm run lint` *(fails: cannot find '@eslint/js' and many lint errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_687e6b6c7c548320a62a78a02fbbd766