### PR TITLE
Fix InsertBlockDialog newlines

### DIFF
--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -364,8 +364,16 @@ export const InsertBlockDialog: React.FC = () => {
   };
 
   const insertBlocks = () => {
-    // Use the editable content which might have been modified by the user
-    insertIntoPromptArea(editableContent);
+    // Rebuild the content to ensure consistent line breaks between blocks
+    const text = selectedBlocks
+      .map(b => {
+        const content = blockContents[b.id] ??
+          (typeof b.content === 'string' ? b.content : b.content.en || '');
+        return buildPromptPart(b.type || 'custom', content);
+      })
+      .join('\n\n');
+
+    insertIntoPromptArea(text);
     trackEvent(EVENTS.INSERT_BLOCK_DIALOG_BLOCKS_INSERTED, { count: selectedBlocks.length });
     handleOpenChange(false);
     toast.success(getMessage('promptInserted', undefined, 'Prompt inserted successfully'));


### PR DESCRIPTION
## Summary
- ensure inserted blocks always include newline separation

## Testing
- `npm run lint` *(fails: cannot resolve `@eslint/js`)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68826c591fe883208c3940eb5628590f