### PR TITLE
Show promo after referral invite

### DIFF
--- a/src/components/dialogs/share/ReferralShareDialog.tsx
+++ b/src/components/dialogs/share/ReferralShareDialog.tsx
@@ -114,8 +114,13 @@ export const ReferralShareDialog: React.FC = () => {
         setEmailSent(true);
         setEmail('');
         setShowConfirmation(false);
-        toast.success(getMessage('inviteEmailSent', undefined, 'Invitation sent successfully! 🎉'));
+        toast.success(
+          getMessage('inviteEmailSent', undefined, 'Invitation sent successfully! 🎉')
+        );
         window.dispatchEvent(new CustomEvent('invite-sent'));
+        // Emit specific event so we can show the promo code only for invites
+        // coming from this dialog
+        window.dispatchEvent(new CustomEvent('referral-invite-sent'));
         trackEvent(EVENTS.SHARE_FRIEND_INVITED, { friend_email: email.trim() });
         setTimeout(() => {
           dialogProps.onOpenChange(false);

--- a/src/components/dialogs/subscription/ManageSubscriptionDialog.tsx
+++ b/src/components/dialogs/subscription/ManageSubscriptionDialog.tsx
@@ -58,11 +58,11 @@ export const ManageSubscriptionDialog: React.FC = () => {
     }
   }, [isOpen, subscription?.status]);
 
-  // Listen for invite sent events from the share dialog
+  // Listen for invite events specifically from the referral share dialog
   useEffect(() => {
     const handler = () => setShowPromo(true);
-    window.addEventListener('invite-sent', handler);
-    return () => window.removeEventListener('invite-sent', handler);
+    window.addEventListener('referral-invite-sent', handler);
+    return () => window.removeEventListener('referral-invite-sent', handler);
   }, []);
 
   const handleManageSubscription = async () => {

--- a/src/components/dialogs/subscription/PaywallDialog.tsx
+++ b/src/components/dialogs/subscription/PaywallDialog.tsx
@@ -19,8 +19,8 @@ export const PaywallDialog: React.FC = () => {
 
   useEffect(() => {
     const handler = () => setShowPromo(true);
-    window.addEventListener('invite-sent', handler);
-    return () => window.removeEventListener('invite-sent', handler);
+    window.addEventListener('referral-invite-sent', handler);
+    return () => window.removeEventListener('referral-invite-sent', handler);
   }, []);
   const handlePaymentSuccess = () => {
     dialogProps.onOpenChange(false);


### PR DESCRIPTION
## Summary
- emit a new `referral-invite-sent` event from `ReferralShareDialog`
- listen for the new event in `ManageSubscriptionDialog` and `PaywallDialog`

## Testing
- `npm run lint` *(fails: 648 problems)*

------
https://chatgpt.com/codex/tasks/task_e_687f87f5d5548320afc31f62ef8232b2