### PR TITLE
Improve cancelled subscription messaging

### DIFF
--- a/src/components/dialogs/subscription/manage/ActionButtons.tsx
+++ b/src/components/dialogs/subscription/manage/ActionButtons.tsx
@@ -26,9 +26,43 @@ export const ActionButtons: React.FC<Props> = ({
   onRefresh,
   onUpgrade,
 }) => (
-  <>
+  <> 
     <div className="jd-space-y-3">
-      {subscription?.status === 'active' ? (
+      {subscription?.cancelAtPeriodEnd ? (
+        // Already cancelled - show info and option to reactivate
+        <>
+          {subscription.currentPeriodEnd && (
+            <div className="jd-p-4 jd-bg-yellow-50 jd-border jd-border-yellow-200 jd-rounded-lg">
+              <p className="jd-text-yellow-800 jd-text-sm jd-text-center">
+                {subscription.status === 'trialing'
+                  ? getMessage(
+                      'trial_end_no_charge',
+                      undefined,
+                      "Your trial will end on {0}. You won't be charged."
+                    ).replace('{0}', formatDate(subscription.currentPeriodEnd))
+                  : getMessage(
+                      'subscription_already_cancelled',
+                      undefined,
+                      'Your subscription has been cancelled and will remain active until {0}. You will not be charged again.'
+                    ).replace('{0}', formatDate(subscription.currentPeriodEnd))}
+              </p>
+            </div>
+          )}
+
+          <Button
+            onClick={onReactivate}
+            disabled={loading || isLoading}
+            className="jd-w-full jd-flex jd-items-center jd-justify-center jd-space-x-2 jd-bg-green-600 hover:jd-bg-green-700"
+          >
+            {loading ? (
+              <RefreshCw className="jd-w-4 jd-h-4 jd-animate-spin" />
+            ) : (
+              <Crown className="jd-w-4 jd-h-4" />
+            )}
+            <span>{getMessage('reactivate_subscription', undefined, 'Reactivate Subscription')}</span>
+          </Button>
+        </>
+      ) : subscription?.status === 'active' ? (
         // Active subscription - show manage and cancel options
         <>
           <Button
@@ -78,20 +112,6 @@ export const ActionButtons: React.FC<Props> = ({
             <span>{getMessage('cancel_trial', undefined, 'Cancel Trial')}</span>
           </Button>
         </div>
-      ) : subscription?.status === 'cancelled' && subscription.cancelAtPeriodEnd ? (
-        // Cancelled but still active until period end - show reactivate option
-        <Button
-          onClick={onReactivate}
-          disabled={loading || isLoading}
-          className="jd-w-full jd-flex jd-items-center jd-justify-center jd-space-x-2 jd-bg-green-600 hover:jd-bg-green-700"
-        >
-          {loading ? (
-            <RefreshCw className="jd-w-4 jd-h-4 jd-animate-spin" />
-          ) : (
-            <Crown className="jd-w-4 jd-h-4" />
-          )}
-          <span>{getMessage('reactivate_subscription', undefined, 'Reactivate Subscription')}</span>
-        </Button>
       ) : subscription?.status === 'past_due' ? (
         // Past due - show update payment method
         <Button

--- a/src/components/dialogs/subscription/manage/SubscriptionStatusCard.tsx
+++ b/src/components/dialogs/subscription/manage/SubscriptionStatusCard.tsx
@@ -94,9 +94,9 @@ export const SubscriptionStatusCard: React.FC<Props> = ({ subscription, statusIn
                       "Your trial will end on {0}. You won't be charged."
                     ).replace('{0}', formatDate(subscription.currentPeriodEnd))
                   : getMessage(
-                      'subscription_cancelling_message',
+                      'subscription_already_cancelled',
                       undefined,
-                      "Your subscription will end on {0}. You'll continue to have access until then."
+                      'Your subscription has been cancelled and will remain active until {0}. You will not be charged again.'
                     ).replace('{0}', formatDate(subscription.currentPeriodEnd))}
               </p>
             </div>


### PR DESCRIPTION
## Summary
- handle subscriptions already cancelled at period end
- clarify status card messaging when cancelling

## Testing
- `npm run lint` *(fails: 615 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6882308eb2b08320ba9e6ff2835aac71