### PR TITLE
Disable network requests when data collection disabled

### DIFF
--- a/src/components/panels/SettingsPanel/index.tsx
+++ b/src/components/panels/SettingsPanel/index.tsx
@@ -69,7 +69,9 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
       const response = await userApi.getUserMetadata();
       
       if (response.success && response.data) {
-        setDataCollection(response.data.data_collection !== false);
+        const enabled = response.data.data_collection !== false;
+        setDataCollection(enabled);
+        chrome.storage.local.set({ data_collection: enabled });
       }
     } catch (error) {
       console.error('Error loading user preferences:', error);
@@ -88,6 +90,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
       
       if (response.success) {
         setDataCollection(enabled);
+        chrome.storage.local.set({ data_collection: enabled });
         toast.success(
           enabled 
             ? getMessage('data_collection_enabled', undefined, 'Data collection enabled')

--- a/src/extension/content/content.js
+++ b/src/extension/content/content.js
@@ -11,13 +11,13 @@
 
   // INJECT THE INTERCEPTOR IMMEDIATELY - don't wait for DOMContentLoaded
   try {
-    
+
     // Create the script element
     const script = document.createElement('script');
     script.id = 'jaydai:network-interceptor';
     script.type = 'module';
     script.src = chrome.runtime.getURL('networkInterceptor.js');
-    
+
     // Function to actually inject the script
     const injectScript = () => {
       // Try to inject into head or documentElement or body, whichever is available
@@ -28,9 +28,14 @@
         console.error("❌ No target element available for script injection");
       }
     };
-    
-    // Try immediate injection
-    injectScript();
+
+    chrome.storage.local.get(['data_collection'], (result) => {
+      if (result.data_collection === false) {
+        console.log('Data collection disabled - skipping network interceptor');
+      } else {
+        injectScript();
+      }
+    });
     
     // Also set up a fallback for DOMContentLoaded
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- store user data collection preference in `chrome.storage`
- check stored preference before injecting the network interceptor

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68800438f6648320922f4217040d76dc