### PR TITLE
Fix block creation payloads

### DIFF
--- a/src/components/dialogs/prompts/CreateBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/CreateBlockDialog/index.tsx
@@ -90,9 +90,9 @@ export const CreateBlockDialog: React.FC = () => {
     try {
       const blockData = {
         type: blockType,
-        content: { en: content.trim() },
-        title: { en: name.trim() },
-        description: description.trim() ? { en: description.trim() } : undefined
+        content: content.trim(),
+        title: name.trim(),
+        description: description.trim() || undefined
       };
 
       if (onBlockCreated) {

--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -98,8 +98,8 @@ const InlineBlockCreator: React.FC<{
     try {
       const blockData = {
         type,
-        content: { en: content.trim() },
-        title: { en: title.trim() || `${BLOCK_TYPE_LABELS[type]} Block` },
+        content: content.trim(),
+        title: title.trim() || `${BLOCK_TYPE_LABELS[type]} Block`,
       };
       
       const response = await blocksApi.createBlock(blockData);

--- a/src/components/prompts/blocks/SaveBlockButton.tsx
+++ b/src/components/prompts/blocks/SaveBlockButton.tsx
@@ -39,9 +39,9 @@ export const SaveBlockButton: React.FC<SaveBlockButtonProps> = ({
     setSaving(true);
     const data: CreateBlockData = {
       type,
-      content: typeof content === 'string' ? { en: content } : content,
-      title: title ? { en: title } : undefined,
-      description: description ? { en: description } : undefined
+      content: content,
+      title: title,
+      description: description
     } as any;
     try {
       const res = await blocksApi.createBlock(data);


### PR DESCRIPTION
## Summary
- send strings not localized objects when creating blocks

## Testing
- `npm run lint` *(fails: cannot pass lint)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687e9684b2908320b601cd2c00be1635