### PR TITLE
Fix template preview not showing on dialog open

### DIFF
--- a/src/components/dialogs/prompts/editors/BasicEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/BasicEditor/index.tsx
@@ -55,6 +55,11 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
   useEffect(() => {
     originalBlockCacheRef.current = blockContentCache;
   }, [blockContentCache]);
+
+  // Keep the original content in sync once it is loaded
+  useEffect(() => {
+    originalContentRef.current = content;
+  }, [content]);
   
   // Utility to gather placeholder keys from content and metadata blocks
   const getPlaceholderKeys = useCallback((): string[] => {


### PR DESCRIPTION
## Summary
- keep original content reference in BasicEditor updated after load

## Testing
- `npm run lint` *(fails: react-hooks and lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688773e857a88320b8ac082cec55f352