### PR TITLE
Update messaging for cancelled subs

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2653,6 +2653,18 @@
     "message": "Your subscription will be cancelled on {0}. You will continue to have access until this date.",
     "description": "Message for the subscription cancelling dialog"
   },
+  "trial_ending_title": {
+    "message": "Trial Ending",
+    "description": "Title shown when a trial will end"
+  },
+  "trial_end_no_charge": {
+    "message": "Your trial will end on {0}. You won't be charged.",
+    "description": "Message shown when the user cancelled during trial"
+  },
+  "subscription_already_cancelled": {
+    "message": "Your subscription has been cancelled and will remain active until {0}. You will not be charged again.",
+    "description": "Message shown when subscription is set to cancel at period end"
+  },
   "billingStatus": {
     "message": "Billing Status",
     "description": "Text for the billing status button"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -2640,6 +2640,18 @@
     "message": "Votre abonnement sera annulé le {0}. Vous continuerez d'avoir accès jusqu'à cette date.",
     "description": "Message de confirmation d'annulation d'abonnement"
   },
+  "trial_ending_title": {
+    "message": "Fin de l'essai",
+    "description": "Titre affiché lorsque l'essai touche à sa fin"
+  },
+  "trial_end_no_charge": {
+    "message": "Votre période d'essai se termine le {0}. Vous ne serez pas facturé.",
+    "description": "Message affiché lorsque l'utilisateur a annulé pendant l'essai"
+  },
+  "subscription_already_cancelled": {
+    "message": "Votre abonnement a été annulé et restera actif jusqu'au {0}. Vous ne serez plus facturé ensuite.",
+    "description": "Message affiché lorsque l'abonnement est programmé pour annulation"
+  },
   "billingStatus": {
     "message": "Statut de facturation",
     "description": "Texte du bouton pour le statut de facturation"

--- a/src/components/dialogs/subscription/manage/ActionButtons.tsx
+++ b/src/components/dialogs/subscription/manage/ActionButtons.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { RefreshCw, ExternalLink, Crown } from 'lucide-react';
 import { getMessage } from '@/core/utils/i18n';
 import { SubscriptionStatus } from '@/types/subscription';
+import { formatDate } from './helpers';
 
 interface Props {
   subscription: SubscriptionStatus | null;
@@ -42,15 +43,33 @@ export const ActionButtons: React.FC<Props> = ({
             <span>{getMessage('manage_billing', undefined, 'Manage Billing & Payment')}</span>
           </Button>
 
-        {subscription.status !== 'cancelled' && subscription.status !== 'inactive' && subscription.status !== 'past_due' && (
-            <Button
-              onClick={onCancel}
-              disabled={loading || isLoading}
-              variant="outline"
-              className="jd-w-full jd-text-red-600 jd-border-red-600 hover:jd-bg-red-50"
-            >
-              {getMessage('cancel_subscription', undefined, 'Cancel Subscription')}
-            </Button>
+        {subscription.status !== 'cancelled' &&
+        subscription.status !== 'inactive' &&
+        subscription.status !== 'past_due' && (
+            subscription.cancelAtPeriodEnd ? (
+              <p className="jd-text-center jd-text-sm jd-text-muted-foreground">
+                {subscription.status === 'trialing'
+                  ? getMessage(
+                      'trial_end_no_charge',
+                      undefined,
+                      "Your trial will end on {0}. You won't be charged."
+                    ).replace('{0}', formatDate(subscription.currentPeriodEnd))
+                  : getMessage(
+                      'subscription_already_cancelled',
+                      undefined,
+                      'Your subscription has been cancelled and will remain active until {0}. You will not be charged again.'
+                    ).replace('{0}', formatDate(subscription.currentPeriodEnd))}
+              </p>
+            ) : (
+              <Button
+                onClick={onCancel}
+                disabled={loading || isLoading}
+                variant="outline"
+                className="jd-w-full jd-text-red-600 jd-border-red-600 hover:jd-bg-red-50"
+              >
+                {getMessage('cancel_subscription', undefined, 'Cancel Subscription')}
+              </Button>
+            )
           )}
         </>
       ) : subscription?.status === 'cancelled' && subscription.cancelAtPeriodEnd ? (

--- a/src/components/dialogs/subscription/manage/SubscriptionStatusCard.tsx
+++ b/src/components/dialogs/subscription/manage/SubscriptionStatusCard.tsx
@@ -76,19 +76,27 @@ export const SubscriptionStatusCard: React.FC<Props> = ({ subscription, statusIn
           </div>
         )}
 
-        {subscription.status === 'cancelled' && subscription.currentPeriodEnd && (
+        {subscription.cancelAtPeriodEnd && subscription.currentPeriodEnd && (
           <div className="jd-flex jd-items-start jd-space-x-2 jd-p-3 jd-bg-yellow-50 jd-border jd-border-yellow-200 jd-rounded-lg">
             <AlertTriangle className="jd-w-5 jd-h-5 jd-text-yellow-600 jd-mt-0.5" />
             <div>
               <p className="jd-text-yellow-800 jd-text-sm jd-font-medium">
-                {getMessage('subscription_cancelling_title', undefined, 'Subscription Cancelling')}
+                {subscription.status === 'trialing'
+                  ? getMessage('trial_ending_title', undefined, 'Trial Ending')
+                  : getMessage('subscription_cancelling_title', undefined, 'Subscription Cancelling')}
               </p>
               <p className="jd-text-yellow-700 jd-text-sm">
-                {getMessage(
-                  'subscription_cancelling_message',
-                  undefined,
-                  "Your subscription will end on {0}. You'll continue to have access until then."
-                ).replace('{0}', formatDate(subscription.currentPeriodEnd))}
+                {subscription.status === 'trialing'
+                  ? getMessage(
+                      'trial_end_no_charge',
+                      undefined,
+                      "Your trial will end on {0}. You won't be charged."
+                    ).replace('{0}', formatDate(subscription.currentPeriodEnd))
+                  : getMessage(
+                      'subscription_cancelling_message',
+                      undefined,
+                      "Your subscription will end on {0}. You'll continue to have access until then."
+                    ).replace('{0}', formatDate(subscription.currentPeriodEnd))}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- show user messaging when their subscription is already scheduled to cancel
- hide cancel button in this case
- localize new strings for English and French

## Testing
- `npm run lint` *(fails: 656 problems)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6882229b645c83209ba043a539784d01