### PR TITLE
Fix template search

### DIFF
--- a/src/hooks/prompts/utils/useGlobalTemplateSearch.ts
+++ b/src/hooks/prompts/utils/useGlobalTemplateSearch.ts
@@ -106,7 +106,10 @@ export function useGlobalTemplateSearch(
       let matchReason: 'title' | 'content' | 'description' | null = null;
 
       // Check title - with safe string handling
-      if (safeStringIncludes(template.title, query)) {
+      if (
+        safeStringIncludes(template.title, query) ||
+        safeStringIncludes((template as any).name, query)
+      ) {
         matchReason = 'title';
       }
       // Check content - with safe string handling

--- a/src/hooks/prompts/utils/useOptimizedSearch.ts
+++ b/src/hooks/prompts/utils/useOptimizedSearch.ts
@@ -91,7 +91,7 @@ export function useOptimizedSearch(
         folder.templates.forEach(template => {
           if (!template?.id) return;
           
-          const title = extractText(template.title);
+          const title = extractText(template.title || (template as any).name);
           const content = extractText(template.content);
           const description = extractText(template.description);
           const searchText = [title, content, description].join(' ').toLowerCase();
@@ -137,7 +137,7 @@ export function useOptimizedSearch(
       unorganizedTemplates.forEach(template => {
         if (!template?.id) return;
         
-        const title = extractText(template.title);
+        const title = extractText(template.title || (template as any).name);
         const content = extractText(template.content);
         const description = extractText(template.description);
         const searchText = [title, content, description].join(' ').toLowerCase();


### PR DESCRIPTION
## Summary
- recognize both `title` and `name` fields when building the search index
- update global template search to check both `title` and `name`

## Testing
- `npm run lint` *(fails: 639 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687e80e720288320a6394320c29a8647