### PR TITLE
Fix scrolling for block list

### DIFF
--- a/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
+++ b/src/components/dialogs/prompts/InsertBlockDialog/index.tsx
@@ -413,7 +413,8 @@ useEffect(() => {
 }, [search, selectedTypeFilter, blocks]);
 
 useEffect(() => {
-  const el = listRef.current;
+  const root = listRef.current;
+  const el = root?.firstElementChild as HTMLElement | null;
   if (!el) return;
   const onScroll = () => {
     if (el.scrollTop + el.clientHeight >= el.scrollHeight - 100) {


### PR DESCRIPTION
## Summary
- attach the scroll listener to the scrollable viewport in InsertBlockDialog

## Testing
- `npm run lint` *(fails: cannot fix massive lint errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688779eb9dd48320a96c9341894312de