### PR TITLE
Add initialization overlay

### DIFF
--- a/src/components/InitializationOverlay.tsx
+++ b/src/components/InitializationOverlay.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { userApi } from '@/services/api';
+import { apiClient } from '@/services/api/ApiClient';
+import { QUERY_KEYS } from '@/constants/queryKeys';
+import { useQueryClient } from 'react-query';
+
+const STORAGE_KEY = 'jaydai.initialized';
+
+/**
+ * Displays a loading screen on first load while initial data is fetched.
+ */
+const InitializationOverlay: React.FC = () => {
+  const [show, setShow] = useState(false);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    chrome.storage.local.get([STORAGE_KEY], async result => {
+      if (result[STORAGE_KEY]) return;
+
+      setShow(true);
+      try {
+        const meta = await userApi.getUserMetadata();
+        if (meta.success) {
+          queryClient.setQueryData(
+            QUERY_KEYS.PINNED_TEMPLATES,
+            meta.data?.pinned_template_ids || []
+          );
+        }
+
+        const checklist = await apiClient.request('/onboarding/checklist');
+        if ((checklist as any).success) {
+          queryClient.setQueryData('onboardingChecklist', (checklist as any).data);
+        }
+
+        chrome.storage.local.set({ [STORAGE_KEY]: true });
+      } catch (error) {
+        console.error('Initialization error:', error);
+      } finally {
+        setShow(false);
+      }
+    });
+  }, [queryClient]);
+
+  if (!show) return null;
+
+  return (
+    <div className="jd-absolute jd-inset-0 jd-flex jd-items-center jd-justify-center jd-z-20 jd-bg-background/80 jd-backdrop-blur">
+      <div className="jd-text-center jd-space-y-4">
+        <div className="jd-spinner">
+          <div className="jd-double-bounce1"></div>
+          <div className="jd-double-bounce2"></div>
+        </div>
+        <p className="jd-text-sm jd-font-medium jd-animate-pulse">Jaydai is initializing</p>
+      </div>
+    </div>
+  );
+};
+
+export default InitializationOverlay;

--- a/src/components/panels/MenuPanel/index.tsx
+++ b/src/components/panels/MenuPanel/index.tsx
@@ -9,6 +9,7 @@ import BasePanel from '../BasePanel';
 import { getMessage } from '@/core/utils/i18n';
 import { trackEvent, EVENTS } from '@/utils/amplitude';
 import { useDialogActions } from '@/hooks/dialogs/useDialogActions';
+import InitializationOverlay from '@/components/InitializationOverlay';
 
 // Define a type for our menu items
 type MenuItem = {
@@ -113,8 +114,9 @@ const MenuPanel: React.FC<MenuPanelProps> = ({
   return (
     <BasePanel
       onClose={onClose}
-      className="jd-w-56"
+      className="jd-w-56 jd-relative"
     >
+      <InitializationOverlay />
       <Card className="jd-p-1 jd-shadow-none jd-border-0 jd-bg-background jd-text-foreground jd-w-full">
         <div className="jd-flex jd-flex-col jd-space-y-1 jd-w-full">
           {menuItems.map((item) => (


### PR DESCRIPTION
## Summary
- show a loader to fetch onboarding checklist and pinned templates on first load
- limit loader to the menu panel

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_687f7dd9865c8320ac040f1df70341f6