### PR TITLE
Mark keyboard shortcut usage from onboarding dialog

### DIFF
--- a/src/components/panels/TemplatesPanel/OnboardingChecklist.tsx
+++ b/src/components/panels/TemplatesPanel/OnboardingChecklist.tsx
@@ -6,6 +6,7 @@ import { CheckCircle, Circle, X, Play, FileText, Blocks, Keyboard } from 'lucide
 import { getMessage } from '@/core/utils/i18n';
 import { cn } from '@/core/utils/classNames';
 import { useDialogActions } from '@/hooks/dialogs/useDialogActions';
+import { onboardingTracker } from '@/services/onboarding/OnboardingTracker';
 import { Template } from '@/types/prompts/templates';
 
 interface OnboardingChecklistData {
@@ -183,6 +184,7 @@ export const OnboardingChecklist: React.FC<OnboardingChecklistProps> = memo(({
   // Memoized quick selector function
   const openQuickSelector = useCallback(() => {
     try {
+      onboardingTracker.markKeyboardShortcutUsed();
       const service: any = window.slashCommandService || {};
       const target = service.inputEl as HTMLElement | null;
       if (target && service.quickSelector) {


### PR DESCRIPTION
## Summary
- update onboarding checklist to dispatch keyboard shortcut completion when quick selector is opened

## Testing
- `npm run lint` *(fails: 619 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687ffe33b80483209d8a89077e4f1deb