### PR TITLE
Add payment-related Amplitude events

### DIFF
--- a/src/components/dialogs/subscription/ManageSubscriptionDialog.tsx
+++ b/src/components/dialogs/subscription/ManageSubscriptionDialog.tsx
@@ -18,6 +18,7 @@ import {
   SubscriptionStatusCard,
   ActionButtons,
 } from './manage';
+import { trackEvent, EVENTS } from '@/utils/amplitude';
 import { useThemeDetector } from '@/hooks/useThemeDetector';
 
 /**
@@ -118,9 +119,10 @@ export const ManageSubscriptionDialog: React.FC = () => {
         try {
           const success = await stripeApi.cancelSubscription(authState.user.id);
           if (success) {
+            trackEvent(EVENTS.SUBSCRIPTION_CANCELLED, { userId: authState.user.id });
             await refreshStatus();
             toast.success(
-              isTrialing 
+              isTrialing
                 ? getMessage('trial_cancelled', undefined, 'Trial cancelled successfully')
                 : getMessage('subscription_cancelled', undefined, 'Subscription cancelled successfully')
             );
@@ -152,6 +154,7 @@ export const ManageSubscriptionDialog: React.FC = () => {
     try {
       const success = await stripeApi.reactivateSubscription(authState.user.id);
       if (success) {
+        trackEvent(EVENTS.SUBSCRIPTION_RENEWED, { userId: authState.user.id });
         await refreshStatus();
         toast.success(getMessage('subscription_reactivated', undefined, 'Subscription reactivated successfully'));
       } else {
@@ -175,12 +178,18 @@ export const ManageSubscriptionDialog: React.FC = () => {
   };
 
   const handlePaymentSuccess = () => {
+    if (authState.user) {
+      trackEvent(EVENTS.PAYMENT_COMPLETED, { source: 'manage_subscription_dialog', userId: authState.user.id });
+    }
     toast.success(getMessage('payment_successful', undefined, 'Payment successful! Your subscription is now active.'));
     refreshStatus();
     setShowPricing(false);
   };
 
   const handlePaymentCancel = () => {
+    if (authState.user) {
+      trackEvent(EVENTS.PAYMENT_CANCELLED, { source: 'manage_subscription_dialog', userId: authState.user.id });
+    }
     toast.info(getMessage('payment_cancelled', undefined, 'Payment cancelled.'));
   };
 

--- a/src/components/dialogs/subscription/PaywallDialog.tsx
+++ b/src/components/dialogs/subscription/PaywallDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { BaseDialog } from '../BaseDialog';
+import { trackEvent, EVENTS } from '@/utils/amplitude';
 import { useDialog, useDialogManager } from '../DialogContext';
 import { DIALOG_TYPES } from '../DialogRegistry';
 import { getMessage } from '@/core/utils/i18n';
@@ -50,12 +51,17 @@ export const PaywallDialog: React.FC = () => {
   }, [data]);
 
   const handlePaymentSuccess = () => {
+    if (authState.user) {
+      trackEvent(EVENTS.PAYMENT_COMPLETED, { source: 'paywall_dialog', userId: authState.user.id });
+    }
     dialogProps.onOpenChange(false);
     openDialog(DIALOG_TYPES.MANAGE_SUBSCRIPTION);
   };
 
   const handlePaymentCancel = () => {
-    // No-op for now
+    if (authState.user) {
+      trackEvent(EVENTS.PAYMENT_CANCELLED, { source: 'paywall_dialog', userId: authState.user.id });
+    }
   };
 
   if (!isOpen) return null;

--- a/src/components/pricing/PricingPlans.tsx
+++ b/src/components/pricing/PricingPlans.tsx
@@ -12,6 +12,7 @@ import { buildReturnUrl } from '@/utils/stripe';
 import { User } from '@/types';
 import { cn } from '@/core/utils/classNames';
 import { detectPlatform } from '@/extension/content/networkInterceptor/detectPlatform';
+import { trackEvent, EVENTS } from '@/utils/amplitude';
 
 interface PricingPlansProps {
   user: User;
@@ -67,6 +68,14 @@ export const PricingPlans: React.FC<PricingPlansProps> = ({
     try {
       const plan = plans.find(p => p.id === selectedPlan);
       if (!plan) throw new Error(getMessage('invalidPlanSelected', undefined, 'Invalid plan selected'));
+
+      // Track the payment initiation
+      trackEvent(EVENTS.PAYMENT_INITIATED, {
+        planName: plan.id,
+        price: plan.price,
+        currency: plan.currency,
+        userId: user.id
+      });
 
       const session = await stripeApi.createCheckoutSession({
         priceId: plan.priceId,

--- a/src/components/welcome/onboarding/steps/PaymentStep/index.tsx
+++ b/src/components/welcome/onboarding/steps/PaymentStep/index.tsx
@@ -24,6 +24,11 @@ export const PaymentStep: React.FC<PaymentStepProps> = ({
   const [paymentResult, setPaymentResult] = useState<PaymentResult | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
 
+  // Track when the payment step is viewed
+  useEffect(() => {
+    trackEvent(EVENTS.ONBOARDING_PAYMENT_STEP_VIEWED, { userId: user.id });
+  }, [user.id]);
+
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
     const paymentStatus = urlParams.get('payment');


### PR DESCRIPTION
## Summary
- emit onboarding payment step view event
- track checkout start in PricingPlans
- record payment completion/cancel events in PaywallDialog
- log subscription updates in ManageSubscriptionDialog

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and many lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6882352ec05c832086e241b84616a2b9