### PR TITLE
Fix edit dialog label

### DIFF
--- a/src/hooks/dialogs/useCreateTemplateDialog.ts
+++ b/src/hooks/dialogs/useCreateTemplateDialog.ts
@@ -15,8 +15,13 @@ export function useCreateTemplateDialog() {
   const { saveTemplate } = useTemplateCreation();
   
   const isOpen = createDialog.isOpen || editDialog.isOpen;
-  const isEditMode = editDialog.isOpen;
   const data = createDialog.isOpen ? createDialog.data : editDialog.data;
+  // When editing through the create template dialog we receive the template
+  // data via `createDialog.data`. Treat this case as edit mode so the UI
+  // displays the correct action text.
+  const isEditMode =
+    editDialog.isOpen ||
+    Boolean((createDialog.data as Record<string, unknown>)?.template);
   
   const handleComplete = async (
     content: string, 


### PR DESCRIPTION
## Summary
- fix detection of edit mode for create template dialog

## Testing
- `npx eslint src/hooks/dialogs/useCreateTemplateDialog.ts`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6882815bf77c83208f05c05145604bac