### PR TITLE
Fix edit dialog button

### DIFF
--- a/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
+++ b/src/components/dialogs/prompts/TemplateEditorDialog/index.tsx
@@ -247,8 +247,12 @@ export const TemplateEditorDialog: React.FC<TemplateEditorDialogProps> = ({
             <div className="jd-animate-spin jd-h-4 jd-w-4 jd-border-2 jd-border-current jd-border-t-transparent jd-rounded-full jd-mr-2"></div>
             {getMessage('saving', undefined, 'Saving...')}
           </>
+        ) : mode === 'create' ? (
+          getMessage('createTemplate', undefined, 'Create Template')
+        ) : mode === 'edit' ? (
+          getMessage('editTemplate', undefined, 'Edit Template')
         ) : (
-          mode === 'create' ? getMessage('createTemplate', undefined, 'Create Template') : getMessage('useTemplate', undefined, 'Use Template')
+          getMessage('useTemplate', undefined, 'Use Template')
         )}
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- show `Edit Template` button text when the create dialog is used to edit a template

## Testing
- `npm run lint` *(fails: 610 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687e8b579cd083209f0e9dcf12f0510b