### PR TITLE
Fix search folder display issues

### DIFF
--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -560,7 +560,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
                 </EmptyMessage>
               ) : (
                 <>
-                  {displayItems.items.length > 30 ? (
+                  {displayItems.items.length > 30 && !searchQuery.trim() ? (
                     <VirtualizedList
                       items={displayItems.items}
                       height={384}
@@ -588,6 +588,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
                               showEditControls={navigation.getItemType(folder) === 'user'}
                               showDeleteControls={navigation.getItemType(folder) === 'user'}
                               pinnedFolderIds={allPinnedFolderIds}
+                              isInGlobalSearch={displayItems.isGlobalSearch}
                             />
                           );
                         }
@@ -637,6 +638,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
                             showEditControls={navigation.getItemType(folder) === 'user'}
                             showDeleteControls={navigation.getItemType(folder) === 'user'}
                             pinnedFolderIds={allPinnedFolderIds}
+                            isInGlobalSearch={displayItems.isGlobalSearch}
                           />
                         );
                       }
@@ -728,6 +730,7 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
                         showEditControls={folderType === 'user'}
                         showDeleteControls={folderType === 'user'}
                         pinnedFolderIds={allPinnedFolderIds}
+                        isInGlobalSearch={false}
                       />
                     );
                   }

--- a/src/components/prompts/folders/FolderItem.tsx
+++ b/src/components/prompts/folders/FolderItem.tsx
@@ -56,6 +56,13 @@ interface FolderItemProps {
   
   // Pinned folder IDs for proper pin state calculation
   pinnedFolderIds?: number[];
+
+  /**
+   * Indicates if this item is being rendered from global search results.
+   * When true we always show the chevron icon so the user knows the folder
+   * can be expanded even if we don't yet know its content count.
+   */
+  isInGlobalSearch?: boolean;
 }
 
 /**
@@ -89,9 +96,12 @@ export const FolderItem: React.FC<FolderItemProps> = ({
   onCreateTemplate,
   onCreateFolder,
   showNavigationHeader = false,
-  
+
   // Pinned folder IDs
-  pinnedFolderIds = []
+  pinnedFolderIds = [],
+
+  // Whether this item is rendered as part of a global search
+  isInGlobalSearch = false
 }) => {
   // Local expansion state for when no external control is provided
   const [localExpanded, setLocalExpanded] = useState(false);
@@ -257,7 +267,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
         {/* Expansion/Navigation Icon */}
         {enableNavigation ? (
           <div className="jd-h-4 jd-flex-shrink-0" />
-        ) : totalItems > 0 || onToggleExpand ? (
+        ) : totalItems > 0 || onToggleExpand || isInGlobalSearch ? (
           expanded ? (
             <ChevronDown className="jd-h-4 jd-w-4 jd-mr-1 jd-flex-shrink-0" />
           ) : (


### PR DESCRIPTION
## Summary
- ensure FolderItem chevron displays during search
- avoid virtualization when searching to prevent layout glitches

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687e769a4fac8320b3be4612821a7efa