### PR TITLE
Fix referral invite button visibility

### DIFF
--- a/src/components/dialogs/DialogProvider.tsx
+++ b/src/components/dialogs/DialogProvider.tsx
@@ -19,6 +19,7 @@ import { PaywallDialog } from './subscription/PaywallDialog';
 import { KeyboardShortcutDialog } from './onboarding/KeyboardShortcutDialog';
 import { InformationDialog } from './onboarding/InformationDialog';
 import { ShareDialog } from './share/ShareDialog';
+import { ReferralShareDialog } from './share/ReferralShareDialog';
 
 
 /**
@@ -76,6 +77,7 @@ export const DialogProvider: React.FC<{children: React.ReactNode}> = ({ children
       <TutorialVideoDialog />
       <PaywallDialog />
       <ManageSubscriptionDialog />
+      <ReferralShareDialog />
       <InformationDialog />
       <KeyboardShortcutDialog />
       <ShareDialog />

--- a/src/components/dialogs/subscription/ManageSubscriptionDialog.tsx
+++ b/src/components/dialogs/subscription/ManageSubscriptionDialog.tsx
@@ -220,7 +220,7 @@ export const ManageSubscriptionDialog: React.FC = () => {
                 />
 
                 <div className="jd-flex jd-flex-col jd-items-center jd-gap-3 jd-pt-4">
-                  <Button variant="ghost" onClick={() => openDialog(DIALOG_TYPES.REFERRAL_SHARE)}>
+                  <Button variant="secondary" onClick={() => openDialog(DIALOG_TYPES.REFERRAL_SHARE)}>
                     <Sparkles className="jd-w-4 jd-h-4 jd-mr-2" />
                     {getMessage('get_discount_promo', undefined, 'Invite a friend and get -10%')}
                   </Button>

--- a/src/components/dialogs/subscription/PaywallDialog.tsx
+++ b/src/components/dialogs/subscription/PaywallDialog.tsx
@@ -76,7 +76,7 @@ export const PaywallDialog: React.FC = () => {
               />
             )}
             <div className="jd-flex jd-justify-center jd-pt-4">
-              <Button variant="ghost" onClick={() => openDialog(DIALOG_TYPES.REFERRAL_SHARE)}>
+              <Button variant="secondary" onClick={() => openDialog(DIALOG_TYPES.REFERRAL_SHARE)}>
                 <Sparkles className="jd-w-4 jd-h-4 jd-mr-2" />
                 {getMessage('get_discount_promo', undefined, 'Invite a friend and get -10%')}
               </Button>


### PR DESCRIPTION
## Summary
- show referral button in DialogProvider
- style referral buttons with `secondary` variant to stand out

## Testing
- `npm run lint` *(fails: 610 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687f81cf99f08320ab71d87a0c56399a