### PR TITLE
Fix template search in TemplatesPanel

### DIFF
--- a/src/components/panels/TemplatesPanel/index.tsx
+++ b/src/components/panels/TemplatesPanel/index.tsx
@@ -35,6 +35,7 @@ import { VirtualizedList } from '@/components/common/VirtualizedList';
 import { promptApi, getWhichTemplate } from '@/services/api';
 
 import { OptimizedFolderSearch } from '@/components/prompts/folders/OptimizedFolderSearch';
+import { useOptimizedSearch } from '@/hooks/prompts/utils/useOptimizedSearch';
 import { LoadingState } from './LoadingState';
 import { EmptyMessage } from './EmptyMessage';
 import { TemplateFolder, Template } from '@/types/prompts/templates';
@@ -42,8 +43,7 @@ import { getLocalizedContent } from '@/utils/prompts/blockUtils';
 import { getFolderTitle } from '@/utils/prompts/folderUtils';
 import { trackEvent, EVENTS } from '@/utils/amplitude';
 
-// Import the new optimized search hook
-import { useOptimizedSearch } from '@/hooks/prompts/utils/useOptimizedSearch';
+// Import the optimized search hook
 
 interface TemplatesPanelProps {
   showBackButton?: boolean;
@@ -124,7 +124,11 @@ const TemplatesPanel: React.FC<TemplatesPanelProps> = ({
     hasResults,
     isSearching,
     totalIndexedItems
-  } = useOptimizedSearch(userFolders, organizationFolders, unorganizedTemplates);
+  } = useOptimizedSearch(
+    userFolders,
+    organizationFolders,
+    unorganizedTemplates
+  );
 
   // Navigation hook for combined user + organization folders
   const navigation = useBreadcrumbNavigation({

--- a/src/hooks/prompts/utils/useOptimizedSearch.ts
+++ b/src/hooks/prompts/utils/useOptimizedSearch.ts
@@ -79,7 +79,7 @@ export function useOptimizedSearch(
           type: 'folder',
           title: folderTitle,
           description: folderDescription,
-          folderPath: path.join(' > '),
+          folderPath: currentPath.join(' > '),
           folderType,
           originalItem: folder,
           searchText


### PR DESCRIPTION
## Summary
- restore `useOptimizedSearch` in TemplatesPanel
- fix folder path generation inside `useOptimizedSearch`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_687e7af4af78832081cebe922bf55e58