### PR TITLE
Add use template gif to tutorials dialog

### DIFF
--- a/src/components/dialogs/tutorials/TutorialsDialog.tsx
+++ b/src/components/dialogs/tutorials/TutorialsDialog.tsx
@@ -45,6 +45,11 @@ const featuredTutorials = [
     subtitle: getMessage('createTemplate', undefined, 'Save and reuse your prompts'),
     url: 'https://vetoswvwgsebhxetqppa.supabase.co/storage/v1/object/public/images//templates_demo.gif',
   },
+  {
+    title: getMessage('useFirstTemplate', undefined, 'Use your first template'),
+    subtitle: getMessage('useFirstTemplate', undefined, 'Use your first template'),
+    url: 'https://vetoswvwgsebhxetqppa.supabase.co/storage/v1/object/public/images//use_template_demo.gif',
+  },
 ];
 
 const videos: VideoInfo[] = [
@@ -101,7 +106,7 @@ const videos: VideoInfo[] = [
 export const TutorialsDialog: React.FC = () => {
   const { isOpen, dialogProps } = useDialog(DIALOG_TYPES.TUTORIALS_LIST);
   const { openDialog } = useDialogManager();
-  const { openCreateTemplate, openInsertBlock } = useDialogActions();
+  const { openCreateTemplate, openInsertBlock, openInformation } = useDialogActions();
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 
   const openQuickSelector = useCallback(() => {
@@ -135,6 +140,13 @@ export const TutorialsDialog: React.FC = () => {
       openInsertBlock();
     } else if (index === 2) {
       openCreateTemplate();
+    } else if (index === 3) {
+      openInformation({
+        title: getMessage('useFirstTemplate', undefined, 'Use your first template'),
+        description: getMessage('useFirstTemplateInfo', undefined, 'Select a template from one of your pinned folders below.'),
+        gifUrl: 'https://vetoswvwgsebhxetqppa.supabase.co/storage/v1/object/public/images//use_template_demo.gif',
+        actionText: getMessage('close', undefined, 'Close'),
+      });
     }
     // Close the tutorials dialog after performing the action
     handleOpenChange(false);


### PR DESCRIPTION
## Summary
- show the *use template* demo GIF in the tutorials dialog
- open an info dialog when this GIF is clicked

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688253f2623483209b71bb270cc1fe51