### PR TITLE
Disable network monitoring when data collection disabled

### DIFF
--- a/src/components/panels/SettingsPanel/index.tsx
+++ b/src/components/panels/SettingsPanel/index.tsx
@@ -69,7 +69,9 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
       const response = await userApi.getUserMetadata();
       
       if (response.success && response.data) {
-        setDataCollection(response.data.data_collection !== false);
+        const enabled = response.data.data_collection !== false;
+        setDataCollection(enabled);
+        chrome.storage.local.set({ data_collection_enabled: enabled });
       }
     } catch (error) {
       console.error('Error loading user preferences:', error);
@@ -88,6 +90,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
       
       if (response.success) {
         setDataCollection(enabled);
+        chrome.storage.local.set({ data_collection_enabled: enabled });
         toast.success(
           enabled 
             ? getMessage('data_collection_enabled', undefined, 'Data collection enabled')

--- a/src/extension/content/content.js
+++ b/src/extension/content/content.js
@@ -11,16 +11,15 @@
 
   // INJECT THE INTERCEPTOR IMMEDIATELY - don't wait for DOMContentLoaded
   try {
-    
+
     // Create the script element
     const script = document.createElement('script');
     script.id = 'jaydai:network-interceptor';
     script.type = 'module';
     script.src = chrome.runtime.getURL('networkInterceptor.js');
-    
+
     // Function to actually inject the script
     const injectScript = () => {
-      // Try to inject into head or documentElement or body, whichever is available
       const target = document.head || document.documentElement || document.body;
       if (target) {
         target.appendChild(script);
@@ -28,9 +27,15 @@
         console.error("❌ No target element available for script injection");
       }
     };
-    
-    // Try immediate injection
-    injectScript();
+
+    chrome.storage.local.get(['data_collection_enabled'], (result) => {
+      if (result.data_collection_enabled !== false) {
+        // Try immediate injection
+        injectScript();
+      } else {
+        console.log('Data collection disabled - skipping network interceptor');
+      }
+    });
     
     // Also set up a fallback for DOMContentLoaded
     document.addEventListener('DOMContentLoaded', () => {

--- a/src/services/analytics/StatsService.ts
+++ b/src/services/analytics/StatsService.ts
@@ -84,6 +84,7 @@ export class StatsService extends AbstractBaseService {
   private lastLoadTime: number = 0;
   private retryCount: number = 0;
   private isLoading: boolean = false;
+  private dataCollectionEnabled: boolean = true;
   private static instance: StatsService;
 
    private constructor() {
@@ -101,21 +102,34 @@ export class StatsService extends AbstractBaseService {
    * Initialize stats tracking
    */
   protected async onInitialize(): Promise<void> {
-    
+    this.dataCollectionEnabled = await new Promise<boolean>((resolve) => {
+      try {
+        chrome.storage.local.get(['data_collection_enabled'], (result) => {
+          resolve(result.data_collection_enabled !== false);
+        });
+      } catch {
+        resolve(true);
+      }
+    });
+
+    if (!this.dataCollectionEnabled) {
+      console.log('Data collection disabled - StatsService not initialized');
+      return;
+    }
+
     // Listen for relevant events
     this.setupEventListeners();
-    
+
     // Load initial stats
     await this.loadStats();
-    
+
     // Set up more frequent refresh from backend
     this.updateInterval = window.setInterval(() => {
-      // Only refresh if it's been at least 10 seconds since the last load
       const now = Date.now();
-      if (now - this.lastLoadTime >= 10000) { // 10 seconds instead of 60 seconds
+      if (now - this.lastLoadTime >= 10000) {
         this.loadStats();
       }
-    }, 20000); // Check every 20 seconds
+    }, 20000);
     
   }
   
@@ -123,6 +137,7 @@ export class StatsService extends AbstractBaseService {
    * Clean up resources
    */
   protected onCleanup(): void {
+    if (!this.dataCollectionEnabled) return;
     if (this.updateInterval) {
       clearInterval(this.updateInterval);
       this.updateInterval = null;


### PR DESCRIPTION
## Summary
- persist user's data collection preference in storage
- skip injecting the network interceptor when data collection is disabled
- disable StatsService if data collection is off

## Testing
- `npm run type-check`
- `npm run lint` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ff943efd083208c534833890dcebe