### PR TITLE
Fix StatsPanel data collection logic

### DIFF
--- a/src/components/panels/MenuPanel/index.tsx
+++ b/src/components/panels/MenuPanel/index.tsx
@@ -9,11 +9,6 @@ import BasePanel from '../BasePanel';
 import { getMessage } from '@/core/utils/i18n';
 import { trackEvent, EVENTS } from '@/utils/amplitude';
 import { useDialogActions } from '@/hooks/dialogs/useDialogActions';
-import { useUserMetadata } from '@/hooks/prompts/queries/user';
-import { userApi } from '@/services/api/UserApi';
-import { QUERY_KEYS } from '@/constants/queryKeys';
-import { useQueryClient } from 'react-query';
-import { toast } from 'sonner';
 
 // Define a type for our menu items
 type MenuItem = {
@@ -67,46 +62,16 @@ const MenuPanel: React.FC<MenuPanelProps> = ({
   notificationCount,
 }) => {
   const { pushPanel } = usePanelNavigation();
-  const { openInsertBlock, openTutorials, openConfirmation } = useDialogActions();
-  const { data: userMetadata } = useUserMetadata();
-  const queryClient = useQueryClient();
+  const { openInsertBlock, openTutorials } = useDialogActions();
 
   // Navigate to a specific panel
   const navigateToPanel = (panelType: 'templates' | 'notifications' | 'stats' | 'settings') => {
     pushPanel({ type: panelType });
   };
 
-  const enableDataCollection = async () => {
-    try {
-      const response = await userApi.updateDataCollection(true);
-      if (response.success) {
-        toast.success(getMessage('data_collection_enabled', undefined, 'Data collection enabled'));
-        queryClient.setQueryData([QUERY_KEYS.USER_METADATA], (old: any) => ({
-          ...(old || {}),
-          data_collection: true,
-        }));
-        navigateToPanel('stats');
-      } else {
-        throw new Error(response.message || 'Failed to update preference');
-      }
-    } catch (error) {
-      console.error('Error enabling data collection:', error);
-      toast.error(getMessage('error_updating_preference', undefined, 'Failed to update preference'));
-    }
-  };
 
   const handleStatsClick = () => {
-    if (userMetadata?.data_collection === false) {
-      openConfirmation({
-        title: getMessage('enable_data_collection', undefined, 'Enable Data Collection'),
-        description: getMessage('enable_data_collection_desc', undefined, 'Data collection must be enabled to view your AI statistics. Do you want to enable it now?'),
-        confirmText: getMessage('enable', undefined, 'Enable'),
-        cancelText: getMessage('cancel', undefined, 'Cancel'),
-        onConfirm: enableDataCollection,
-      });
-    } else {
-      navigateToPanel('stats');
-    }
+    navigateToPanel('stats');
   };
 
   // Define menu items for better maintainability

--- a/src/components/panels/StatsPanel/index.tsx
+++ b/src/components/panels/StatsPanel/index.tsx
@@ -15,6 +15,7 @@ import { userApi } from '@/services/api';
 import { useQueryClient } from 'react-query';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 import { toast } from 'sonner';
+import { useUserMetadata } from '@/hooks/prompts/queries/user';
 
 interface StatsPanelProps {
   showBackButton?: boolean;
@@ -65,7 +66,12 @@ const StatsPanel: React.FC<StatsPanelProps> = ({
     },
     efficiency: 0
   });
-  const [dataCollectionEnabled, setDataCollectionEnabled] = useState(false);
+  const {
+    data: userMetadata,
+    isLoading: userLoading,
+  } = useUserMetadata();
+  const dataCollectionEnabled =
+    userMetadata?.data_collection !== false;
   const [loading, setLoading] = useState(true);
   const queryClient = useQueryClient();
 
@@ -79,7 +85,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({
           ...(old || {}),
           data_collection: true,
         }));
-        setDataCollectionEnabled(true);
+        setLoading(false);
       } else {
         throw new Error(response.message || 'Failed to update preference');
       }
@@ -90,19 +96,8 @@ const StatsPanel: React.FC<StatsPanelProps> = ({
   };
 
   useEffect(() => {
-    const loadUserMetadata = async () => {
-      try {
-        const userMetadata = await userApi.getUserMetadata();
-        setDataCollectionEnabled(userMetadata.data_collection);
-        setLoading(false);
-      } catch (error) {
-        console.error('Error loading user metadata:', error);
-        setLoading(false);
-      }
-    };
-    
-    loadUserMetadata();
-  }, []);
+    setLoading(userLoading);
+  }, [userLoading]);
 
   // Get stats on mount and subscribe to updates
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure the stats panel relies on the cached `useUserMetadata` hook
- keep loading state in sync with metadata
- always open the stats panel from the menu without prompting the user

## Testing
- `npm run type-check`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68801bb045248320bc79ef79793d2d62