### PR TITLE
Add contextual paywall messages

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2457,6 +2457,18 @@
     "message": "Free users can create up to 5 custom templates or blocks. Upgrade your subscription to add more.",
     "description": "Message of the paywall"
   },
+  "paywall_premium_template_message": {
+    "message": "This template is only available to Premium users. Upgrade your subscription to access premium templates.",
+    "description": "Paywall message when accessing a premium template"
+  },
+  "paywall_template_limit_message": {
+    "message": "Free users can create up to 5 custom templates. Upgrade your subscription to add more.",
+    "description": "Paywall message when reaching the free template limit"
+  },
+  "paywall_block_limit_message": {
+    "message": "Free users can create up to 5 blocks. Upgrade your subscription to add more.",
+    "description": "Paywall message when reaching the free block limit"
+  },
   "upgrade_required": {
     "message": "Upgrade Required",
     "description": "Title of the paywall"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -2444,6 +2444,18 @@
     "message": "Les utilisateurs gratuits peuvent créer jusqu'à 5 modèles personnels ou blocs. Passez à l'abonnement pour en créer plus.",
     "description": "Message de paywall"
   },
+  "paywall_premium_template_message": {
+    "message": "Ce modèle est réservé aux utilisateurs Premium. Passez à l'abonnement pour accéder aux modèles premium.",
+    "description": "Message de paywall lors de l'accès à un modèle premium"
+  },
+  "paywall_template_limit_message": {
+    "message": "Les utilisateurs gratuits peuvent créer jusqu'à 5 modèles personnalisés. Passez à l'abonnement pour en créer plus.",
+    "description": "Message de paywall lors de l'atteinte de la limite de modèles"
+  },
+  "paywall_block_limit_message": {
+    "message": "Les utilisateurs gratuits peuvent créer jusqu'à 5 blocs. Passez à l'abonnement pour en créer plus.",
+    "description": "Message de paywall lors de l'atteinte de la limite de blocs"
+  },
   "upgrade_required": {
     "message": "Mise à niveau requise",
     "description": "Titre de la fenêtre de paywall"

--- a/src/components/dialogs/DialogRegistry.ts
+++ b/src/components/dialogs/DialogRegistry.ts
@@ -119,7 +119,9 @@ export interface DialogProps {
 
   [DIALOG_TYPES.MANAGE_SUBSCRIPTION]: Record<string, never>;
 
-  [DIALOG_TYPES.PAYWALL]: Record<string, never>;
+  [DIALOG_TYPES.PAYWALL]: {
+    reason?: 'premiumTemplate' | 'templateLimit' | 'blockLimit';
+  };
 
   [DIALOG_TYPES.KEYBOARD_SHORTCUT]: {
     onShortcutUsed?: () => void;

--- a/src/components/dialogs/subscription/PaywallDialog.tsx
+++ b/src/components/dialogs/subscription/PaywallDialog.tsx
@@ -11,7 +11,7 @@ import { Sparkles, Copy, ArrowLeft } from 'lucide-react';
 import { toast } from 'sonner';
 
 export const PaywallDialog: React.FC = () => {
-  const { isOpen, dialogProps } = useDialog(DIALOG_TYPES.PAYWALL);
+  const { isOpen, dialogProps, data } = useDialog(DIALOG_TYPES.PAYWALL);
   const { openDialog } = useDialogManager();
   const { authState } = useAuthState();
   const isDark = useThemeDetector();
@@ -33,6 +33,32 @@ export const PaywallDialog: React.FC = () => {
 
   if (!isOpen) return null;
 
+  const messageKey = React.useMemo(() => {
+    switch (data?.reason) {
+      case 'premiumTemplate':
+        return 'paywall_premium_template_message';
+      case 'templateLimit':
+        return 'paywall_template_limit_message';
+      case 'blockLimit':
+        return 'paywall_block_limit_message';
+      default:
+        return 'paywall_message';
+    }
+  }, [data]);
+
+  const defaultMessage = (() => {
+    switch (data?.reason) {
+      case 'premiumTemplate':
+        return 'This template is only available to Premium users. Upgrade your subscription to access premium templates.';
+      case 'templateLimit':
+        return 'Free users can create up to 5 custom templates. Upgrade your subscription to add more.';
+      case 'blockLimit':
+        return 'Free users can create up to 5 blocks. Upgrade your subscription to add more.';
+      default:
+        return 'Free users can create up to 5 custom templates or blocks. Upgrade your subscription to add more.';
+    }
+  })();
+
   return (
     <BaseDialog
       open={isOpen}
@@ -42,11 +68,7 @@ export const PaywallDialog: React.FC = () => {
     >
       <div className="jd-space-y-2">
         <p className="jd-text-muted-foreground">
-          {getMessage(
-            'paywall_message',
-            undefined,
-            'Free users can create up to 5 custom templates or blocks. Upgrade your subscription to add more.'
-          )}
+          {getMessage(messageKey, undefined, defaultMessage)}
         </p>
         {showPromo ? (
           <>

--- a/src/hooks/prompts/actions/useBlockActions.ts
+++ b/src/hooks/prompts/actions/useBlockActions.ts
@@ -179,7 +179,7 @@ export function useBlockActions({
             return true; // Success - close dialog
           } else {
             if (response.message && response.message.includes('Subscription')) {
-              openDialog(DIALOG_TYPES.PAYWALL);
+              openDialog(DIALOG_TYPES.PAYWALL, { reason: 'blockLimit' });
             }
             toast.error(response.message || getMessage('blockCreateFailed', undefined, 'Failed to create block'));
             return false; // Keep dialog open
@@ -187,7 +187,7 @@ export function useBlockActions({
         } catch (error) {
           console.error('Error creating block:', error);
           if (error instanceof Error && error.message.includes('Subscription')) {
-            openDialog(DIALOG_TYPES.PAYWALL);
+            openDialog(DIALOG_TYPES.PAYWALL, { reason: 'blockLimit' });
           }
           toast.error(getMessage('blockCreateError', undefined, 'An error occurred while creating the block'));
           return false;

--- a/src/hooks/prompts/actions/useTemplateActions.ts
+++ b/src/hooks/prompts/actions/useTemplateActions.ts
@@ -114,7 +114,7 @@ export function useTemplateActions() {
           (response.message.includes('Subscription') ||
             response.message.includes('402'))
         ) {
-          openDialog(DIALOG_TYPES.PAYWALL);
+          openDialog(DIALOG_TYPES.PAYWALL, { reason: 'premiumTemplate' });
         }
         throw new Error(response.message || 'Failed to load template');
       }
@@ -150,7 +150,7 @@ export function useTemplateActions() {
         error instanceof Error &&
         (error.message.includes('Subscription') || error.message.includes('402'))
       ) {
-        openDialog(DIALOG_TYPES.PAYWALL);
+        openDialog(DIALOG_TYPES.PAYWALL, { reason: 'premiumTemplate' });
       }
       toast.error('Failed to open template editor');
     } finally {

--- a/src/hooks/prompts/useTemplateCreation.ts
+++ b/src/hooks/prompts/useTemplateCreation.ts
@@ -81,7 +81,7 @@ export function useTemplateCreation() {
       onError: (error: any) => {
         console.error('Error creating template:', error);
         if (error?.message && error.message.includes('Subscription')) {
-          openDialog(DIALOG_TYPES.PAYWALL);
+          openDialog(DIALOG_TYPES.PAYWALL, { reason: 'templateLimit' });
         }
         toast.error(`Failed to create template: ${error?.message || 'Unknown error'}`);
       }
@@ -161,7 +161,7 @@ export function useTemplateCreation() {
       return true;
     } catch (error) {
       if (error instanceof Error && error.message.includes('Subscription')) {
-        openDialog(DIALOG_TYPES.PAYWALL);
+        openDialog(DIALOG_TYPES.PAYWALL, { reason: 'templateLimit' });
       }
       return false;
     }


### PR DESCRIPTION
## Summary
- add new paywall translations for premium templates and limits
- allow PaywallDialog to display a message depending on the opening reason
- pass a reason to PaywallDialog when premium actions or template/block limits trigger the dialog
- update dialog type definitions for the new prop

## Testing
- `npm run lint` *(fails: 621 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68800232bcbc8320bbfc6bca38c2cf52