### PR TITLE
Fix pin state in folder browse dialog

### DIFF
--- a/src/components/dialogs/prompts/BrowseMoreFoldersDialog/index.tsx
+++ b/src/components/dialogs/prompts/BrowseMoreFoldersDialog/index.tsx
@@ -31,13 +31,18 @@ export const BrowseMoreFoldersDialog: React.FC = () => {
   const { data: userFolders = [], isLoading: loadingUser } = useUserFolders();
   const { data: organizationFolders = [], isLoading: loadingOrg } = useOrganizationFolders();
   const { data: organizations = [] } = useOrganizations();
-  const { data: pinnedData, refetch: refetchPinned } = usePinnedFolders();
+  const { data: pinnedData } = usePinnedFolders();
   const { toggleFolderPin } = useFolderMutations();
   const { toggleTemplatePin } = useTemplateMutations();
   const { useTemplate } = useTemplateActions();
   const { data: unorganizedTemplates = [], isLoading: loadingUnorganized } = useUnorganizedTemplates();
 
-  const pinnedFolderIds = useMemo(() => pinnedData?.pinnedIds || [], [pinnedData]);
+  const pinnedFolderIds = useMemo(() => {
+    if (Array.isArray(pinnedData)) {
+      return pinnedData.map(f => f.id);
+    }
+    return pinnedData?.pinnedIds || [];
+  }, [pinnedData]);
   const [localPinnedIds, setLocalPinnedIds] = useState<number[]>(pinnedFolderIds);
 
   useEffect(() => {
@@ -76,7 +81,6 @@ export const BrowseMoreFoldersDialog: React.FC = () => {
 
       try {
         await toggleFolderPin.mutateAsync({ folderId, isPinned, type });
-        refetchPinned();
       } catch (error) {
         console.error('Error toggling pin:', error);
         // Revert on error
@@ -85,7 +89,7 @@ export const BrowseMoreFoldersDialog: React.FC = () => {
         );
       }
     },
-    [toggleFolderPin, refetchPinned]
+    [toggleFolderPin]
   );
 
   const handleToggleTemplatePin = useCallback(


### PR DESCRIPTION
## Summary
- ensure BrowseMoreFoldersDialog reads pinned folders correctly
- rely on toggleFolderPin mutation to invalidate queries automatically

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687fbc39463483208a54e35cbff82548