### PR TITLE
Fix onboarding check for first template use

### DIFF
--- a/src/hooks/prompts/actions/useTemplateActions.ts
+++ b/src/hooks/prompts/actions/useTemplateActions.ts
@@ -77,21 +77,21 @@ export function useTemplateActions() {
     // Format content for insertion - normalizes newlines while preserving paragraph breaks
     const formattedContent = formatContentForInsertion(cleanContent);
     
+    // Mark onboarding completion immediately so the event isn't lost
+    onboardingTracker.markTemplateUsed();
+
     // Insert the content with a small delay to ensure dialog is fully closed
     setTimeout(() => {
       const success = insertContentIntoChat(formattedContent);
-      
+
       if (success) {
-        // Mark onboarding completion for first template use
-        onboardingTracker.markTemplateUsed();
-        
         // Only show toast on success
         toast.success('Template applied successfully');
         incrementUserProperty('template_usage_count', 1);
       } else {
         toast.error('Failed to apply template');
       }
-      
+
       // Dispatch an event to close the main button and panels
       //document.dispatchEvent(new CustomEvent('jaydai:close-all-panels'));
     }, 50);


### PR DESCRIPTION
## Summary
- update onboarding tracker call so it fires before closing panels

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68801e84cea48320adf268b9b3f41b8d