### PR TITLE
Fix folder deletion refresh

### DIFF
--- a/src/hooks/prompts/actions/useFolderMutations.ts
+++ b/src/hooks/prompts/actions/useFolderMutations.ts
@@ -183,10 +183,12 @@ export function useFolderMutations() {
         {
           onSuccess: () => {
             invalidateFolderQueries();
-            // Also invalidate template queries since templates may be orphaned
+            // Also invalidate template and pinned queries since templates may be orphaned
             if (queryClient) {
               queryClient.invalidateQueries(QUERY_KEYS.USER_TEMPLATES);
               queryClient.invalidateQueries(QUERY_KEYS.UNORGANIZED_TEMPLATES);
+              queryClient.invalidateQueries(QUERY_KEYS.PINNED_FOLDERS);
+              queryClient.invalidateQueries(QUERY_KEYS.PINNED_TEMPLATES);
             }
           },
           onError: (error: Error) => {


### PR DESCRIPTION
## Summary
- invalidate pinned folder and template queries after deleting a folder so the UI immediately reflects the change

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: many lint errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6887a5192c04832093e0bd5eed9ee014