### PR TITLE
Fix QueryClient not available

### DIFF
--- a/src/services/ui/QuickSelectorManager.ts
+++ b/src/services/ui/QuickSelectorManager.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import { QuickBlockSelector } from '@/components/prompts/blocks/quick-selector';
 import { DIALOG_TYPES } from '@/components/dialogs/DialogRegistry';
+import { QueryProvider } from '@/providers/QueryProvider';
 
 export class QuickSelectorManager {
   private root: Root | null = null;
@@ -15,18 +16,20 @@ export class QuickSelectorManager {
     document.body.appendChild(this.container);
     this.root = createRoot(this.container);
     this.root.render(
-      React.createElement(QuickBlockSelector, {
-        position,
-        onClose: () => this.close(),
-        targetElement,
-        cursorPosition,
-        triggerLength,
-        onOpenFullDialog: () => {
-          if (window.dialogManager && typeof window.dialogManager.openDialog === 'function') {
-            window.dialogManager.openDialog(DIALOG_TYPES.INSERT_BLOCK);
+      React.createElement(QueryProvider, null,
+        React.createElement(QuickBlockSelector, {
+          position,
+          onClose: () => this.close(),
+          targetElement,
+          cursorPosition,
+          triggerLength,
+          onOpenFullDialog: () => {
+            if (window.dialogManager && typeof window.dialogManager.openDialog === 'function') {
+              window.dialogManager.openDialog(DIALOG_TYPES.INSERT_BLOCK);
+            }
           }
-        }
-      })
+        })
+      )
     );
     this.isOpen = true;
   }


### PR DESCRIPTION
## Summary
- wrap `QuickBlockSelector` in `QueryProvider`

## Testing
- `npm run lint` *(fails: Unexpected any, hooks order)*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find type definition file for 'prompts')*

------
https://chatgpt.com/codex/tasks/task_e_687fbdd235a48320bef9bca142049aba