### PR TITLE
Fix confirmation dialog stacking

### DIFF
--- a/src/components/dialogs/common/ConfirmationDialog.tsx
+++ b/src/components/dialogs/common/ConfirmationDialog.tsx
@@ -35,12 +35,13 @@ export const ConfirmationDialog: React.FC = () => {
   if (!isOpen) return null;
   
   return (
-    <BaseDialog 
-      open={isOpen} 
+    <BaseDialog
+      open={isOpen}
       onOpenChange={dialogProps.onOpenChange}
       title={title}
       description={description}
       className="jd-max-w-md"
+      baseZIndex={10060}
     >
       <div className="jd-flex jd-flex-col jd-space-y-4 jd-mt-4">
         <div className="jd-flex jd-justify-end jd-space-x-2">


### PR DESCRIPTION
## Summary
- ensure the confirmation dialog appears above other dialogs

## Testing
- `npm run lint`
- `npx eslint src/components/dialogs/common/ConfirmationDialog.tsx`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688230b1dad08320ac2dbb105b706e03