### PR TITLE
Fix block creation payload

### DIFF
--- a/src/components/dialogs/prompts/CreateBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateBlockDialog/index.tsx
@@ -90,9 +90,9 @@ export const CreateBlockDialog: React.FC = () => {
     try {
       const blockData = {
         type: blockType,
-        content: content.trim(),
-        title: name.trim(),
-        description: description.trim() || undefined
+        content: { en: content.trim() },
+        title: { en: name.trim() },
+        description: description.trim() ? { en: description.trim() } : undefined
       };
 
       if (onBlockCreated) {

--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -98,8 +98,8 @@ const InlineBlockCreator: React.FC<{
     try {
       const blockData = {
         type,
-        content: content.trim(),
-        title: title.trim() || `${BLOCK_TYPE_LABELS[type]} Block`,
+        content: { en: content.trim() },
+        title: { en: title.trim() || `${BLOCK_TYPE_LABELS[type]} Block` },
       };
       
       const response = await blocksApi.createBlock(blockData);

--- a/src/services/api/BlocksApi.ts
+++ b/src/services/api/BlocksApi.ts
@@ -2,10 +2,10 @@ import { apiClient } from './ApiClient';
 import { Block, BlockType } from '@/types/prompts/blocks';
 
 interface CreateBlockData {
-  title: string;                    
-  content: string;                  
+  title: string | Record<string, string>;
+  content: string | Record<string, string>;
   type: BlockType;
-  description?: string;             
+  description?: string | Record<string, string>;
   published?: boolean;
   parent_block_id?: number;
   tags?: string[];


### PR DESCRIPTION
## Summary
- send localized block data when creating blocks
- allow block creation API to accept localized values

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_687e8c3278288320a2627fc592872f4e