### PR TITLE
Disable StatsPanel when data collection off

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2585,6 +2585,18 @@
     "message": "Warning: Without data collection, you won't be able to see your AI statistics and usage analytics. Are you sure you want to continue?",
     "description": "Warning message for the data collection disable dialog"
   },
+  "enable_data_collection": {
+    "message": "Enable Data Collection",
+    "description": "Title for the data collection enable dialog"
+  },
+  "enable_data_collection_desc": {
+    "message": "Data collection must be enabled to view your AI statistics. Do you want to enable it now?",
+    "description": "Description for the data collection enable dialog"
+  },
+  "enable": {
+    "message": "Enable",
+    "description": "Text for the enable button"
+  },
   "disable": {
     "message": "Disable",
     "description": "Text for the disable button"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -2572,6 +2572,18 @@
     "message": "Avertissement : Sans collecte de données, vous ne pourrez pas voir vos statistiques d'utilisation et vos analyses. Êtes-vous sûr de vouloir continuer ?",
     "description": "Avertissement pour la désactivation de la collecte de données"
   },
+  "enable_data_collection": {
+    "message": "Activer la collecte de données",
+    "description": "Titre de la fenêtre d'activation de la collecte de données"
+  },
+  "enable_data_collection_desc": {
+    "message": "La collecte de données doit être activée pour afficher vos statistiques d'IA. Voulez-vous l'activer maintenant ?",
+    "description": "Description de la fenêtre d'activation de la collecte de données"
+  },
+  "enable": {
+    "message": "Activer",
+    "description": "Texte du bouton pour activer"
+  },
   "disable": {
     "message": "Désactiver",
     "description": "Texte du bouton pour désactiver la collecte de données"

--- a/src/components/panels/MenuPanel/index.tsx
+++ b/src/components/panels/MenuPanel/index.tsx
@@ -9,6 +9,11 @@ import BasePanel from '../BasePanel';
 import { getMessage } from '@/core/utils/i18n';
 import { trackEvent, EVENTS } from '@/utils/amplitude';
 import { useDialogActions } from '@/hooks/dialogs/useDialogActions';
+import { useUserMetadata } from '@/hooks/prompts/queries/user';
+import { userApi } from '@/services/api/UserApi';
+import { QUERY_KEYS } from '@/constants/queryKeys';
+import { useQueryClient } from 'react-query';
+import { toast } from 'sonner';
 
 // Define a type for our menu items
 type MenuItem = {
@@ -62,11 +67,46 @@ const MenuPanel: React.FC<MenuPanelProps> = ({
   notificationCount,
 }) => {
   const { pushPanel } = usePanelNavigation();
-  const { openInsertBlock, openTutorials } = useDialogActions();
+  const { openInsertBlock, openTutorials, openConfirmation } = useDialogActions();
+  const { data: userMetadata } = useUserMetadata();
+  const queryClient = useQueryClient();
 
   // Navigate to a specific panel
   const navigateToPanel = (panelType: 'templates' | 'notifications' | 'stats' | 'settings') => {
     pushPanel({ type: panelType });
+  };
+
+  const enableDataCollection = async () => {
+    try {
+      const response = await userApi.updateDataCollection(true);
+      if (response.success) {
+        toast.success(getMessage('data_collection_enabled', undefined, 'Data collection enabled'));
+        queryClient.setQueryData([QUERY_KEYS.USER_METADATA], (old: any) => ({
+          ...(old || {}),
+          data_collection: true,
+        }));
+        navigateToPanel('stats');
+      } else {
+        throw new Error(response.message || 'Failed to update preference');
+      }
+    } catch (error) {
+      console.error('Error enabling data collection:', error);
+      toast.error(getMessage('error_updating_preference', undefined, 'Failed to update preference'));
+    }
+  };
+
+  const handleStatsClick = () => {
+    if (userMetadata?.data_collection === false) {
+      openConfirmation({
+        title: getMessage('enable_data_collection', undefined, 'Enable Data Collection'),
+        description: getMessage('enable_data_collection_desc', undefined, 'Data collection must be enabled to view your AI statistics. Do you want to enable it now?'),
+        confirmText: getMessage('enable', undefined, 'Enable'),
+        cancelText: getMessage('cancel', undefined, 'Cancel'),
+        onConfirm: enableDataCollection,
+      });
+    } else {
+      navigateToPanel('stats');
+    }
   };
 
   // Define menu items for better maintainability
@@ -87,7 +127,7 @@ const MenuPanel: React.FC<MenuPanelProps> = ({
       id: 'stats',
       icon: <BarChart className="jd-h-4 jd-w-4" />,
       label: getMessage('aiStats', undefined, 'AI Stats'),
-      action: () => navigateToPanel('stats')
+      action: handleStatsClick
     },
     {
       id: 'notifications',


### PR DESCRIPTION
## Summary
- restrict StatsPanel access when user data collection is disabled
- prompt to enable data collection when the stats menu is clicked
- provide translations for the new dialog text

## Testing
- `npm run lint` *(fails: cannot resolve deps)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687ff9229c2883209c4d382be034c731