### PR TITLE
Show pinned folders in onboarding

### DIFF
--- a/src/components/dialogs/DialogRegistry.ts
+++ b/src/components/dialogs/DialogRegistry.ts
@@ -1,4 +1,5 @@
 // src/components/dialogs/DialogRegistry.ts
+import React from 'react';
 // Define dialog types
 export const DIALOG_TYPES = {
   // Existing dialog types
@@ -129,6 +130,7 @@ export interface DialogProps {
     gifUrl?: string;
     actionText?: string;
     onAction?: () => void;
+    children?: React.ReactNode;
   };
   [DIALOG_TYPES.SHARE]: Record<string, never>;
 }

--- a/src/components/dialogs/onboarding/InformationDialog.tsx
+++ b/src/components/dialogs/onboarding/InformationDialog.tsx
@@ -17,6 +17,7 @@ export const InformationDialog: React.FC = () => {
   const gifUrl = data?.gifUrl as string | undefined;
   const actionText = data?.actionText || getMessage('continue', undefined, 'Continue');
   const onAction = data?.onAction as (() => void) | undefined;
+  const children = data?.children as React.ReactNode;
 
   if (!isOpen) return null;
 
@@ -47,9 +48,10 @@ export const InformationDialog: React.FC = () => {
         <img
           src={gifUrl}
           alt={title}
-          className="jd-w-full  jd-object-contain jd-rounded-md"
+          className="jd-w-full  jd-object-contain jd-rounded-md jd-mb-4"
         />
       )}
+      {children}
     </BaseDialog>
   );
 

--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -487,6 +487,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
             checklist={checklist}
             onCreateTemplate={handleCreateTemplate}
             onUseTemplate={handleUseTemplate}
+            onSelectTemplate={useTemplate}
             onCreateBlock={handleCreateBlock}
             onShowKeyboardShortcut={handleShowKeyboardShortcut}
             onDismiss={dismissOnboarding}


### PR DESCRIPTION
## Summary
- extend InformationDialog to allow children
- add pinned folders dialog when using first template in onboarding
- pass useTemplate handler to OnboardingChecklist

## Testing
- `npm run lint` *(fails: cannot satisfy all lint rules)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687e72f0b64083209278a8a2e2f1ce41