### PR TITLE
Show paywall on block create 402

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/CompactMetadataSection.tsx
@@ -186,11 +186,20 @@ export const CompactMetadataSection: React.FC<CompactMetadataProps> = ({
                 toast.success(getMessage('blockCreated', undefined, 'Block created successfully'));
                 return true;
               } else {
+                if (response.message && (response.message.includes('Subscription') || response.message.includes('402'))) {
+                  openDialog(DIALOG_TYPES.PAYWALL, { reason: 'blockLimit' });
+                }
                 toast.error(response.message || getMessage('blockCreateFailed', undefined, 'Failed to create block'));
                 return false;
               }
             } catch (error) {
               console.error('Error creating block:', error);
+              if (
+                error instanceof Error &&
+                (error.message.includes('Subscription') || error.message.includes('402'))
+              ) {
+                openDialog(DIALOG_TYPES.PAYWALL, { reason: 'blockLimit' });
+              }
               toast.error(getMessage('blockCreateError', undefined, 'An error occurred while creating the block'));
               return false;
             }
@@ -261,11 +270,20 @@ export const CompactMetadataSection: React.FC<CompactMetadataProps> = ({
                   toast.success(getMessage('blockCreated', undefined, 'Block created successfully'));
                   return true;
                 } else {
+                  if (response.message && (response.message.includes('Subscription') || response.message.includes('402'))) {
+                    openDialog(DIALOG_TYPES.PAYWALL, { reason: 'blockLimit' });
+                  }
                   toast.error(response.message || getMessage('blockCreateFailed', undefined, 'Failed to create block'));
                   return false;
                 }
               } catch (error) {
                 console.error('Error creating block:', error);
+                if (
+                  error instanceof Error &&
+                  (error.message.includes('Subscription') || error.message.includes('402'))
+                ) {
+                  openDialog(DIALOG_TYPES.PAYWALL, { reason: 'blockLimit' });
+                }
                 toast.error(getMessage('blockCreateError', undefined, 'An error occurred while creating the block'));
                 return false;
               }

--- a/src/components/dialogs/subscription/PaywallDialog.tsx
+++ b/src/components/dialogs/subscription/PaywallDialog.tsx
@@ -73,6 +73,7 @@ export const PaywallDialog: React.FC = () => {
       onOpenChange={dialogProps.onOpenChange}
       title={getMessage('upgrade_required', undefined, 'Upgrade Required')}
       className="jd-max-w-2xl"
+      baseZIndex={10070}
     >
       <div className="jd-space-y-2">
         <p className="jd-text-muted-foreground">

--- a/src/hooks/prompts/actions/useBlockActions.ts
+++ b/src/hooks/prompts/actions/useBlockActions.ts
@@ -178,7 +178,11 @@ export function useBlockActions({
             }
             return true; // Success - close dialog
           } else {
-            if (response.message && response.message.includes('Subscription')) {
+            if (
+              response.message &&
+              (response.message.includes('Subscription') ||
+                response.message.includes('402'))
+            ) {
               openDialog(DIALOG_TYPES.PAYWALL, { reason: 'blockLimit' });
             }
             toast.error(response.message || getMessage('blockCreateFailed', undefined, 'Failed to create block'));
@@ -186,7 +190,10 @@ export function useBlockActions({
           }
         } catch (error) {
           console.error('Error creating block:', error);
-          if (error instanceof Error && error.message.includes('Subscription')) {
+          if (
+            error instanceof Error &&
+            (error.message.includes('Subscription') || error.message.includes('402'))
+          ) {
             openDialog(DIALOG_TYPES.PAYWALL, { reason: 'blockLimit' });
           }
           toast.error(getMessage('blockCreateError', undefined, 'An error occurred while creating the block'));


### PR DESCRIPTION
## Summary
- handle 402 response in more block creation flows
- ensure paywall dialog overlays other dialogs

## Testing
- `npm run lint` *(fails: eslint errors across repo)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688779430650832097ca1b43dfc45608