### PR TITLE
Fix new block type default

### DIFF
--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -81,8 +81,9 @@ const METADATA_FILTERS = [
 const InlineBlockCreator: React.FC<{
   onBlockCreated: (block: Block) => void;
   onCancel: () => void;
-}> = ({ onBlockCreated, onCancel }) => {
-  const [type, setType] = useState<BlockType>('custom');
+  initialType?: BlockType;
+}> = ({ onBlockCreated, onCancel, initialType }) => {
+  const [type, setType] = useState<BlockType>(initialType || 'custom');
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [isCreating, setIsCreating] = useState(false);
@@ -248,6 +249,7 @@ export const InsertBlockDialog: React.FC = () => {
   const [selectedTypeFilter, setSelectedTypeFilter] = useState<string>('all');
   const [previewMode, setPreviewMode] = useState<'visual' | 'text'>('text');
   const [showInlineCreator, setShowInlineCreator] = useState(false);
+  const [inlineCreatorType, setInlineCreatorType] = useState<BlockType>('custom');
   const [showShortcutHelp, setShowShortcutHelp] = useState(false);
   const [editableContent, setEditableContent] = useState('');
   const [blockContents, setBlockContents] = useState<Record<number, string>>({});
@@ -372,6 +374,11 @@ export const InsertBlockDialog: React.FC = () => {
   };
 
   const handleCreate = () => {
+    setInlineCreatorType(
+      selectedTypeFilter !== 'all'
+        ? (selectedTypeFilter as BlockType)
+        : 'custom'
+    );
     setShowInlineCreator(true);
   };
 
@@ -593,6 +600,7 @@ useEffect(() => {
           {showInlineCreator && (
             <div className="jd-mb-4">
               <InlineBlockCreator
+                initialType={inlineCreatorType}
                 onBlockCreated={handleBlockCreated}
                 onCancel={() => setShowInlineCreator(false)}
               />


### PR DESCRIPTION
## Summary
- default InlineBlockCreator type based on current filter
- send type when opening block creator

## Testing
- `npm run lint` *(fails: 663 errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688279fef4a08320914075cbb3b7a474