### PR TITLE
Lock non-free templates

### DIFF
--- a/src/components/prompts/templates/TemplateItem.tsx
+++ b/src/components/prompts/templates/TemplateItem.tsx
@@ -1,6 +1,6 @@
 // src/components/prompts/templates/TemplateItem.tsx - Enhanced with smart organization image logic
 import React, { useCallback, useMemo } from 'react';
-import { FileText, Edit, Trash2 } from 'lucide-react';
+import { FileText, Edit, Trash2, Lock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { PinButton } from '@/components/prompts/common/PinButton';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -66,6 +66,9 @@ export const TemplateItem: React.FC<TemplateItemProps> = ({
     }
     return pinnedTemplateIds.includes(template.id);
   }, [pinnedTemplateIds, template.id, (template as any).is_pinned]);
+
+  // Determine if the template is free to use
+  const isFree = (template as any).is_free === true;
   
   // Get organization data
   const templateOrganization = (template as any).organization || 
@@ -222,21 +225,25 @@ export const TemplateItem: React.FC<TemplateItemProps> = ({
         )}
 
       <div className="jd-ml-2 jd-flex jd-items-center jd-gap-1">
-          {/* Pin Button */}
-          {showPinControls && onTogglePin && (
-            <div
-              className={`jd-ml-auto jd-items-center jd-gap-1 jd-flex ${
-                isPinned ? '' : 'jd-opacity-0 group-hover/template:jd-opacity-100 jd-transition-opacity'
-              }`}
-            >
+        {/* Pin button or lock icon depending on template availability */}
+        {showPinControls && (
+          <div
+            className={`jd-ml-auto jd-items-center jd-gap-1 jd-flex ${
+              isPinned ? '' : 'jd-opacity-0 group-hover/template:jd-opacity-100 jd-transition-opacity'
+            }`}
+          >
+            {onTogglePin && isFree ? (
               <PinButton
                 type="template"
                 isPinned={isPinned}
                 onClick={handleTogglePin}
               />
-            </div>
-          )}
-        </div>
+            ) : (
+              <Lock className="jd-h-4 jd-w-4 jd-text-muted-foreground jd-opacity-70" />
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/types/prompts/templates.ts
+++ b/src/types/prompts/templates.ts
@@ -27,6 +27,10 @@ export interface Template {
     language?: string;
     based_on_company_id?: number | null;
     metadata?: TemplateMetadata;
+    /**
+     * Indicates if the template is available for free users
+     */
+    is_free?: boolean;
   }
   
   /**


### PR DESCRIPTION
## Summary
- add `is_free` field to Template type
- display lock icon instead of pin button on templates that aren't free

## Testing
- `npm run lint` *(fails: lots of existing lint errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_687ffe755a9c8320a941fbb948296768