### PR TITLE
Fix placeholder panel losing items after edits

### DIFF
--- a/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/AdvancedEditor/index.tsx
@@ -116,6 +116,8 @@ export const AdvancedEditor: React.FC<AdvancedEditorProps> = ({
           return { key, value: existing?.value || '' };
         })
       );
+      // Preserve the initial content with placeholders intact
+    } else {
       originalContentRef.current = content;
     }
   }, [content, mode, getPlaceholderKeys]);

--- a/src/components/dialogs/prompts/editors/BasicEditor/index.tsx
+++ b/src/components/dialogs/prompts/editors/BasicEditor/index.tsx
@@ -56,10 +56,13 @@ export const BasicEditor: React.FC<BasicEditorProps> = ({
     originalBlockCacheRef.current = blockContentCache;
   }, [blockContentCache]);
 
-  // Keep the original content in sync once it is loaded
+  // Keep the original content reference stable in customize mode so
+  // placeholder keys remain available after replacement.
   useEffect(() => {
-    originalContentRef.current = content;
-  }, [content]);
+    if (mode !== 'customize') {
+      originalContentRef.current = content;
+    }
+  }, [content, mode]);
   
   // Utility to gather placeholder keys from content and metadata blocks
   const getPlaceholderKeys = useCallback((): string[] => {


### PR DESCRIPTION
## Summary
- keep the original template text stable in BasicEditor customize mode
- avoid overwriting original text in AdvancedEditor while customizing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6887a0699ea48320aa75667c7855311d