### PR TITLE
Handle stats API responses without success flag

### DIFF
--- a/src/hooks/stats/queries/useMessageDistribution.ts
+++ b/src/hooks/stats/queries/useMessageDistribution.ts
@@ -11,10 +11,13 @@ export function useMessageDistribution(enabled = true) {
     [QUERY_KEYS.MESSAGE_DISTRIBUTION],
     async () => {
       const response = await userApi.getMessageDistribution();
-      if (!response.success) {
-        throw new Error(response.message || 'Failed to load message distribution');
+      if ('success' in response) {
+        if (!response.success) {
+          throw new Error(response.message || 'Failed to load message distribution');
+        }
+        return response.data as MessageDistributionResponse;
       }
-      return response.data as MessageDistributionResponse;
+      return response as MessageDistributionResponse;
     },
     {
       enabled,

--- a/src/hooks/stats/queries/useUserStats.ts
+++ b/src/hooks/stats/queries/useUserStats.ts
@@ -11,10 +11,12 @@ export function useUserStats(enabled = true) {
     [QUERY_KEYS.USER_STATS],
     async () => {
       const response = await userApi.getUserStats();
-      if (!response.success) {
-        throw new Error(response.message || 'Failed to load stats');
-      }
-      const data = response.data || {};
+      const data = 'success' in response ? (() => {
+        if (!response.success) {
+          throw new Error(response.message || 'Failed to load stats');
+        }
+        return response.data || {};
+      })() : response;
       const stats: Stats = {
         totalChats: data.total_chats || 0,
         recentChats: data.recent_chats || 0,

--- a/src/hooks/stats/queries/useWeeklyStats.ts
+++ b/src/hooks/stats/queries/useWeeklyStats.ts
@@ -11,10 +11,13 @@ export function useWeeklyStats(enabled = true) {
     [QUERY_KEYS.WEEKLY_STATS],
     async () => {
       const response = await userApi.getWeeklyConversationStats();
-      if (!response.success) {
-        throw new Error(response.message || 'Failed to load weekly stats');
+      if ('success' in response) {
+        if (!response.success) {
+          throw new Error(response.message || 'Failed to load weekly stats');
+        }
+        return response.data as WeeklyConversationsResponse;
       }
-      return response.data as WeeklyConversationsResponse;
+      return response as WeeklyConversationsResponse;
     },
     {
       enabled,


### PR DESCRIPTION
## Summary
- update user stats query hooks to work with API responses that return raw data without `success`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6882014645b88320b709adc31af01e64